### PR TITLE
feat(brig): achieve flag parity for rerun command (to run); add unit tests

### DIFF
--- a/brig/cmd/brig/commands/build_list_test.go
+++ b/brig/cmd/brig/commands/build_list_test.go
@@ -18,6 +18,10 @@ const (
 	stubBuild3ID   = "01cxmy71nbq7nasvth8pva1s23"
 )
 
+type DefaultBuildData struct {
+	LogLevel, Event, Commit, Ref string
+}
+
 var (
 	stubDT1Start     = time.Now().Add(-5 * time.Minute)
 	stubTimeDT1Start = metav1.NewTime(stubDT1Start)
@@ -29,6 +33,13 @@ var (
 	stubDT3Start     = time.Now().Add(-3 * time.Minute)
 	stubTimeDT3Start = metav1.NewTime(stubDT3Start)
 	stubDT3End       = time.Now().Add(-time.Minute)
+
+	defaultStubBuildData = DefaultBuildData{
+		LogLevel: "log",
+		Event:    "exec",
+		Commit:   "abc1234",
+		Ref:      "master",
+	}
 )
 
 func TestGetEmptyBuildList(t *testing.T) {
@@ -235,6 +246,12 @@ func createStubBuildSecret(projectID string, buildID string) *v1.Secret {
 			},
 		},
 		Type: "brigade.sh/build",
+		Data: map[string][]byte{
+			"log_level":  []byte(defaultStubBuildData.LogLevel),
+			"event_type": []byte(defaultStubBuildData.Event),
+			"commit_id":  []byte(defaultStubBuildData.Commit),
+			"commit_ref": []byte(defaultStubBuildData.Ref),
+		},
 	}
 
 	if buildID != "" {

--- a/brig/cmd/brig/commands/rerun_test.go
+++ b/brig/cmd/brig/commands/rerun_test.go
@@ -1,0 +1,150 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/pkg/decolorizer"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/brigadecore/brigade/pkg/script"
+)
+
+func TestRerun_updateRunner(t *testing.T) {
+	type updateRunnerTest struct {
+		Name       string
+		NoColor    bool
+		NoProgress bool
+		Background bool
+		Verbose    bool
+	}
+
+	testcases := []updateRunnerTest{
+		{
+			Name:       "Defaults",
+			NoColor:    false,
+			NoProgress: false,
+			Background: false,
+			Verbose:    false,
+		},
+		{
+			Name:       "Overrides",
+			NoColor:    true,
+			NoProgress: true,
+			Background: true,
+			Verbose:    true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			r := &script.Runner{}
+
+			if tc.Name == "Overrides" {
+				rerunBackground = tc.Background
+				rerunNoColor = tc.NoColor
+				rerunNoProgress = tc.NoProgress
+				globalVerbose = tc.Verbose
+			}
+
+			updateRunner(r)
+
+			if r.NoProgress != tc.NoProgress {
+				t.Errorf("expected NoProgress to be %t, was %t", tc.NoProgress, r.NoProgress)
+			}
+
+			if r.Background != tc.Background {
+				t.Errorf("expected Background to be %t, was %t", tc.Background, r.Background)
+			}
+
+			if r.Verbose != tc.Verbose {
+				t.Errorf("expected Verbose to be %t, was %t", tc.Verbose, r.Verbose)
+			}
+
+			if _, ok := r.ScriptLogDestination.(*decolorizer.Writer); ok != tc.NoColor {
+				if tc.NoColor {
+					t.Error("expected ScriptLogDestination to be of type *decolorizer.Writer")
+				} else {
+					t.Error("expected ScriptLogDestination to be of type io.Writer")
+				}
+			}
+		})
+	}
+}
+
+func TestRerun_getUpdatedBuild(t *testing.T) {
+	type updatedBuildTest struct {
+		Name     string
+		LogLevel string
+		Type     string
+		Commit   string
+		Ref      string
+	}
+
+	testcases := []updatedBuildTest{
+		{
+			Name:     "Defaults",
+			LogLevel: defaultStubBuildData.LogLevel,
+			Type:     defaultStubBuildData.Event,
+			Commit:   defaultStubBuildData.Commit,
+			Ref:      defaultStubBuildData.Ref,
+		},
+		{
+			Name:     "Overrides",
+			LogLevel: "warn",
+			Type:     "different-event",
+			Commit:   "new-commit",
+			Ref:      "new-ref",
+		},
+	}
+
+	client := fake.NewSimpleClientset()
+
+	// Thank you, build_list_test.go!
+	createFakeBuilds(t, client)
+
+	r, err := script.NewDelegatedRunner(client, "default")
+	if err != nil {
+		t.Fatalf("expected err to be nil, was: %s", err.Error())
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			if tc.Name == "Overrides" {
+				rerunLogLevel = tc.LogLevel
+				rerunCommitish = tc.Commit
+				rerunRef = tc.Ref
+				rerunEvent = tc.Type
+			}
+
+			build, err := getUpdatedBuild(r, stubBuild1ID)
+			if err != nil {
+				t.Errorf("expected err to be nil, was: %s", err.Error())
+			}
+
+			if build.ID != "" {
+				t.Errorf("expected build.ID to be empty, was: %s", build.ID)
+			}
+
+			if build.Worker != nil {
+				t.Errorf("expected build.Worker to be %v, was: %v", nil, build.Worker)
+			}
+
+			if build.LogLevel != tc.LogLevel {
+				t.Errorf("expected build.LogLevel to be %s, was: %s", tc.LogLevel, build.LogLevel)
+			}
+
+			if build.Revision.Commit != tc.Commit {
+				t.Errorf("expected build.Revision.Commit to be %s, was: %s", tc.Commit, build.Revision.Commit)
+			}
+
+			if build.Revision.Ref != tc.Ref {
+				t.Errorf("expected build.Revision.Ref to be %s, was: %s", tc.Ref, build.Revision.Ref)
+			}
+
+			if build.Type != tc.Type {
+				t.Errorf("expected build.Type to be %s, was: %s", tc.Type, build.Type)
+			}
+		})
+	}
+}

--- a/pkg/script/delegated_runner.go
+++ b/pkg/script/delegated_runner.go
@@ -28,7 +28,7 @@ const (
 )
 
 // NewDelegatedRunner returns a new Runner object with the provided Kubernetes Clientset and namespace
-func NewDelegatedRunner(c *kubernetes.Clientset, namespace string) (*Runner, error) {
+func NewDelegatedRunner(c kubernetes.Interface, namespace string) (*Runner, error) {
 	app := &Runner{
 		store:                kube.New(c, namespace),
 		kc:                   c,


### PR DESCRIPTION
**What this PR does / why we need it**:

Proposed implementation to address https://github.com/brigadecore/brigade/issues/941, including refactoring for unit testability.

**Special Notes for the Reviewer**:

I went the route of using the same set of flags for `run` and `rerun`, as I didn't see harm in enabling overriding any of the `run` flags/fields for `rerun`.  Open to suggestions/revisiting if others have feedback.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

Closes https://github.com/brigadecore/brigade/issues/941
