### PR TITLE
brig project create templates

### DIFF
--- a/brig/README.md
+++ b/brig/README.md
@@ -16,6 +16,7 @@ An example setup might look like the following:
 
 ```console
 $ brig project create
+? VCS or no-VCS project? VCS
 ? Project name brigadecore/empty-testbed
 ? Full repository name github.com/brigadecore/empty-testbed
 ? Clone URL (https://github.com/your/repo.git) https://github.com/brigadecore/empty-testbed.git

--- a/brig/cmd/brig/commands/project_create_no_vcs.go
+++ b/brig/cmd/brig/commands/project_create_no_vcs.go
@@ -1,0 +1,93 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/brigadecore/brigade/pkg/brigade"
+	"github.com/brigadecore/brigade/pkg/storage"
+
+	"gopkg.in/AlecAivazis/survey.v1"
+)
+
+// projectCreatePromptsNoVCS handles all of the prompts.
+//
+// Default values are read from the given project. Values are then
+// replaced on that object.
+func projectCreatePromptsNoVCS(p *brigade.Project, store storage.Store) error {
+
+	setDefaultValuesNoVCS(p)
+
+	err := setProjectName(p, store, false)
+	if err != nil {
+		return fmt.Errorf(abort, err)
+	}
+
+	err = addEditSecrets(p, store)
+	if err != nil {
+		return err
+	}
+
+	err = addGenericGatewaySecret(p, store)
+	if err != nil {
+		return err
+	}
+
+	// ask/edit a Brigade.js file either in a ConfigMap or local
+	err = addBrigadeJS(p, store)
+	if err != nil {
+		return fmt.Errorf(abort, err)
+	}
+	// this is a no-VCS Build, so we require a Brigade.js file
+	for p.DefaultScript == "" && p.DefaultScriptName == "" {
+		fmt.Println("A Brigade.js file is mandatory for no-VCS Brigade Projects (either via a ConfigMap reference or local). Please try again.")
+		err = addBrigadeJS(p, store)
+		if err != nil {
+			return fmt.Errorf(abort, err)
+		}
+	}
+
+	doAdvanced := false
+	if err := survey.AskOne(&survey.Confirm{
+		Message: "Configure advanced options",
+		Help:    "Show the advanced configuration options for projects",
+	}, &doAdvanced, nil); err != nil {
+		return fmt.Errorf(abort, err)
+	} else if doAdvanced {
+		return projectAdvancedPromptsNoVCS(p, store)
+	}
+	return nil
+}
+
+func projectAdvancedPromptsNoVCS(p *brigade.Project, store storage.Store) error {
+	questionsKubernetes, err := advancedQuestionsKubernetes(p, store)
+	if err != nil {
+		return fmt.Errorf(abort, err)
+	}
+	if err := survey.Ask(questionsKubernetes, &p.Kubernetes); err != nil {
+		return fmt.Errorf(abort, err)
+	}
+
+	questionsWorker := advancedQuestionsWorker(p, store)
+	if err := survey.Ask(questionsWorker, &p.Worker); err != nil {
+		return fmt.Errorf(abort, err)
+	}
+
+	questionsProject := advancedQuestionsProject(p, store)
+	if err := survey.Ask(questionsProject, p); err != nil {
+		return fmt.Errorf(abort, err)
+	}
+
+	return nil
+}
+
+// setDefaultValuesNoVCS sets some Project defaults for a no-VCS Project
+func setDefaultValuesNoVCS(p *brigade.Project) {
+	// set some non-VCS Project Default
+	// set the name to a non-VCS one
+	p.Name = "myproject"
+	// setting the sidecar to NONE
+	p.Kubernetes.VCSSidecar = "NONE"
+	// empty values for the repo
+	p.Repo.CloneURL = ""
+	p.Repo.Name = ""
+}

--- a/brig/cmd/brig/commands/project_create_test.go
+++ b/brig/cmd/brig/commands/project_create_test.go
@@ -7,15 +7,32 @@ import (
 
 const testProjectSecret = "./testdata/project_secret.json"
 
-func TestInitProject(t *testing.T) {
-	p := newProject()
-	if p.Name != defaultProject.Name {
+func TestInitProjectVCS(t *testing.T) {
+	p := newProjectVCS()
+	if p.Name != defaultProjectVCS.Name {
 		t.Fatal("newProject is not cloning default project")
 	}
 
 	p.Name = "overrideName"
-	if p.Name == defaultProject.Name {
+	if p.Name == defaultProjectVCS.Name {
 		t.Fatal("newProject returned the pointer to the default project.")
+	}
+}
+
+func TestInitProjectNoVCS(t *testing.T) {
+	p := newProjectVCS()     // VCS is the default
+	setDefaultValuesNoVCS(p) // switch the defaults to a no VCS project
+
+	if p.Kubernetes.VCSSidecar != "NONE" {
+		t.Fatal("VCSSidecar should be NONE")
+	}
+
+	if p.Repo.CloneURL != "" {
+		t.Fatal("CloneURL should be an empty string")
+	}
+
+	if p.Repo.Name != "" {
+		t.Fatal("Repo.Name should be an empty string")
 	}
 }
 
@@ -36,7 +53,7 @@ func TestParseSecret(t *testing.T) {
 }
 
 func TestLoadProjectConfig(t *testing.T) {
-	proj, err := loadProjectConfig(testProjectSecret, newProject())
+	proj, err := loadProjectConfig(testProjectSecret, newProjectVCS())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/brig/cmd/brig/commands/project_create_vcs.go
+++ b/brig/cmd/brig/commands/project_create_vcs.go
@@ -1,0 +1,265 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Masterminds/goutils"
+	survey "gopkg.in/AlecAivazis/survey.v1"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"github.com/brigadecore/brigade/pkg/brigade"
+	"github.com/brigadecore/brigade/pkg/storage"
+	"github.com/brigadecore/brigade/pkg/storage/kube"
+)
+
+// projectCreatePromptsVCS handles all of the prompts.
+//
+// Default values are read from the given project. Values are then
+// replaced on that object.
+func projectCreatePromptsVCS(p *brigade.Project, store storage.Store) error {
+
+	err := setProjectName(p, store, true)
+	if err != nil {
+		return fmt.Errorf(abort, err)
+	}
+
+	// a couple of questions that make sense only if the Project is VCS-backed
+	qs := []*survey.Question{
+		{
+			Name: "name",
+			Prompt: &survey.Input{
+				Message: "Full repository name",
+				Help:    "A protocol-neutral path to your repo, like github.com/foo/bar",
+				Default: p.Repo.Name,
+			},
+		},
+		{
+			Name: "cloneURL",
+			Prompt: &survey.Input{
+				Message: "Clone URL (https://github.com/your/repo.git)",
+				Help:    "The URL that Git should use to clone. The protocol (https, git, ssh) will determine how the repo is fetched.",
+				Default: p.Repo.CloneURL,
+			},
+		},
+	}
+	if err = survey.Ask(qs, &p.Repo); err != nil {
+		return fmt.Errorf(abort, err)
+	}
+
+	// Don't prompt for key if the URL is HTTP(S).
+	if !isHTTP(p.Repo.CloneURL) {
+		var fname string
+		err := survey.AskOne(&survey.Input{
+			Message: "Path to SSH key for SSH clone URLs (leave blank to skip)",
+			Help:    "The local path to an SSH key file, which will be uploaded to the project. Use this for SSH clone URLs.",
+		}, &fname, loadFileValidator)
+		if err != nil {
+			return fmt.Errorf(abort, err)
+		}
+		if key := loadFileStr(fname); key != "" {
+			p.Repo.SSHKey = replaceNewlines(key)
+		}
+	}
+
+	err = addEditSecrets(p, store)
+	if err != nil {
+		return err
+	}
+
+	if p.SharedSecret == "" {
+		p.SharedSecret, _ = goutils.RandomAlphaNumeric(24)
+		fmt.Printf("Auto-generated a Shared Secret: %q\n", p.SharedSecret)
+	}
+
+	configureGitHub := false
+	if err := survey.AskOne(&survey.Confirm{
+		Message: "Configure GitHub Access?",
+		Help:    "Configure GitHub CI/CD integration for this project",
+	}, &configureGitHub, nil); err != nil {
+		return fmt.Errorf(abort, err)
+	} else if configureGitHub {
+		if err := survey.Ask([]*survey.Question{
+			{
+				Name: "token",
+				Prompt: &survey.Input{
+					Message: "OAuth2 token",
+					Help:    "Used for contacting the GitHub API. GitHub issues this.",
+					Default: p.Github.Token,
+				},
+			},
+			{
+				Name: "baseURL",
+				Prompt: &survey.Input{
+					Message: "GitHub Enterprise URL",
+					Help:    "If using GitHub Enterprise, set the base URL here",
+					Default: p.Github.BaseURL,
+				},
+			},
+			{
+				Name: "uploadURL",
+				Prompt: &survey.Input{
+					Message: "GitHub Enterprise upload URL",
+					Help:    "If using GitHub Enterprise, set the upload URL here",
+					Default: p.Github.UploadURL,
+				},
+			},
+		}, &p.Github); err != nil {
+			return fmt.Errorf(abort, err)
+		}
+	}
+
+	doAdvanced := false
+	if err := survey.AskOne(&survey.Confirm{
+		Message: "Configure advanced options",
+		Help:    "Show the advanced configuration options for projects",
+	}, &doAdvanced, nil); err != nil {
+		return fmt.Errorf(abort, err)
+	} else if doAdvanced {
+		return projectAdvancedPromptsVCS(p, store)
+	}
+	return nil
+}
+
+func projectAdvancedPromptsVCS(p *brigade.Project, store storage.Store) error {
+	questionsKubernetes, err := advancedQuestionsKubernetes(p, store)
+	if err != nil {
+		return fmt.Errorf(abort, err)
+	}
+	// VCSSidecar question makes sense only when we use a VCS
+	questionsKubernetes = append(questionsKubernetes, &survey.Question{
+		Name: "vCSSidecar",
+		Prompt: &survey.Input{
+			Message: "Custom VCS sidecar (enter 'NONE' for no sidecar)",
+			Help:    "The default sidecar uses Git to fetch your repository (enter 'NONE' for no sidecar)",
+			Default: p.Kubernetes.VCSSidecar,
+		},
+	})
+	if err := survey.Ask(questionsKubernetes, &p.Kubernetes); err != nil {
+		return fmt.Errorf(abort, err)
+	}
+
+	questionsWorker := advancedQuestionsWorker(p, store)
+	if err := survey.Ask(questionsWorker, &p.Worker); err != nil {
+		return fmt.Errorf(abort, err)
+	}
+
+	questionsProject := advancedQuestionsProject(p, store)
+	// adding a couple of questions that make sense only when we do have a VCS
+	questionsProject = append(questionsProject, []*survey.Question{
+		{
+			Name: "initGitSubmodules",
+			Prompt: &survey.Confirm{
+				Message: "Initialize Git submodules",
+				Help:    "For repos that have submodules, initialize them on each clone. Not recommended on public repos.",
+				Default: p.InitGitSubmodules,
+			},
+		},
+		{
+			Name: "brigadejsPath",
+			Prompt: &survey.Input{
+				Message: "brigade.js file path relative to the repository root",
+				Help:    "brigade.js file path relative to the repository root, e.g. 'mypath/brigade.js'",
+				Default: p.BrigadejsPath,
+			},
+			Validate: func(ans interface{}) error {
+				sans := fmt.Sprintf("%v", ans)
+				if filepath.IsAbs(sans) {
+					return errors.New("Path must be relative")
+				}
+				return nil
+			},
+		},
+	}...)
+	if err := survey.Ask(questionsProject, p); err != nil {
+		return fmt.Errorf(abort, err)
+	}
+
+	err = addBrigadeJS(p, store)
+	if err != nil {
+		return fmt.Errorf(abort, err)
+	}
+
+	err = addGenericGatewaySecret(p, store)
+	if err != nil {
+		return fmt.Errorf(abort, err)
+	}
+
+	return nil
+}
+
+// loadFileValidator validates that a file exists and can be read.
+func loadFileValidator(val interface{}) error {
+	name := os.ExpandEnv(val.(string))
+	if name == "" {
+		return nil
+	}
+	_, err := ioutil.ReadFile(name)
+	return err
+}
+
+// loadFileStr should not be called unless loadFileValidator is called first.
+func loadFileStr(name string) string {
+	if name == "" {
+		return ""
+	}
+	data, err := ioutil.ReadFile(name)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func replaceNewlines(data string) string {
+	return strings.Replace(data, "\n", "$", -1)
+}
+
+// loadProjectConfig loads a project configuration from the local filesystem.
+func loadProjectConfig(file string, proj *brigade.Project) (*brigade.Project, error) {
+	rdr, err := os.Open(file)
+	if err != nil {
+		return proj, err
+	}
+	defer rdr.Close()
+
+	sec, err := parseSecret(rdr)
+	if err != nil {
+		return proj, err
+	}
+
+	if sec.Name == "" {
+		return proj, fmt.Errorf("secret in %s is missing required name field", file)
+	}
+	return kube.NewProjectFromSecret(sec, "")
+}
+
+func parseSecret(reader io.Reader) (*v1.Secret, error) {
+	dec := yaml.NewYAMLOrJSONDecoder(reader, 4096)
+	secret := &v1.Secret{}
+	// We are only decoding the first item in the YAML.
+	err := dec.Decode(secret)
+
+	// Convert StringData to Data
+	if len(secret.StringData) > 0 {
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		for key, val := range secret.StringData {
+			secret.Data[key] = []byte(val)
+		}
+	}
+
+	return secret, err
+}
+
+func isHTTP(str string) bool {
+	str = strings.ToLower(str)
+	return strings.HasPrefix(str, "http:") || strings.HasPrefix(str, "https:")
+}

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -46,7 +46,7 @@ const wrapClient = fns => {
   // wrap client methods with retry logic
   for (let fn of fns) {
     let originalFn = defaultClient[fn.name];
-    defaultClient[fn.name] = function() {
+    defaultClient[fn.name] = function () {
       return retry(originalFn, arguments, 4000, 5);
     };
   }
@@ -248,7 +248,7 @@ export class JobRunner implements jobs.JobRunner {
   cancel: boolean;
   reconnect: boolean;
 
-  constructor() {}
+  constructor() { }
 
   /**
    * init takes a generic so we can run this against mocks as well as against the real Job type.
@@ -331,9 +331,9 @@ export class JobRunner implements jobs.JobRunner {
         // add the reference to the env var list.
 
         if (val.secretKeyRef != null && !allowSecretKeyRef) {
-         // allowSecretKeyRef is not to true so disallow setting secrets in the environment
-         this.logger.warn(`Using secretKeyRef is not allowed in this project, not setting environment variable ${key}`);
-         continue
+          // allowSecretKeyRef is not to true so disallow setting secrets in the environment
+          this.logger.warn(`Using secretKeyRef is not allowed in this project, not setting environment variable ${key}`);
+          continue
         }
 
         envVars.push({
@@ -595,7 +595,7 @@ export class JobRunner implements jobs.JobRunner {
         } else {
           obj = JSON.parse(data);
         }
-      } catch (e) {} //let it stay connected.
+      } catch (e) { } //let it stay connected.
       if (obj && obj.object) {
         this.pod = obj.object as kubernetes.V1Pod;
       }
@@ -910,7 +910,7 @@ function newRunnerPod(
     jobShell = "/bin/sh";
   }
   c1.command = [jobShell, "/hook/main.sh"];
-  
+
   c1.imagePullPolicy = imageForcePull ? "Always" : "IfNotPresent";
   c1.securityContext = new kubernetes.V1SecurityContext();
 
@@ -1006,7 +1006,7 @@ export function secretToProject(
 ): Project {
   let p: Project = {
     id: secret.metadata.name,
-    name: b64dec(secret.data.repository),
+    name: secret.metadata.annotations["projectName"],
     kubernetes: {
       namespace: secret.metadata.namespace || ns,
       buildStorageSize: "50Mi",
@@ -1018,15 +1018,17 @@ export function secretToProject(
       cacheStorageClass: "",
       buildStorageClass: ""
     },
-    repo: {
-      name: secret.metadata.annotations["projectName"],
-      cloneURL: null,
-      initGitSubmodules: false
-    },
     secrets: {},
     allowPrivilegedJobs: true,
     allowHostMounts: false
   };
+  if (secret.data.repository != null) {
+    p.repo = {
+      name: b64dec(secret.data.repository),
+      cloneURL: null,
+      initGitSubmodules: false
+    }
+  }
   if (secret.data.vcsSidecar) {
     p.kubernetes.vcsSidecar = b64dec(secret.data.vcsSidecar);
   }

--- a/docs/content/intro/quickstart.md
+++ b/docs/content/intro/quickstart.md
@@ -51,6 +51,7 @@ brig project create
 
 Output would be similar to this:
 ```
