### PR TITLE
end to end testing for Brigade using kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,3 +241,7 @@ test-functional:
 		echo $$! > /tmp/$(BRIGADE_GITHUB_GW_SERVICE).PID
 	go test --tags integration ./tests -kubeconfig $(KUBECONFIG) $(TEST_REPO_COMMIT)
 	@kill -TERM $$(cat /tmp/$(BRIGADE_GITHUB_GW_SERVICE).PID)
+
+.PHONY: e2e
+e2e:
+	./e2e/run.sh

--- a/docs/content/topics/developers.md
+++ b/docs/content/topics/developers.md
@@ -275,8 +275,8 @@ kubectl --namespace kube-system create serviceaccount tiller
 kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller 
 kubectl --namespace kube-system patch deploy tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}' 
 ```
-- Run `DOCKER_REGISTRY=brigadecore make build-all-images load-all-images` to build all images locally for the kind cluster
-- Run `make helm-install` to install/upgrade Brigade onto the kind cluster. This is the command you should re-run to test your changes during your Brigade development workflow
+- Run `DOCKER_ORG=brigadecore make build-all-images load-all-images` to build all images locally for the kind cluster
+- Run `make helm-install` to install/upgrade Brigade onto the kind cluster. This is the command you should re-run to test your changes during your Brigade development workflow. If this command does not work, you probably need to run `helm repo add brigade https://brigadecore.github.io/charts`
 
 When you're done, feel free to `kind delete cluster` to tear down the kind cluster resources.
 
@@ -354,3 +354,16 @@ You may change the variables above to point to the desired project.
 
 [charts]: https://github.com/brigadecore/charts
 [brigade-project-chart]: https://github.com/brigadecore/charts/tree/master/charts/brigade-project
