### PR TITLE
feat(brig): option to show logs from vcs-sidecar

### DIFF
--- a/brig/cmd/brig/commands/build_logs.go
+++ b/brig/cmd/brig/commands/build_logs.go
@@ -22,11 +22,13 @@ build.
 )
 
 var (
+	logsInit bool
 	logsJobs bool
 	logsLast bool
 )
 
 func init() {
+	buildLogs.Flags().BoolVarP(&logsInit, "init", "i", false, "Show init container logs as well as the worker log")
 	buildLogs.Flags().BoolVarP(&logsJobs, "jobs", "j", false, "Show job logs as well as the worker log")
 	buildLogs.Flags().BoolVarP(&logsLast, "last", "l", false, "Show last build's log (ignores BUILD_ID)")
 	build.AddCommand(buildLogs)
@@ -76,6 +78,13 @@ func showBuildLogs(out io.Writer, buildID string) error {
 	}
 
 	fmt.Fprintf(out, logHeader, bs.Worker.ID)
+	if logsInit {
+		initLogs, err := store.GetWorkerInitLog(bs.Worker)
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(out, initLogs)
+	}
 	fmt.Fprint(out, workerLog)
 	if logsJobs {
 		return showJobLogs(out, bs, store)

--- a/pkg/storage/kube/worker.go
+++ b/pkg/storage/kube/worker.go
@@ -72,10 +72,25 @@ func (s *store) GetWorkerLog(worker *brigade.Worker) (string, error) {
 	return buf.String(), nil
 }
 
-func (s *store) getWorkerLogStream(follow bool, worker *brigade.Worker) (io.ReadCloser, error) {
-	req := s.client.CoreV1().Pods(s.namespace).GetLogs(worker.ID, &v1.PodLogOptions{
+func (s *store) GetWorkerInitLog(worker *brigade.Worker) (string, error) {
+	buf := new(bytes.Buffer)
+	r, err := s.getWorkerLogStream(false, worker, "vcs-sidecar")
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+	io.Copy(buf, r)
+	return buf.String(), nil
+}
+
+func (s *store) getWorkerLogStream(follow bool, worker *brigade.Worker, container ...string) (io.ReadCloser, error) {
+	opts := &v1.PodLogOptions{
 		Follow: follow,
-	})
+	}
+	if len(container) > 0 {
+		opts.Container = container[0]
+	}
+	req := s.client.CoreV1().Pods(s.namespace).GetLogs(worker.ID, opts)
 
 	readCloser, err := req.Stream()
 	if err != nil {

--- a/pkg/storage/mock/storage.go
+++ b/pkg/storage/mock/storage.go
@@ -208,6 +208,11 @@ func (s *Store) GetWorkerLog(w *brigade.Worker) (string, error) {
 	return s.LogData, nil
 }
 
+// GetWorkerInitLog gets the mock log data.
+func (s *Store) GetWorkerInitLog(w *brigade.Worker) (string, error) {
+	return s.LogData, nil
+}
+
 // GetWorkerLogStream gets a readcloser of the mock log data.
 func (s *Store) GetWorkerLogStream(w *brigade.Worker) (io.ReadCloser, error) {
 	return rc(s.LogData), nil

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -50,6 +50,8 @@ type Store interface {
 	GetJobLogStream(job *brigade.Job) (io.ReadCloser, error)
 	// GetJobLogStreamFollow retrieve a follow stream of all logs for a job from storage.
 	GetJobLogStreamFollow(job *brigade.Job) (io.ReadCloser, error)
+	// GetWorkerInitLog retrieves all logs for a worker's init container from storage.
+	GetWorkerInitLog(job *brigade.Worker) (string, error)
 	// GetWorkerLog retrieves all logs for a worker from storage.
 	GetWorkerLog(job *brigade.Worker) (string, error)
 	// GetWorkerLogStream retrieve a stream of all logs for a worker from storage.


### PR DESCRIPTION
You can now add `--init` like `brig build logs --init BUILD_ID` to view logs from the init container of a worker(=vcs-sidecar).

When the init-container failed due to reasons like a wrong ssh key or invalid git repo reference,
`brig build logs` has been giving us nothing useful.
So you had to run `kubectl logs -c vcs-sidecar $BRIGADE_WORKER` to finally catch it.

The `--init` flag just makes this process simple.
If your build failed, you always run `brig build logs --init` (or perhaps `brig build logs --init --jobs`) to catch any issues regardless of in which container in the worker pod the fatal error happened.

Ref #938


<!--
Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR (https://github.com/brigadecore/brigade/blob/master/docs/topics/developers.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).

2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
-->

**What this PR does / why we need it**:

Adds the `--init` flag to `brig`.

**Special notes for your reviewer**:

This is the MVP or a foundational work to fully address #938

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility