### PR TITLE
Eliminates a yarn race condition when installing brigade.json deps

### DIFF
--- a/brigade-worker/package.json
+++ b/brigade-worker/package.json
@@ -21,12 +21,16 @@
   "devDependencies": {
     "@types/chai": "^4.0.1",
     "@types/mocha": "^5.2.6",
+    "@types/mock-require": "^2.0.0",
     "@types/node": "^11.9.6",
+    "@types/sinon": "^7.0.11",
     "@types/ws": "6.0.1",
     "chai": "^4.1.0",
     "mocha": "^6.0.2",
+    "mock-require": "^3.0.3",
     "prettier": "^1.9.1",
     "rimraf": "^2.6.2",
+    "sinon": "^7.3.1",
     "ts-node": "^8.0.2",
     "typedoc": "^0.14.2",
     "typescript": "^3.2.2"

--- a/brigade-worker/test/prestart.ts
+++ b/brigade-worker/test/prestart.ts
@@ -1,0 +1,203 @@
+import "mocha";
+import { assert } from "chai";
+import * as mock from "mock-require";
+import * as sinon from "sinon";
+
+// Using `let` and `require` so `mock.reRequire` is legal later.
+let prestart = require('../prestart');
+
+describe("prestart", function() {
+  describe("buildPackageList", function() {
+    it("rejects null", function () {
+      assert.throws(() => prestart.buildPackageList(null));
+    });
+
+    it("builds a list with no deps", function() {
+      assert.deepEqual(
+        prestart.buildPackageList({}),
+        []);
+    });
+
+    it("builds a list with multiple deps", function() {
+      assert.deepEqual(
+        prestart.buildPackageList({
+          "is-thirteen": "2.0.0",
+          "lodash": "4.0.0",
+        }),
+        ["is-thirteen@2.0.0", "lodash@4.0.0"]);
+    });
+  });
+
+  describe("addYarn", function() {
+
+    it("rejects null", function() {
+      assert.throws(() => prestart.addYarn(null));
+    });
+
+    it("rejects the empty list", function() {
+      assert.throws(() => prestart.addYarn([]));
+    });
+
+    describe("mocked", function() {
+      let execFileSync;
+      beforeEach(function() {
+        execFileSync = sinon.stub();
+        mock("child_process", { execFileSync });
+        prestart = mock.reRequire("../prestart");
+      });
+
+      afterEach(function() {
+        mock.stopAll();
+      });
+
+      it("invokes execFileSync for a single package", function () {
+        try {
+          prestart.addYarn(["is-thirteen@2.0.0"]);
+        } finally {
+          mock.stopAll();
+        }
+
+        sinon.assert.calledOnce(execFileSync);
+        sinon.assert.calledWithExactly(
+          execFileSync, "yarn", ["add", "is-thirteen@2.0.0"]);
+      });
+
+      it("invokes execFileSync for multiple packages", function () {
+        try {
+          prestart.addYarn(["is-thirteen@2.0.0", "lodash@4.0.0"]);
+        } finally {
+          mock.stopAll();
+        }
+
+        sinon.assert.calledOnce(execFileSync);
+        sinon.assert.calledWithExactly(
+          execFileSync, "yarn", ["add", "is-thirteen@2.0.0", "lodash@4.0.0"]);
+      });
+
+    });
+  });
+
+  describe("addDeps", function () {
+    let
+      execFileSync: sinon.SinonStub,
+      existsSync: sinon.SinonStub,
+      exit: sinon.SinonStub;
+
+      beforeEach(function() {
+        execFileSync = sinon.stub();
+        mock("child_process", { execFileSync });
+
+        existsSync = sinon.stub();
+        mock("fs", { existsSync })
+
+        exit = sinon.stub();
+        mock("process", { env: {}, exit });
+
+        sinon.stub(console, 'error');
+
+        prestart = mock.reRequire("../prestart");
+      });
+
+      afterEach(function() {
+        mock.stopAll();
+
+        (console as any).error.restore();
+      });
+
+      it("no brigade.json", function() {
+        existsSync.callsFake(() => false);
+
+        prestart.addDeps();
+
+        sinon.assert.calledOnce(existsSync);
+        sinon.assert.calledWithExactly(existsSync, prestart.depsFile);
+        sinon.assert.notCalled(execFileSync);
+        sinon.assert.notCalled(exit);
+      });
+
+      it("no dependencies object", function() {
+        mock(prestart.depsFile, {});
+        existsSync.callsFake(() => true);
+
+        prestart.addDeps();
+
+        sinon.assert.calledOnce(existsSync);
+        sinon.assert.calledWithExactly(existsSync, prestart.depsFile);
+        sinon.assert.notCalled(execFileSync);
+        sinon.assert.notCalled(exit);
+      });
+
+      it("empty dependencies", function() {
+        mock(prestart.depsFile, { dependencies: {}})
+        existsSync.callsFake(() => true);
+
+        prestart.addDeps();
+
+        sinon.assert.calledOnce(existsSync);
+        sinon.assert.calledWithExactly(existsSync, prestart.depsFile);
+        sinon.assert.notCalled(execFileSync);
+        sinon.assert.notCalled(exit);
+      });
+
+      it("one dependency", function() {
+        mock(prestart.depsFile, {
+          dependencies: {
+            "is-thirteen": "2.0.0",
+          },
+        });
+        existsSync.callsFake(() => true);
+
+        prestart.addDeps();
+
+        sinon.assert.calledOnce(existsSync);
+        sinon.assert.calledWithExactly(existsSync, prestart.depsFile);
+        sinon.assert.calledOnce(execFileSync);
+        sinon.assert.calledWithExactly(
+          execFileSync, "yarn", ["add", "is-thirteen@2.0.0"]);
+        sinon.assert.notCalled(exit);
+      })
+
+      it("two dependencies", function() {
+        mock(prestart.depsFile, {
+          dependencies: {
+            "is-thirteen": "2.0.0",
+            "lodash": "4.0.0",
+          },
+        });
+        existsSync.callsFake(() => true);
+
+        prestart.addDeps();
+
+        sinon.assert.calledOnce(existsSync);
+        sinon.assert.calledWithExactly(existsSync, prestart.depsFile);
+        sinon.assert.calledOnce(execFileSync);
+        sinon.assert.calledWithExactly(
+          execFileSync, "yarn", ["add", "is-thirteen@2.0.0", "lodash@4.0.0"]);
+        sinon.assert.notCalled(exit);
+      });
+
+      it("yarn error", function() {
+        mock(prestart.depsFile, {
+          dependencies: {
+            "is-thirteen": "2.0.0",
+          },
+        });
+        existsSync.callsFake(() => true);
+        execFileSync.callsFake(() => {
+          const e = new Error('Command failed: yarn');
+          (e as any).status = 1;
+          throw e;
+        });
+
+        prestart.addDeps();
+
+        sinon.assert.calledOnce(existsSync);
+        sinon.assert.calledWithExactly(existsSync, prestart.depsFile);
+        sinon.assert.calledOnce(execFileSync);
+        sinon.assert.calledWithExactly(execFileSync, "yarn", ["add", "is-thirteen@2.0.0"]);
+        sinon.assert.calledOnce(exit);
+        sinon.assert.calledWithExactly(exit, 1);
+      });
+  });
+});
+

--- a/brigade-worker/yarn.lock
+++ b/brigade-worker/yarn.lock
@@ -30,6 +30,35 @@
     underscore "^1.9.1"
     ws "^6.1.0"
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78"
+  integrity sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^3.1.0", "@sinonjs/formatio@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.1.tgz#52310f2f9bcbc67bdac18c94ad4901b95fde267e"
+  integrity sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^3.1.0"
+
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.1.tgz#e88c53fbd9d91ad9f0f2b0140c16c7c107fe0d07"
+  integrity sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==
+  dependencies:
+    "@sinonjs/commons" "^1.0.2"
+    array-from "^2.1.1"
+    lodash "^4.17.11"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@types/chai@^4.0.1":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.7.tgz#1b8e33b61a8c09cbe1f85133071baa0dbf9fa71a"
@@ -88,6 +117,13 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.6.tgz#b8622d50557dd155e9f2f634b7d68fd38de5e94b"
   integrity sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==
 
+"@types/mock-require@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mock-require/-/mock-require-2.0.0.tgz#57a4f0db0b4b6274f610a2d2c20beb3c842181e1"
+  integrity sha512-nOgjoE5bBiDeiA+z41i95makyHUSMWQMOPocP+J67Pqx/68HAXaeWN1NFtrAYYV6LrISIZZ8vKHm/a50k0f6Sg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@^11.9.6":
   version "11.11.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.3.tgz#7c6b0f8eaf16ae530795de2ad1b85d34bf2f5c58"
@@ -100,6 +136,11 @@
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
+
+"@types/sinon@^7.0.11":
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.0.11.tgz#6f28f005a36e779b7db0f1359b9fb9eef72aae88"
+  integrity sha512-6ee09Ugx6GyEr0opUIakmxIWFNmqYPjkqa3/BuxCBokA0klsOLPgMD5K4q40lH7/yZVuJVzOfQpd7pipwjngkQ==
 
 "@types/ws@6.0.1":
   version "6.0.1"
@@ -172,6 +213,11 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -566,7 +612,7 @@ detect-file@^1.0.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
-diff@3.5.0, diff@^3.1.0:
+diff@3.5.0, diff@^3.1.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -893,7 +939,7 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-get-caller-file@^1.0.1:
+get-caller-file@^1.0.1, get-caller-file@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
@@ -1247,6 +1293,11 @@ is-windows@^1.0.1, is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1364,6 +1415,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -1427,6 +1483,16 @@ log-symbols@2.2.0:
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
+
+lolex@^2.3.2:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
+  integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
+
+lolex@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.1.0.tgz#1a7feb2fefd75b3e3a7f79f0e110d9476e294434"
+  integrity sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==
 
 lru-cache@^4.0.1:
   version "4.1.5"
@@ -1571,6 +1637,14 @@ mocha@^6.0.2:
     yargs-parser "11.1.1"
     yargs-unparser "1.5.0"
 
+mock-require@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/mock-require/-/mock-require-3.0.3.tgz#ccd544d9eae81dd576b3f219f69ec867318a1946"
+  integrity sha512-lLzfLHcyc10MKQnNUCv7dMcoY/2Qxd6wJfbqCcVk3LDb8An4hF6ohk5AztrvgKhJCqj36uyzi/p5se+tvyD+Wg==
+  dependencies:
+    get-caller-file "^1.0.2"
+    normalize-path "^2.1.1"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -1608,6 +1682,17 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+nise@^1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.10.tgz#ae46a09a26436fae91a38a60919356ae6db143b6"
+  integrity sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==
+  dependencies:
+    "@sinonjs/formatio" "^3.1.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+
 node-environment-flags@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.4.tgz#0b784a6551426bfc16d3b2208424dcbc2b2ff038"
@@ -1627,6 +1712,13 @@ nomnom@1.5.2:
   dependencies:
     colors "0.5.x"
     underscore "1.1.x"
+
+normalize-path@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
+  dependencies:
+    remove-trailing-separator "^1.0.1"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -1798,6 +1890,13 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  dependencies:
+    isarray "0.0.1"
+
 pathval@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
@@ -1897,6 +1996,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+remove-trailing-separator@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+  integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
 
 renderkid@^2.0.1:
   version "2.0.3"
@@ -2059,6 +2163,19 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+sinon@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.3.1.tgz#e8276522104e6c08d1cb52a907270b0e316655c4"
+  integrity sha512-eQKMaeWovtOtYe2xThEvaHmmxf870Di+bim10c3ZPrL5bZhLGtu8cz+rOBTFz0CwBV4Q/7dYwZiqZbGVLZ+vjQ==
+  dependencies:
+    "@sinonjs/commons" "^1.4.0"
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/samsam" "^3.3.1"
+    diff "^3.5.0"
+    lolex "^3.1.0"
+    nise "^1.4.10"
+    supports-color "^5.5.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -2226,7 +2343,7 @@ supports-color@6.0.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -2301,7 +2418,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
`yarn` was previously invoked using via `child-process-promise` without
waiting for the promises to resolve, which led to a race between
multiple `yarn` instances attempting to update package.json, yarn.lock
and node_modules simultaneously.  This led to failed package
installation for brigade.json files with more than one dependency.

Now, `yarn` is invoked synchronously and in a single invocation, rather
than via multiple asynchronous execs.  This prevents the race condition
and makes package installation faster.

Signed-off-by: Chris Chambers <chris.chambers@peanutcode.com>

<!--
Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR (https://github.com/brigadecore/brigade/blob/master/docs/topics/developers.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).

2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
-->

**What this PR does / why we need it**:
Closes #867 

**Special notes for your reviewer**:
I need some help assessing the "If applicable" section below. I didn't see any existing unit tests for this functionality, and it may be tricky to mock.  For backward compatibility, are there functional tests I can run?

**If applicable**:
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
