### PR TITLE
fix(main.go): remove double print of error message

### DIFF
--- a/brig/cmd/brig/main.go
+++ b/brig/cmd/brig/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/brigadecore/brigade/brig/cmd/brig/commands"
@@ -9,7 +8,6 @@ import (
 
 func main() {
 	if err := commands.Root.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		switch e := err.(type) {
 		case commands.BrigError:
 			os.Exit(e.Code)


### PR DESCRIPTION
While working on https://github.com/brigadecore/brigade/pull/946, I noticed that we were usually double-logging error messages.

(Below I omit the bulk of the usage output, intended to be fixed in https://github.com/brigadecore/brigade/pull/946)

Before:
```
 $ ./bin/brig build list foo
Error: secrets "brigade-2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e" not found
Usage:
  brig build list [project] [flags]
...
secrets "brigade-2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e" not found
```

After:
```
 $ ./bin/brig-darwin-amd64 build list foo
Error: secrets "brigade-2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e" not found
Usage:
  brig build list [project] [flags]
...
```