### PR TITLE
fix(brigade-worker): ensure backwards compatibility for project name and repo name values

### DIFF
--- a/brig/cmd/brig/commands/project_create_no_vcs.go
+++ b/brig/cmd/brig/commands/project_create_no_vcs.go
@@ -87,7 +87,4 @@ func setDefaultValuesNoVCS(p *brigade.Project) {
 	p.Name = "myproject"
 	// setting the sidecar to NONE
 	p.Kubernetes.VCSSidecar = "NONE"
-	// empty values for the repo
-	p.Repo.CloneURL = ""
-	p.Repo.Name = ""
 }

--- a/brig/cmd/brig/commands/project_create_test.go
+++ b/brig/cmd/brig/commands/project_create_test.go
@@ -2,7 +2,10 @@ package commands
 
 import (
 	"os"
+	"reflect"
 	"testing"
+
+	"github.com/brigadecore/brigade/pkg/brigade"
 )
 
 const testProjectSecret = "./testdata/project_secret.json"
@@ -27,12 +30,8 @@ func TestInitProjectNoVCS(t *testing.T) {
 		t.Fatal("VCSSidecar should be NONE")
 	}
 
-	if p.Repo.CloneURL != "" {
-		t.Fatal("CloneURL should be an empty string")
-	}
-
-	if p.Repo.Name != "" {
-		t.Fatal("Repo.Name should be an empty string")
+	if reflect.DeepEqual(p.Repo, brigade.Repo{}) {
+		t.Fatal("Project Repo should be empty/unset")
 	}
 }
 

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -1023,8 +1023,12 @@ export function secretToProject(
     allowHostMounts: false
   };
   if (secret.data.repository != null) {
+    // For legacy/backwards-compatibility reasons,
+    // we set project name and repo name to the following values,
+    // despite the fact that they should logically be swapped.
+    p.name = b64dec(secret.data.repository)
     p.repo = {
-      name: b64dec(secret.data.repository),
+      name: secret.metadata.annotations["projectName"],
       cloneURL: null,
       initGitSubmodules: false
     }

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -29,8 +29,8 @@ describe("k8s", function() {
         p.id,
         "brigade-7e3d1157331f6726338395e320cffa41d2bc9e20157fd7a4df355d"
       );
-      assert.equal(p.name, "brigadecore/test-private-testbed");
-      assert.equal(p.repo.name, "github.com/brigadecore/test-private-testbed");
+      assert.equal(p.name, "github.com/brigadecore/test-private-testbed");
+      assert.equal(p.repo.name, "brigadecore/test-private-testbed");
       assert.equal(
         p.repo.cloneURL,
         "https://github.com/brigadecore/empty-testbed.git"
@@ -53,8 +53,8 @@ describe("k8s", function() {
           p.id,
           "brigade-7e3d1157331f6726338395e320cffa41d2bc9e20157fd7a4df355d"
         );
-        assert.equal(p.name, "brigadecore/test-private-testbed");
-        assert.equal(p.repo.name, "github.com/brigadecore/test-private-testbed");
+        assert.equal(p.name, "github.com/brigadecore/test-private-testbed");
+        assert.equal(p.repo.name, "brigadecore/test-private-testbed");
         assert.equal(p.repo.token, "pretend password\n");
         assert.equal(p.kubernetes.namespace, "default");
         assert.equal(p.kubernetes.vcsSidecar, "vcs-image:latest");


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR restores the legacy values for project name and repo name for a VCS project, albeit somewhat reluctantly.  The values were updated, logically so, in https://github.com/brigadecore/brigade/pull/892.  However, for users who may be relying on the the previous/legacy values for these two, say, in corresponding `brigade.js` files for a given project, breaking changes may result.

As a concrete example, if a URL in a `brigade.js` file is derived using `project.repo.name`, the legacy value of this interpolated string (restored in this PR) would have been `myorg/myrepo`, whereas in 892, it would be `github.com/myorg/myrepo`, thus invalidating the URL.  

If we feel strongly about following the (sane) precedent/updates of 892 at some point in the future, we'd have to point out the breaking changes to users (and thus might strictly require a `v2.x.x` release.)

