### PR TITLE
fix: wrong `helm upgrade` usage in "Installing Brigade"

### DIFF
--- a/docs/content/intro/install.md
+++ b/docs/content/intro/install.md
@@ -31,7 +31,7 @@ Let's take the example of enabling the [GitHub App Gateway](../topics/github.md)
 We would upgrade our `brigade-server` release like so:
 
 ```
-$ helm upgrade -n brigade-server brigade/brigade --set brigade-github-app.enabled=true
+$ helm upgrade brigade-server brigade/brigade --set brigade-github-app.enabled=true
 ```
 
 We'd then locate the external IP as follows:


### PR DESCRIPTION
The `Installing Brigade` document says that you should run `helm upgrade -n brigade-server brigade/brigade` to upgrade it, but it doesn't work:

```
$ helm upgrade -n brigade brigade/brigade --set brigade-github-app.enabled=true
Error: unknown shorthand flag: 'n' in -n
```

I believe the correct command should be `helm upgrade brigade ...` without `-n`, assuming you want to upgrade the release `brigade-server` with the latest version of the chart `brigade/brigade`.

<!--
Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR (https://github.com/brigadecore/brigade/blob/master/docs/topics/developers.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).

2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
