### PR TITLE
call glide up

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e1fc97f7acb345cf7b970b1eec3479065526f3f6dd3ad43b55dd79a88ef91b47
-updated: 2017-09-15T14:36:39.04693767-06:00
+hash: 51d03224caaad76c14999c98f53d5ffbafbf0a7060723c1e17cbede59aa9ff35
+updated: 2017-10-23T20:41:57.416167-07:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d


### PR DESCRIPTION
This broke when we moved the repository to the Azure org.