+
+## End to end testing
+
+We've written an end to end test scenario for Brigade that that you can run using `make e2e`. Currently, what the test in the `run.sh` does is
+
+* installs kubectl, kind, helm 3 if not already installed
+* builds docker images of Brigade components
+* loads them into kind
+* installs them onto the kind cluster
+* confirm that all components are successfully deployed
+* installs a test Brigade project (brig project create -x -f) and confirms that the corresponding k8s Secret is created
+* runs a custom brigade.js and verifies some output from worker Pod
+* on completion (or on error) it tears down the kind cluster

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# custom script for e2e testing
+# ~/bin must exist and be part of $PATH
+
+# kudos to https://elder.dev/posts/safer-bash/
+set -o errexit # script exits when a command fails == set -e
+set -o nounset # script exits when tries to use undeclared variables == set -u
+#set -o xtrace # trace what's executed == set -x (useful for debugging)
+set -o pipefail # causes pipelines to retain / set the last non-zero status
+
+KUBECTL_PLATFORM=linux/amd64
+KUBECTL_VERSION=v1.15.0
+KUBECTL_EXECUTABLE=kubectl
+
+KIND_PLATFORM=kind-linux-amd64
+KIND_VERSION=v0.4.0
+KIND_EXECUTABLE=kind
+
+HELM_PLATFORM=linux-amd64
+HELM_VERSION=helm-v3.0.0-alpha.1
+HELM_EXECUTABLE=helm3
+
+########################################################################################################################################################
+
+function prerequisites_check(){
+    # check if kubectl is installed
+    if ! [ -x "$(command -v kubectl)" ]; then
+      echo 'Error: kubectl is not installed. Installing...'
+      curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$KUBECTL_PLATFORM/kubectl && chmod +x ./kubectl && mv kubectl ~/bin/$KUBECTL_EXECUTABLE
+    fi
+
+    # check if kind is installed
+    if ! [ -x "$(command -v $KIND_EXECUTABLE)" ]; then
+        echo 'Error: kind is not installed. Installing...'
+        wget https://github.com/kubernetes-sigs/kind/releases/download/$KIND_VERSION/$KIND_PLATFORM && mv $KIND_PLATFORM ~/bin/$KIND_EXECUTABLE && chmod +x ~/bin/$KIND_EXECUTABLE
+    fi
+
+    # check if helm is installed
+    if ! [ -x "$(command -v $HELM_EXECUTABLE)" ]; then
+        echo 'Error: Helm is not installed. Installing...'
+        wget https://get.helm.sh/$HELM_VERSION-$HELM_PLATFORM.tar.gz && tar -xvzf $HELM_VERSION-$HELM_PLATFORM.tar.gz && rm -rf $HELM_VERSION-$HELM_PLATFORM.tar.gz && mv $HELM_PLATFORM/helm ~/bin/$HELM_EXECUTABLE && chmod +x ~/bin/$HELM_EXECUTABLE
+    fi
+}
+
+
+function install_helm_project(){
+    # init helm
+    $HELM_EXECUTABLE init
+
+    # add brigade chart repo
+    $HELM_EXECUTABLE repo add brigade https://brigadecore.github.io/charts
+
+    # install the images onto kind cluster
+    HELM=$HELM_EXECUTABLE make helm-install
+}
+
+function wait_for_deployments() {
+    echo "-----Waiting for Brigade components' deployments-----"
+    # https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+    "${DIR}"/wait-for-deployment.sh -n default brigade-server-brigade-api
+    "${DIR}"/wait-for-deployment.sh -n default brigade-server-brigade-cr-gw
+    "${DIR}"/wait-for-deployment.sh -n default brigade-server-brigade-ctrl
+    "${DIR}"/wait-for-deployment.sh -n default brigade-server-brigade-generic-gateway
+    "${DIR}"/wait-for-deployment.sh -n default brigade-server-brigade-github-app
+    "${DIR}"/wait-for-deployment.sh -n default brigade-server-brigade-github-oauth
+    "${DIR}"/wait-for-deployment.sh -n default brigade-server-kashti
+}
+
+function create_verify_test_project(){
+    echo "-----Creating a test project-----"
+    go run "${DIR}"/../brig/cmd/brig/main.go project create -f "${DIR}"/testproject.yaml -x
+
+    echo "-----Checking if the test project secret was created-----"
+    PROJECT_NAME=$($KUBECTL_EXECUTABLE get secret -l app=brigade,component=project,heritage=brigade -o=jsonpath='{.items[0].metadata.name}')
+    if [ $PROJECT_NAME != "$TEST_PROJECT_NAME" ]; then
+        echo "Wrong secret name. Expected $TEST_PROJECT_NAME, got $PROJECT_NAME"
+        exit 1
+    fi
+}
+
+function run_verify_build(){
+    echo "-----Running a Build on the test project-----"
+    go run "${DIR}"/../brig/cmd/brig/main.go run e2eproject -f "${DIR}"/test.js
+
+    # get the worker pod name
+    WORKER_POD_NAME=$($KUBECTL_EXECUTABLE get pod -l component=build,heritage=brigade,project=$TEST_PROJECT_NAME -o=jsonpath='{.items[0].metadata.name}')
+
+    # get the number of lines the expected log output appears
+    LOG_LINES=$($KUBECTL_EXECUTABLE logs $WORKER_POD_NAME | grep "==> handling an 'exec' event" | wc -l)
+
+    if [ $LOG_LINES != 1 ]; then
+        echo "Did not find expected output on worker Pod logs"
+        exit 1
+    fi
+}
+
+########################################################################################################################################################
+
+prerequisites_check
+
+# create kind k8s cluster
+$KIND_EXECUTABLE create cluster
+
+function finish {
+  echo "-----Cleaning up-----"
+  $KIND_EXECUTABLE delete cluster
+}
+
+trap finish EXIT
+
+# set KUBECONFIG with details from kind
+export KUBECONFIG="$($KIND_EXECUTABLE get kubeconfig-path --name="kind")"
+
+# build all images and load them onto kind
+DOCKER_ORG=brigadecore make build-all-images load-all-images
+
+
+install_helm_project # installs helm and Brigade onto kind
+
+TEST_PROJECT_NAME=brigade-5b55ed522537b663e178f751959d234fd650d626f33f70557b2e82
+
+wait_for_deployments # waits for Brigade deployments
+create_verify_test_project # create a test project
+run_verify_build # run a custom build and make sure it's completed
+

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -1,0 +1,5 @@
+const { events } = require("brigadier")
+
+events.on("exec", () => {
+  console.log("==> handling an 'exec' event")
+})

