### PR TITLE
[docs](#840) fix image paths

### DIFF
--- a/docs/content/topics/design.md
+++ b/docs/content/topics/design.md
@@ -153,13 +153,13 @@ multiple containers within a cluster.
 
 Brigade has several functional concepts.
 
-![Design Overview](img/design-overview.png)
+![Design Overview](https://docs.brigade.sh/img/design-overview.png)
 
 A Gateway is a workload, typically a Kubernetes Deployment fronted by a Service
 or Ingress, that transforms a trigger (inbound webhook, item on queue) into a
 Brigade event.
 
-![Service, Trigger, Gateway, Event](img/design-trigger-gateway.png)
+![Service, Trigger, Gateway, Event](https://docs.brigade.sh/img/design-trigger-gateway.png)
 
 The illustration above shows how GitHub translates a Git event into a webhook, which
 the optional [Brigade GitHub Gateway](./github.md) translates into an event to be


### PR DESCRIPTION
Fixes broken images in the `topics/design.md` doc. As [reported here](https://github.com/brigadecore/brigade-www/issues/7).

Partially addresses [#7](https://github.com/brigadecore/brigade-www/issues/7).