### PR TITLE
fix(k8s.ts): extract error message for log/reject

### DIFF
--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -516,8 +516,7 @@ export class JobRunner implements jobs.JobRunner {
           resolve(this);
         })
         .catch(reason => {
-          this.logger.error(reason);
-          reject(reason);
+          reject(new Error(reason.body.message));
         });
     });
   }
@@ -553,8 +552,7 @@ export class JobRunner implements jobs.JobRunner {
               });
           })
           .catch(err => {
-            this.logger.error(err);
-            reject(err);
+            reject(new Error(err.body.message));
           });
       }
     });
@@ -595,7 +593,7 @@ export class JobRunner implements jobs.JobRunner {
     });
     const req = request(requestOptions, (error, response, body) => {
       if (error) {
-        this.logger.error(error);
+        this.logger.error(error.body.message);
         this.reconnect = true; //reconnect unless aborted
       }
     });
@@ -680,7 +678,7 @@ export class JobRunner implements jobs.JobRunner {
               name,
               ns,
               new kubernetes.V1DeleteOptions()
-            ).catch(e => this.logger.error(e));
+            ).catch(e => this.logger.error(e.body.message));
             clearTimers();
             reject(new Error(cs[0].state.waiting.message));
           }
@@ -739,7 +737,7 @@ export class JobRunner implements jobs.JobRunner {
         });
         const req = request(requestOptions, (error, response, body) => {
           if (error) {
-            this.logger.error(error);
+            this.logger.error(error.body.message);
             this.reconnect = true; //reconnect unless aborted
           }
         });


### PR DESCRIPTION
Proposed fix for https://github.com/brigadecore/brigade/issues/898

Previously, the entire error/response was being logged and/or supplied to `reject()`.  In doing so, the request headers to the k8s api server may be logged (including the auth token.)

This PR updates the code to extract/log only the error message itself.

For the repro mentioned in the corresponding issue, this is the result with the changes on this branch:
```
 $ b run test -f test-project/brigade.js
Event created. Waiting for worker pod named "brigade-worker-01d989tg4b92y29x7mv4v0akg7".
Build: 01d989tg4b92y29x7mv4v0akg7, Worker: brigade-worker-01d989tg4b92y29x7mv4v0akg7
prestart: no dependencies file found
[brigade] brigade-worker version: 1.0.0
[brigade:k8s] Creating secret myjob-01d989tg4b92y29x7mv4v0akg7
[brigade:k8s] Creating pod myjob-01d989tg4b92y29x7mv4v0akg7
[brigade:k8s] Timeout set at 900000
[brigade:k8s] Pod not yet scheduled
[brigade:k8s] default/myjob-01d989tg4b92y29x7mv4v0akg7 phase Succeeded
[brigade:k8s] Creating secret myjob-01d989tg4b92y29x7mv4v0akg7
  Error: secrets "myjob-01d989tg4b92y29x7mv4v0akg7" already exists

  - k8s.js:417 pvcPromise.then.then.then.catch.reason
    /home/src/dist/k8s.js:417:24


  - next_tick.js:189 process._tickCallback
    internal/process/next_tick.js:189:7


error Command failed with exit code 1.
build failed. (Build ID: 01d989tg4b92y29x7mv4v0akg7)
```

Closes https://github.com/brigadecore/brigade/issues/898
