### PR TITLE
fix sorting on topics docs

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -66,61 +66,11 @@ relativeURLs = "false"
 [[menu.index]]
     name = "Topic Guides"
     url = "/topics/"
-    weight = 30
+    weight = 40
     identifier = "topics"
-    [[menu.index]]
-    name = "Advanced Scripting Guide"
-    url = "/topics/scripting_advanced/"
-    weight = 31
-    parent = "topics"
-    [[menu.index]]
-    name = "Container Registry Integration"
-    url = "/topics/dockerhub/"
-    weight = 32
-    parent = "topics"
-    [[menu.index]]
-    name = "Dependencies"
-    url = "/topics/dependencies/"
-    weight = 33
-    parent = "topics"
     [[menu.index]]
     name = "Design"
     url = "/topics/design/"
-    weight = 34
-    parent = "topics"
-    [[menu.index]]
-    name = "Developer Guide"
-    url = "/topics/developers/"
-    weight = 35
-    parent = "topics"
-    [[menu.index]]
-    name = "Gateways"
-    url = "/topics/gateways/"
-    weight = 36
-    parent = "topics"
-    [[menu.index]]
-    name = "Generic Gateway"
-    url = "/topics/genericgateway/"
-    weight = 37
-    parent = "topics"
-    [[menu.index]]
-    name = "GitHub Integration"
-    url = "/topics/github/"
-    weight = 38
-    parent = "topics"
-    [[menu.index]]
-    name = "Ingress"
-    url = "/topics/ingress/"
-    weight = 39
-    parent = "topics"
-    [[menu.index]]
-    name = "Projects"
-    url = "/topics/projects/"
-    weight = 40
-    parent = "topics"
-    [[menu.index]]
-    name = "Releasing Brigade"
-    url = "/topics/releasing/"
     weight = 41
     parent = "topics"
     [[menu.index]]
@@ -129,39 +79,89 @@ relativeURLs = "false"
     weight = 42
     parent = "topics"
     [[menu.index]]
+    name = "The Brigade.js API"
+    url = "/topics/javascript/"
+    weight = 43
+    parent = "topics"
+    [[menu.index]]
+    name = "Advanced Scripting Guide"
+    url = "/topics/scripting_advanced/"
+    weight = 44
+    parent = "topics"
+    [[menu.index]]
+    name = "Dependencies"
+    url = "/topics/dependencies/"
+    weight = 45
+    parent = "topics"
+    [[menu.index]]
+    name = "GitHub Integration"
+    url = "/topics/github/"
+    weight = 46
+    parent = "topics"
+    [[menu.index]]
+    name = "Container Registry Integration"
+    url = "/topics/dockerhub/"
+    weight = 47
+    parent = "topics"
+    [[menu.index]]
+    name = "Generic Gateway"
+    url = "/topics/genericgateway/"
+    weight = 48
+    parent = "topics"
+    [[menu.index]]
     name = "Secret Management"
     url = "/topics/secrets/"
-    weight = 43
+    weight = 49
+    parent = "topics" 
+    [[menu.index]]
+    name = "Gateways"
+    url = "/topics/gateways/"
+    weight = 50
+    parent = "topics"
+    [[menu.index]]
+    name = "Ingress"
+    url = "/topics/ingress/"
+    weight = 51
+    parent = "topics"
+    [[menu.index]]
+    name = "Projects"
+    url = "/topics/projects/"
+    weight = 52
     parent = "topics"
     [[menu.index]]
     name = "Securing Brigade"
     url = "/topics/security/"
-    weight = 44
+    weight = 53
     parent = "topics"
     [[menu.index]]
     name = "Storage"
     url = "/topics/storage/"
-    weight = 45
-    parent = "topics"
-    [[menu.index]]
-    name = "Testing"
-    url = "/topics/testing/"
-    weight = 46
-    parent = "topics"
-    [[menu.index]]
-    name = "The Brigade.js API"
-    url = "/topics/javascript/"
-    weight = 47
+    weight = 54
     parent = "topics"
     [[menu.index]]
     name = "Workers"
     url = "/topics/workers/"
-    weight = 48
+    weight = 55
+    parent = "topics"
+    [[menu.index]]
+    name = "Testing"
+    url = "/topics/testing/"
+    weight = 56
+    parent = "topics"
+    [[menu.index]]
+    name = "Developer Guide"
+    url = "/topics/developers/"
+    weight = 57
+    parent = "topics"
+    [[menu.index]]
+    name = "Releasing Brigade"
+    url = "/topics/releasing/"
+    weight = 58
     parent = "topics"
 [[menu.index]]
     name = "Contributing"
     url = "/contributing/"
-    weight = 50
+    weight = 60
 
 
 # top navigation - project links


### PR DESCRIPTION
Fixes #883 

This is a better sorting of the articles presented on the `Topic Guides` of Brigade documentation. It highly resembles the order found [here](https://github.com/brigadecore/brigade/blob/6140dc7d2440a5efe94e3be9aedfaf9ae94e7024/docs/topics/index.md) (one of the last commits before the introduction of netlify).

Also weight numbering on `Topic Guides` starts with a higher number, in case we wish to add more articles in the `intro` section.

- [X] this PR contains documentation

preview on https://deploy-preview-897--brigade-docs.netlify.com/