### PR TITLE
[docs] make deploy previews use rel paths

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,5 +1,5 @@
 baseURL = "https://docs.brigade.sh/"
-title = "Brigade"
+title = "Brigade Docs"
 theme = "techdoc-brigade"
 canonifyURLs = "true"
 relativeURLs = "true"

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -2,7 +2,7 @@ baseURL = "https://docs.brigade.sh/"
 title = "Brigade"
 theme = "techdoc-brigade"
 canonifyURLs = "true"
-relativeURLs = "false"
+relativeURLs = "true"
 
 [params]
   title = "Brigade"

--- a/docs/themes/techdoc-brigade/layouts/partials/head.html
+++ b/docs/themes/techdoc-brigade/layouts/partials/head.html
@@ -16,7 +16,8 @@
 <link rel="canonical" href="{{ .Permalink }}">
 
 {{ $fonts := resources.Get "fonts/" | absURL }}  
-{{ $style := resources.Get "scss/theme.scss" | toCSS | minify | fingerprint }} 
-<link rel="stylesheet" href="{{ $style.Permalink }}" emotion="🤩">
+{{ $options := (dict "outputStyle" "compressed" "enableSourceMap" true }}
+{{ $style := resources.Get "scss/theme.scss" | toCSS | minify | fingerprint  $options }} 
+<link rel="stylesheet" href="{{ $style.RelPermalink }}" emotion="🤩">
 
 <link rel="icon" type="image/png" href="https://docs.brigade.sh/img/favicon.png">

--- a/docs/themes/techdoc-brigade/layouts/partials/head.html
+++ b/docs/themes/techdoc-brigade/layouts/partials/head.html
@@ -16,8 +16,7 @@
 <link rel="canonical" href="{{ .Permalink }}">
 
 {{ $fonts := resources.Get "fonts/" | absURL }}  
-{{ $options := (dict "outputStyle" "compressed" "enableSourceMap" true }}
-{{ $style := resources.Get "scss/theme.scss" | toCSS | minify | fingerprint  $options }} 
+{{ $style := resources.Get "scss/theme.scss" | toCSS | minify | fingerprint }} 
 <link rel="stylesheet" href="{{ $style.RelPermalink }}" emotion="🤩">
 
 <link rel="icon" type="image/png" href="https://docs.brigade.sh/img/favicon.png">

--- a/docs/themes/techdoc-brigade/layouts/partials/menu.html
+++ b/docs/themes/techdoc-brigade/layouts/partials/menu.html
@@ -4,16 +4,16 @@
   <ul>
     {{- range .Site.Menus.index.ByWeight -}}
       {{ if .HasChildren -}}
-      <li class="parent{{ if $currentPage.HasMenuCurrent "index" . }} active{{ end }}"><a href="{{ .URL | absURL }}">{{- .Name -}} <i class="fas fa-angle-right"></i></a>
+      <li class="parent{{ if $currentPage.HasMenuCurrent "index" . }} active{{ end }}"><a href="{{ .URL | relURL }}">{{- .Name -}} <i class="fas fa-angle-right"></i></a>
         
         <ul class="sub-menu">
           {{ range .Children -}}
-          <li class="child{{ if $currentPage.HasMenuCurrent "index" . }} active{{ end }}"><a href="{{ .URL | absURL }}">{{ .Name }}</a></li>
+          <li class="child{{ if $currentPage.HasMenuCurrent "index" . }} active{{ end }}"><a href="{{ .URL | relURL }}">{{ .Name }}</a></li>
           {{ end -}}
         </ul>
       </li>
       {{- else }}
-      <li{{ if $currentPage.HasMenuCurrent "index" . }} class="active"{{ end }}><a href="{{ .URL | absURL }}">{{- .Name -}}</a></li>
+      <li{{ if $currentPage.HasMenuCurrent "index" . }} class="active"{{ end }}><a href="{{ .URL | relURL }}">{{- .Name -}}</a></li>
       {{- end -}}
     {{- end -}}
   </ul>


### PR DESCRIPTION
This PR fixes issue #909, by setting urls and import paths in the hugo theme to use relative rather than absolute urls. This resolves two issues with the current docs site:

* Left-hand menu: you can now properly browse and test the staging previews that netlify generates, instead of constantly being directed to the live site
* CSS stylesheets: are now relative, so updates to the site CSS will no longer be broken as per #909 

You can see these changes on the preview for this PR: [https://5cd47650e631c80008da00cd--brigade-docs.netlify.com/](https://5cd47650e631c80008da00cd--brigade-docs.netlify.com/)

---

Closes #909.