### PR TITLE
allow default worker command to also be set via env var

### DIFF
--- a/brigade-controller/cmd/brigade-controller/main.go
+++ b/brigade-controller/cmd/brigade-controller/main.go
@@ -30,7 +30,7 @@ func main() {
 	flag.StringVar(&master, "master", "", "master url")
 	flag.StringVar(&ctrConfig.Namespace, "namespace", defaultNamespace(), "kubernetes namespace")
 	flag.StringVar(&ctrConfig.WorkerImage, "worker-image", defaultWorkerImage(), "kubernetes worker image")
-	flag.StringVar(&ctrConfig.WorkerCommand, "worker-command", "", "kubernetes worker command")
+	flag.StringVar(&ctrConfig.WorkerCommand, "worker-command", defaultWorkerCommand(), "kubernetes worker command")
 	flag.StringVar(&ctrConfig.WorkerPullPolicy, "worker-pull-policy", defaultWorkerPullPolicy(), "kubernetes worker image pull policy")
 	flag.StringVar(&ctrConfig.WorkerServiceAccount, "worker-service-account", defaultWorkerServiceAccount(), "kubernetes worker service account name")
 	flag.StringVar(&ctrConfig.ProjectServiceAccount, "project-service-account", defaultProjectServiceAccount(), "default brigade project service account name")
@@ -75,6 +75,10 @@ func defaultWorkerImage() string {
 		return image
 	}
 	return "brigadecore/brigade-worker:latest"
+}
+
+func defaultWorkerCommand() string {
+	return os.Getenv("BRIGADE_WORKER_COMMAND")
 }
 
 func defaultWorkerPullPolicy() string {


### PR DESCRIPTION
This is a follow-up to #906 because when I went to expose this through the Helm chart, I noticed that the chart passed other bits of worker configuration (such as image and pull policy) to the controller as environment variables. Rather than use a flag for that purpose where related attributes are managed as env vars, I figured it would be more consistent to circle back on what I did in #906 and make it configurable via flag or env var.