+? VCS or no-VCS project? VCS
 ? Project name brigadecore/empty-testbed
 ? Full repository name github.com/brigadecore/empty-testbed
 ? Clone URL (https://github.com/your/repo.git) https://github.com/brigadecore/empty-testbed.git
@@ -196,45 +197,18 @@ On each Build, Brigade Worker will run this file and create a container with a n
 
 We will create a Project that will listen for a [SimpleEvent](https://docs.brigade.sh/topics/genericgateway/), which you can think of as a simple JSON object.
 
-To create a new project, use `brig project create`. You should pay attention to the following:
-
-- `Full repository name` and `Clone URL` will not be taken into consideration, so use whatever values you want
-- Select `Yes` for `advanced options`
-- Give `NONE` for a `Custom VCS sidecar` since we won't use VCS
-- Use `brigade.js` for the `Upload a default brigade.js script` option
-- Feel free to select a `secret for the Generic Gateway` (we're using `mysecret` in the example below)
-- You can leave all other options at their default values (just press Enter on every interactive prompt)
+To create a new project, use `brig project create`. You should make sure to add a `brigade.js` script, either using the `Default script ConfigMap name` or the `Upload a default brigade.js script` option.
 
 ```
+? VCS or no-VCS project? no-VCS
 ? Project Name brigadecore/empty-testbed
-? Full repository name github.com/brigadecore/empty-testbed
-? Clone URL (https://github.com/your/repo.git) https://github.com/brigadecore/empty-testbed.git
 ? Add secrets? No
-Auto-generated a Shared Secret: "VdNQ1eO4qVBXNmZZgNcO51CP"
-? Configure GitHub Access? No
-? Configure advanced options Yes
-? Custom VCS sidecar (enter 'NONE' for no sidecar) NONE
-? Build storage size
-? SecretKeyRef usage No
-? Build storage class default
-? Job cache storage class default
-? Worker image registry or DockerHub org
-? Worker image name
-? Custom worker image tag
-? Worker image pull policy IfNotPresent
-? Worker command yarn -s start
-? Initialize Git submodules No
-? Allow host mounts No
-? Allow privileged jobs No
-? Image pull secrets
-? Default script ConfigMap name
-? brigade.js file path relative to the repository root
-? Upload a default brigade.js script brigade.js
 ? Secret for the Generic Gateway (alphanumeric characters only). Press Enter if you want it to be auto-generated mysecret
+? Default script ConfigMap name
+? Upload a default brigade.js script brigade.js
+? Configure advanced options [? for help] (y/N)
 Project ID: brigade-4897c99315be5d2a2403ea33bdcb24f8116dc69613d5917d879d5f
 ```
-
-*Yes, we do know that the process to create a non-VCS/Generic Gateway Project is a bit cumbersome. This is going to be fixed in [#816](https://github.com/brigadecore/brigade/issues/816)*
 
 ### Send a SimpleEvent to the Generic Gateway
 

--- a/docs/content/intro/tutorial03.md
+++ b/docs/content/intro/tutorial03.md
@@ -15,7 +15,8 @@ The Brigade server tracks separate configuration for each project you set up. To
 Here we create a project for our GitHub repo:
 
 ```console
- $ brig project create
+$ brig project create
+? VCS or no-VCS project? VCS
 ? Project Name bacongobbler/uuid-generator
 ? Full repository name github.com/bacongobbler/uuid-generator
 ? Clone URL (https://github.com/your/repo.git) https://github.com/bacongobbler/uuid-generator.git

--- a/docs/content/topics/projects.md
+++ b/docs/content/topics/projects.md
@@ -53,6 +53,7 @@ new Brigade project, simply run `brig project create` and you will be prompted t
 
 ```console
 $ brig project create
+? VCS or no-VCS project? VCS
 ? Project name brigadecore/empty-testbed
 ? Full repository name github.com/brigadecore/empty-testbed
 ? Clone URL (https://github.com/your/repo.git) https://github.com/brigadecore/empty-testbed.git

--- a/docs/content/topics/scripting.md
+++ b/docs/content/topics/scripting.md
@@ -33,6 +33,7 @@ For the examples in this document, we have created a project via `brig` with the
 
 ```console
 $ brig project create
+? VCS or no-VCS project? VCS
 ? Project Name brigadecore/empty-testbed
 ? Full repository name github.com/brigadecore/empty-testbed
 ? Clone URL (https://github.com/your/repo.git) https://github.com/brigadecore/empty-testbed.git

--- a/pkg/storage/kube/project.go
+++ b/pkg/storage/kube/project.go
@@ -194,7 +194,7 @@ func NewProjectFromSecret(secret *v1.Secret, namespace string) (*brigade.Project
 	proj.DefaultScriptName = sv.String("defaultScriptName")
 
 	proj.Repo = brigade.Repo{
-		Name: def(sv.String("repository"), proj.Name),
+		Name: sv.String("repository"),
 		// Note that we have to undo the key escaping.
 		SSHKey:   strings.Replace(sv.String("sshKey"), "$", "\n", -1),
 		CloneURL: sv.String("cloneURL"),


### PR DESCRIPTION
Fixes #816, #917 

This PR modifies `brig project create` so that
- User is asked whether they do want to create a VCS or a no-VCS project
- If a no-VCS project is selected, some defaults are set (based on [comment](https://github.com/brigadecore/brigade/issues/816#issue-413206378))
  - repository information would not be configurable
  - clone URL information would not be configurable
  - the custom VCS sidecar would be automatically set to NONE
  - Git submodules inforrmation would not be configurable
  - a Brigade.js file would be mandatory (either config map, or local)
  - a secret for the generic gateway would be required

This needs TONS of testing, so pinging @technosophos @radu-matei @vdice @adamreese  :) Happy to say that VS Code for Kubernetes extension is pretty awesome for that, since you can run the modified code and immediately check what has been created.

The approach I've taken is to split the VCS and no-VCS code in two files (project_create_vcs.go and project_create_no_vcs.go) since I presume we'll add more stuff in the future so it will be cool to have keep two `templates` separate.

~~This PR is created as WIP till~~
- ~~we do agree on code/file format and messages~~
- ~~once previous point is agreed, a separate commit will be added that changes all docs that reference `brig project create`~~

~~Just for reference, files I've seen that document `brig project create` are~~
- ~~https://docs.brigade.sh/intro/quickstart/~~
- ~~https://github.com/brigadecore/brigade/blob/master/brig/README.md~~
- ~~https://docs.brigade.sh/intro/install/~~
- ~~https://docs.brigade.sh/intro/tutorial03/~~
- ~~https://docs.brigade.sh/topics/developers/~~
- ~~https://docs.brigade.sh/topics/genericgateway/~~
- ~~https://docs.brigade.sh/topics/projects/~~
- ~~https://docs.brigade.sh/topics/scripting/~~
- ~~https://docs.brigade.sh/topics/secrets/~~
- ~~https://docs.brigade.sh/topics/workers/~~

~~All these files will probably need to be amended with new `brig project create` messages and options.~~

Added a fix for #917, even though I suspect that this might be a breaking change for `brigade.js` files that for (whatever reason) got the repo URL from project.name and the actual project name from project.repo.name.