### PR TITLE
Log unhandled rejection with error message

### DIFF
--- a/brigade-worker/src/app.ts
+++ b/brigade-worker/src/app.ts
@@ -130,6 +130,7 @@ export class App {
     // Run if an uncaught rejection happens.
     process.on("unhandledRejection", (reason: any, p: Promise<any>) => {
       this.logger.error(reason);
+      console.log("Unhandled rejection: " + reason);
       this.fireError(reason, "unhandledRejection");
     });
 


### PR DESCRIPTION
closes #913 

**What this PR does / why we need it**:
This PR logs the error message when an error is thrown but not handled.

One area I'd like to dig a bit deeper is around the different log levels, but for the time being, this is the easiest way to get the error to show up in the pod logs.

To test:

```
const { events } = require("brigadier")

events.on("exec", function() {
  throw new Error("This should be logged when failing the event handler.")
});
```

This generates:

```
prestart: no dependencies file found
[brigade] brigade-worker version: 1.0.0 
Unhandled rejection: Error: This should be logged when failing the event handler.
error Command failed with exit code 1
```
