### PR TITLE
fix(brig): silence usage on errors by default for root command

### DIFF
--- a/brig/cmd/brig/commands/app.go
+++ b/brig/cmd/brig/commands/app.go
@@ -52,9 +52,10 @@ func init() {
 
 // Root is the root command
 var Root = &cobra.Command{
-	Use:   "brig",
-	Short: "The Brigade client",
-	Long:  mainUsage,
+	Use:          "brig",
+	Short:        "The Brigade client",
+	Long:         mainUsage,
+	SilenceUsage: true,
 }
 
 // kubeClient returns a Kubernetes clientset.


### PR DESCRIPTION
Proposed fix for https://github.com/brigadecore/brigade/issues/940

Here, we silence usage (on errors) by default for the root command (and hence, all sub-commands.)

Sample:

Before:
```
 $ ./bin/brig run foo
Error: could not find the project "foo": secrets "brigade-2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e" not found
Usage:
  brig run PROJECT [flags]

Aliases:
  run, exec

Flags:
  -b, --background       Trigger the event and exit. Let the job run in the background.
  -c, --commit string    A VCS (git) commit
  -e, --event string     The name of the event to fire (default "exec")
  -f, --file string      The JavaScript file to execute
  -h, --help             help for run
  -l, --level string     Specified log level: log, info, warn, error (default "log")
      --no-color         Remove color codes from log output
      --no-progress      Disable progress meter
  -p, --payload string   The path to a payload file
  -r, --ref string       A VCS (git) version, tag, or branch (default "master")

Global Flags:
      --kube-context string   The name of the kubeconfig context to use.
      --kubeconfig string     The path to a KUBECONFIG file, overrides $KUBECONFIG.
  -n, --namespace string      The Kubernetes namespace for Brigade, overrides $BRIGADE_NAMESPACE. (default "default")
  -v, --verbose               Turn on verbose output

could not find the project "foo": secrets "brigade-2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e" not found
```
After:
```
 $ ./bin/brig-darwin-amd64 run foo
Error: could not find the project "foo": secrets "brigade-2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e" not found
could not find the project "foo": secrets "brigade-2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e" not found
```

(Note: proposed fix for double error printing in https://github.com/brigadecore/brigade/pull/947)

Closes https://github.com/brigadecore/brigade/issues/940