--- a/e2e/testproject.yaml
+++ b/e2e/testproject.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+data:
+  allowHostMounts: ZmFsc2U=
+  allowPrivilegedJobs: ZmFsc2U=
+  brigadejsPath: ""
+  buildStorageSize: ""
+  cloneURL: aHR0cHM6Ly9naXRodWIuY29tL2JyaWdhZGVjb3JlL2VtcHR5LXRlc3RiZWQuZ2l0
+  defaultScript: Y29uc3QgeyBldmVudHMsIEpvYiB9ID0gcmVxdWlyZSgiYnJpZ2FkaWVyIik7CgpldmVudHMub24oInNpbXBsZWV2ZW50IiwgKGUsIHApID0+IHsgIC8vIGhhbmRsZXIgZm9yIGEgU2ltcGxlRXZlbnQKICB2YXIgZWNobyA9IG5ldyBKb2IoImVjaG9zaW1wbGVldmVudCIsICJhbHBpbmU6My44Iik7CiAgZWNoby50YXNrcyA9IFsKICAgICJlY2hvIFByb2plY3QgIiArIHAubmFtZSwKICAgICJlY2hvIGV2ZW50IHR5cGU6ICRFVkVOVF9UWVBFIgogIF07CiAgZWNoby5lbnYgPSB7CiAgICAiRVZFTlRfVFlQRSI6IGUudHlwZQogIH07CiAgZWNoby5ydW4oKTsKfSk7Cg==
+  defaultScriptName: ""
+  genericGatewaySecret: MTIzNA==
+  github.baseURL: ""
+  github.token: ""
+  github.uploadURL: ""
+  imagePullSecrets: ""
+  initGitSubmodules: ZmFsc2U=
+  kubernetes.allowSecretKeyRef: ZmFsc2U=
+  kubernetes.buildStorageClass: ""
+  kubernetes.cacheStorageClass: ""
+  namespace: ZGVmYXVsdA==
+  repository: Z2l0aHViLmNvbS9icmlnYWRlY29yZS9lbXB0eS10ZXN0YmVk
+  secrets: e30=
+  serviceAccount: ""
+  sharedSecret: ""
+  sshKey: ""
+  vcsSidecar: ""
+  worker.name: ""
+  worker.pullPolicy: SWZOb3RQcmVzZW50
+  worker.registry: ""
+  worker.tag: ""
+  workerCommand: ""
+kind: Secret
+metadata:
+  annotations:
+    projectName: e2eproject
+  creationTimestamp: "2019-07-16T13:18:32Z"
+  labels:
+    app: brigade
+    component: project
+    heritage: brigade
+  name: brigade-5b55ed522537b663e178f751959d234fd650d626f33f70557b2e82
+  namespace: default
+  resourceVersion: "1195"
+  selfLink: /api/v1/namespaces/default/secrets/brigade-5b55ed522537b663e178f751959d234fd650d626f33f70557b2e82
+  uid: cc1a07b1-72ca-4788-9496-244194545269
+type: brigade.sh/project

