### PR TITLE
fix(brigade-worker): uppercase BRIGADE_LOG_LEVEL val for deriving cor…

### DIFF
--- a/brigade-worker/src/index.ts
+++ b/brigade-worker/src/index.ts
@@ -84,7 +84,8 @@ if (script) {
   require(script);
 }
 
-const logLevel = LogLevel[process.env.BRIGADE_LOG_LEVEL || "LOG"];
+// Log level may come in as lowercased 'log', 'info', etc., if run by the brig cli
+const logLevel = LogLevel[process.env.BRIGADE_LOG_LEVEL.toUpperCase() || "LOG"];
 const logger = new ContextLogger([], logLevel);
 
 const version = require("../package.json").version;


### PR DESCRIPTION
Closes https://github.com/brigadecore/brigade/issues/913

When a build's log level is set by the user/`brig` cli (e.g.,`log`, `info`, `warn`, etc.) the derived `LogLevel` (e.g., `LogLevel["log"]`) using the corresponding [enum in brigadier](https://github.com/brigadecore/brigadier/blob/master/src/logger.ts#L12-L19) would be `undefined`, as all of the keys are in all-caps.

Therefore, we need to uppercase their values such that the appropriate level is used, e.g., `LogLevel["LOG"]` gives a defined value, etc.

With this change, we now see the log levels being properly set/used, e.g. in the following example that was previously broken (see https://github.com/brigadecore/brigade/pull/914#discussion_r285256405):
```
 $ brig run vdice/empty-testbed -l error -f throw-error.js
Event created. Waiting for worker pod named "brigade-worker-01dbbehxaeg3w2pfp9yjgjcpg3".
Build: 01dbbehxaeg3w2pfp9yjgjcpg3, Worker: brigade-worker-01dbbehxaeg3w2pfp9yjgjcpg3
prestart: no dependencies file found
[brigade:app]   Error: This should be logged when failing the event handler.

  - script:4 EventRegistry.<anonymous>
    /etc/brigade/..2019_05_20_20_22_32.115709736/script:4:9

  - events.js:107 EventRegistry.fire
    [src]/[@brigadecore]/brigadier/out/events.js:107:14

  - brigadier.js:34 Object.fire
    /home/src/dist/brigadier.js:34:20

  - app.js:157 loadProject.then.then
    /home/src/dist/app.js:157:23


  - next_tick.js:189 process._tickCallback
    internal/process/next_tick.js:189:7


error Command failed with exit code 1.
build failed. (Build ID: 01dbbehxaeg3w2pfp9yjgjcpg3)
```