### PR TITLE
brig check initial implementation

### DIFF
--- a/brig/cmd/brig/commands/check.go
+++ b/brig/cmd/brig/commands/check.go
@@ -1,0 +1,118 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	apps_v1 "k8s.io/api/apps/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func init() {
+	Root.AddCommand(check)
+}
+
+const (
+	checkUsage = `Checks the status of your Brigade installation
+
+Specifically, it reports Desired/Current/Running/Up-to-date/Available/Unavailable Pods for the Controller, API Server and Kashti deployments.
+`
+)
+
+var check = &cobra.Command{
+	Use:   "check",
+	Short: "Checks the status of your Brigade installation",
+	Long:  checkUsage,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return checkBrigadeSystem()
+	},
+}
+
+func checkBrigadeSystem() error {
+	/*
+		If you run `kubectl get deploy --show-labels` on the namespace where Brigade is installed, you'll see
+		NAME                                DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE    LABELS
+		mybrigade-brigade-api               1         1         1            1           170m   app.kubernetes.io/instance=mybrigade,app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/name=mybrigade-brigade-api,helm.sh/chart=brigade-1.0.0,role=api
+		mybrigade-brigade-ctrl              1         1         1            1           170m   app.kubernetes.io/instance=mybrigade,app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/name=mybrigade-brigade-ctrl,helm.sh/chart=brigade-1.0.0,role=controller
+		mybrigade-brigade-generic-gateway   1         1         1            1           170m   app.kubernetes.io/instance=mybrigade,app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/name=mybrigade-brigade,helm.sh/chart=brigade-1.0.0,role=gateway,type=generic
+		mybrigade-kashti                    1         1         1            1           170m   app=kashti,chart=kashti-0.1.1,heritage=Tiller,release=mybrigade
+	*/
+
+	c, err := kubeClient()
+	if err != nil {
+		return err
+	}
+
+	// check deployments
+	deployList, err := c.AppsV1().Deployments(globalNamespace).List(meta_v1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	apiDeploymentFound := false
+	controllerDeploymentFound := false
+	kashtiDeploymentFound := false
+
+	for _, deployment := range deployList.Items {
+		if lbl := deployment.Labels["app.kubernetes.io/name"]; lbl != "" {
+			if strings.HasSuffix(lbl, "-brigade-api") && deployment.Labels["role"] == "api" {
+				apiDeploymentFound = true
+				reportDeployStatus(deployment, "Brigade API Server")
+			} else if strings.HasSuffix(lbl, "-brigade-ctrl") && deployment.Labels["role"] == "controller" {
+				controllerDeploymentFound = true
+				reportDeployStatus(deployment, "Brigade Controller")
+			}
+		} else if lblApp := deployment.Labels["app"]; lblApp == "kashti" {
+			kashtiDeploymentFound = true
+			reportDeployStatus(deployment, "Kashti")
+		}
+
+		if apiDeploymentFound && controllerDeploymentFound && kashtiDeploymentFound {
+			break // we're not interested in checking other Deployments
+		}
+	}
+
+	if !apiDeploymentFound {
+		fmt.Printf("Info: Brigade API Server Deployment not found")
+	}
+	if !controllerDeploymentFound {
+		fmt.Println("Error: Brigade Controller Deployment not found")
+	}
+	if !kashtiDeploymentFound {
+		fmt.Println("Info: Kashti deployment not found")
+	}
+
+	// check vacuum cronjob
+	cjList, err := c.BatchV1beta1().CronJobs(globalNamespace).List(meta_v1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	vacuumCronJobFound := false
+	for _, cronjob := range cjList.Items {
+		if lbl := cronjob.Labels["app.kubernetes.io/name"]; lbl != "" {
+			if strings.HasSuffix(lbl, "-brigade") && cronjob.Labels["role"] == "vacuum" {
+				vacuumCronJobFound = true
+				if *cronjob.Spec.Suspend {
+					fmt.Println("Warning: Vacuum CronJob is suspended")
+				} else if cronjob.Spec.Schedule == "" {
+					fmt.Println("Warning: Vacuum has an empty schedule")
+				} else {
+					fmt.Println("Info: Vacuum is healthy (not suspended and its schedule is non-empty)")
+				}
+			}
+		}
+
+		if vacuumCronJobFound {
+			break // we're not interested in checking other CronJobs
+		}
+	}
+
+	return nil
+}
+
+func reportDeployStatus(deployment apps_v1.Deployment, name string) {
+	ds := deployment.Status
+	fmt.Printf("%s replicas: Desired %d, Ready %d, Updated %d, Available %d, Unavailable %d \n", name, ds.Replicas, ds.ReadyReplicas, ds.UpdatedReplicas, ds.AvailableReplicas, ds.UnavailableReplicas)
+}


### PR DESCRIPTION
Fixes #815 as per https://github.com/brigadecore/brigade/issues/815#issuecomment-466362299

It's a trivial PR that implements of `brig check` which offers a quick check on the health of the system by checking for
-  at least one active API Server Pods
-  at least one active Controller Pods
-  at least one active Kashti Pods
-  if Vacuum CronJob is not suspended and has a non-empty schedule

Do you think we can add anything else?