--- a/e2e/wait-for-deployment.sh
+++ b/e2e/wait-for-deployment.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# stolen from https://raw.githubusercontent.com/timoreimann/kubernetes-scripts/master/wait-for-deployment
+# Waits for a deployment to complete.
+#
+# Includes a two-step approach:
+#
+# 1. Wait for the observed generation to match the specified one.
+# 2. Waits for the number of available replicas to match the specified one.
+#
+# Spawn from my answer to this StackOverflow question: http://stackoverflow.com/questions/37448357/ensure-kubernetes-deployment-has-completed-and-all-pods-are-updated-and-availabl
+#
+set -o errexit
+set -o pipefail
+set -o nounset
+# -m enables job control which is otherwise only enabled in interactive mode
+# http://unix.stackexchange.com/a/196606/73578
+set -m
+
+DEFAULT_TIMEOUT=60
+DEFAULT_NAMESPACE=default
+
+monitor_timeout() {
+  local -r wait_pid="$1"
+  sleep "${timeout}"
+  echo "Timeout ${timeout} exceeded" >&2
+  kill "${wait_pid}"
+}
+
+get_generation() {
+  get_deployment_jsonpath '{.metadata.generation}'
+}
+
+get_observed_generation() {
+  get_deployment_jsonpath '{.status.observedGeneration}'
+}
+
+get_specified_replicas() {
+  get_deployment_jsonpath '{.spec.replicas}'
+}
+
+get_replicas() {
+  get_deployment_jsonpath '{.status.replicas}'
+}
+
+get_updated_replicas() {
+  get_deployment_jsonpath '{.status.updatedReplicas}'
+}
+
+get_available_replicas() {
+  get_deployment_jsonpath '{.status.availableReplicas}'
+}
+
+get_deployment_jsonpath() {
+  local -r jsonpath="$1"
+
+  kubectl --namespace "${namespace}" get deployment "${deployment}" -o "jsonpath=${jsonpath}"
+}
+
+display_usage_and_exit() {
+  echo "Usage: $(basename "$0") [-n <namespace>] [-t <timeout>] <deployment>" >&2
+  echo "Arguments:" >&2
+  echo "deployment REQUIRED: The name of the deployment the script should wait on" >&2
+  echo "-n OPTIONAL: The namespace the deployment exists in, defaults is the 'default' namespace" >&2
+  echo "-t OPTIONAL: How long to wait for the deployment to be available, defaults to ${DEFAULT_TIMEOUT} seconds, must be greater than 0" >&2
+  exit 1
+}
+
+namespace=${DEFAULT_NAMESPACE}
+timeout=${DEFAULT_TIMEOUT}
+
+while getopts ':n:t:' arg
+do
+    case ${arg} in
+        n) namespace=${OPTARG};;
+        t) timeout=${OPTARG};;
+        *) display_usage_and_exit
+    esac
+done
+
+shift $((OPTIND-1))
+if [ "$#" -ne 1 ] ; then   
+  display_usage_and_exit
+fi
+readonly deployment="$1"
+
+if [[ ${timeout} -le 0 ]]; then
+  display_usage_and_exit
+fi
+
+echo "Waiting for deployment of ${deployment} in namespace ${namespace} with a timeout ${timeout} seconds"
+
+monitor_timeout $$ &
+readonly timeout_monitor_pid=$!
+
+trap 'kill -- -${timeout_monitor_pid}' EXIT #Stop timeout monitor
+
+generation=$(get_generation);  readonly generation
+current_generation=$(get_observed_generation)
+
+echo "Expected generation for deployment ${deployment}: ${generation}"
+while [[ ${current_generation} -lt ${generation} ]]; do
+  sleep .5
+  echo "Currently observed generation: ${current_generation}"
+  current_generation=$(get_observed_generation)
+done
+echo "Observed expected generation: ${current_generation}"
+
+specified_replicas="$(get_specified_replicas)"; readonly specified_replicas
+echo "Specified replicas: ${specified_replicas}"
+
+current_replicas=$(get_replicas)
+updated_replicas=$(get_updated_replicas)
+available_replicas=$(get_available_replicas)
+
+while [[ ${updated_replicas} -lt ${specified_replicas} || ${current_replicas} -gt ${updated_replicas} || ${available_replicas} -lt ${updated_replicas} ]]; do
+  sleep .5
+  echo "current/updated/available replicas: ${current_replicas}/${updated_replicas}/${available_replicas}, waiting"
+  current_replicas=$(get_replicas)
+  updated_replicas=$(get_updated_replicas)
+  available_replicas=$(get_available_replicas)
+done
+
+echo "Deployment ${deployment} successful. All ${available_replicas} replicas are ready."


### PR DESCRIPTION
Closes #879
PR towards implementing end to end testing (described in #879)

What it does

- installs kubectl, kind, helm 3 if not already installed
- builds docker images of Brigade components
- loads them into kind
- installs them onto the kind cluster
- confirm that all components are successfully deployed
- installs a test Brigade project (brig project create -f) and confirms that the corresponding k8s Secret is created
- runs a custom brigade.js and verifies some output from worker Pod

Usage: `make e2e`.

As agreed on the standup, we'll set a goal to evolve this e2e suite using more tests. 

Links for follow-up
- https://github.com/blimmer/brigade-project-integration-test
- https://github.com/sstephenson/bats 