### PR TITLE
make sure version is set correctly for brig binaries

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -193,7 +193,7 @@ function githubRelease(p, tag) {
   job.tasks = [
     "go get github.com/aktau/github-release",
     `cd ${localPath}`,
-    "make build-brig",
+    `VERSION=${tag} make build-brig`,
     `last_tag=$(git describe --tags ${tag}^ --abbrev=0 --always)`,
     `github-release release \
       -t ${tag} \


### PR DESCRIPTION
This definitely needs to get in before 1.1... it will ensure version information is set correctly when building the brig binaries for release.