### PR TITLE
added instructions to develop with kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ ifneq ($(SKIP_DOCKER),true)
 		-w /code/$(BASE_PACKAGE_NAME) $(JS_DEV_IMAGE)
 endif
 
+# Allow for users to supply a different helm cli name,
+# for instance, if one has helm v3 as `helm3` and helm v2 as `helm`
+HELM ?= helm
+
 ################################################################################
 # Binaries and Docker images we build and publish                              #
 ################################################################################
@@ -141,6 +145,14 @@ build-all-images: $(addsuffix -build-image,$(IMAGES))
 		.
 	docker tag $(DOCKER_IMAGE_PREFIX)$*:$(IMMUTABLE_DOCKER_TAG) $(DOCKER_IMAGE_PREFIX)$*:$(MUTABLE_DOCKER_TAG)
 
+.PHONY: load-all-images
+load-all-images: $(addsuffix -load-image,$(IMAGES))
+
+%-load-image:
+	@echo "Loading $(DOCKER_IMAGE_PREFIX)$*:$(IMMUTABLE_DOCKER_TAG)"
+	@kind load docker-image $(DOCKER_IMAGE_PREFIX)$*:$(IMMUTABLE_DOCKER_TAG) \
+			|| echo >&2 "kind not installed or error loading image: $(DOCKER_IMAGE_PREFIX)$*:$(IMMUTABLE_DOCKER_TAG)"
+
 # Cross-compile binaries for brig
 build-brig:
 	$(GO_DOCKER_CMD) bash -c 'LDFLAGS="$(LDFLAGS)" scripts/build-brig.sh'
@@ -187,7 +199,7 @@ helm-install: helm-upgrade
 
 .PHONY: helm-upgrade
 helm-upgrade:
-	helm upgrade --install $(BRIGADE_RELEASE) brigade/brigade --namespace $(BRIGADE_NAMESPACE) \
+	$(HELM) upgrade --install $(BRIGADE_RELEASE) brigade/brigade --namespace $(BRIGADE_NAMESPACE) \
 		--set brigade-github-app.enabled=true \
 		--set controller.registry=$(BRIGADE_REGISTRY) \
 		--set controller.tag=$(BRIGADE_VERSION) \


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR includes instructions for Brigade development with [kind](https://github.com/kubernetes-sigs/kind). Same commands will also be used in building [e2e tests for Brigade](https://github.com/brigadecore/brigade/issues/879).

**Special notes for your reviewer**:

I added a line on Makefile to `kind load` images, this should run only if kind is installed. Is there a better way to do that?

**If applicable**:
- [X] this PR contains documentation