### PR TITLE
add support for optional build-level cloneURL field

### DIFF
--- a/brigade-controller/cmd/brigade-controller/controller/handler.go
+++ b/brigade-controller/cmd/brigade-controller/controller/handler.go
@@ -245,6 +245,15 @@ func workerEnv(project, build *v1.Secret, config *Config) []v1.EnvVar {
 		serviceAccount = string(project.Data["serviceAccount"])
 	}
 
+	// Try to get cloneURL from the build first. This allows gateways to override
+	// the project-level cloneURL if the commit that should be built, for
+	// instance, exists only within a fork. If this isn't set at the build-level,
+	// fall back to the project-level default.
+	cloneURL := bsv.String("clone_url")
+	if cloneURL == "" {
+		cloneURL = string(project.Data["cloneURL"])
+	}
+
 	envs := []v1.EnvVar{
 		{Name: "CI", Value: "true"},
 		{Name: "BRIGADE_BUILD_ID", Value: build.Labels["build"]},
@@ -255,7 +264,7 @@ func workerEnv(project, build *v1.Secret, config *Config) []v1.EnvVar {
 		{Name: "BRIGADE_EVENT_TYPE", Value: bsv.String("event_type")},
 		{Name: "BRIGADE_PROJECT_ID", Value: bsv.String("project_id")},
 		{Name: "BRIGADE_LOG_LEVEL", Value: bsv.String("log_level")},
-		{Name: "BRIGADE_REMOTE_URL", Value: string(project.Data["cloneURL"])},
+		{Name: "BRIGADE_REMOTE_URL", Value: cloneURL},
 		{Name: "BRIGADE_WORKSPACE", Value: "/vcs"},
 		{Name: "BRIGADE_PROJECT_NAMESPACE", Value: build.Namespace},
 		{Name: "BRIGADE_SERVICE_ACCOUNT", Value: serviceAccount},

--- a/brigade-worker/node_modules/.yarn-integrity
+++ b/brigade-worker/node_modules/.yarn-integrity
@@ -6,7 +6,7 @@
   "flags": [],
   "linkedModules": [],
   "topLevelPatterns": [
-    "@brigadecore/brigadier@^0.6.1",
+    "@brigadecore/brigadier@^0.8.0",
     "@kubernetes/client-node@^0.10.1",
     "@types/byline@^4.2.31",
     "@types/chai@^4.0.1",
@@ -32,7 +32,7 @@
     "ulid@^0.2.0"
   ],
   "lockfileEntries": {
-    "@brigadecore/brigadier@^0.6.1": "https://registry.yarnpkg.com/@brigadecore/brigadier/-/brigadier-0.6.1.tgz#deb4174de9314c5997521a1b3e2a7c6bcfeddc68",
+    "@brigadecore/brigadier@^0.8.0": "https://registry.yarnpkg.com/@brigadecore/brigadier/-/brigadier-0.8.0.tgz#8ef41ff5ee13a18a8fbe7c8621fa39d21bc7e266",
     "@kubernetes/client-node@^0.10.1": "https://registry.yarnpkg.com/@kubernetes/client-node/-/client-node-0.10.2.tgz#9ca9d605148774c7fd77346d73743e5869f9205b",
     "@sinonjs/commons@^1": "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78",
     "@sinonjs/commons@^1.0.2": "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78",

--- a/brigade-worker/node_modules/@brigadecore/brigadier/out/events.d.ts
+++ b/brigade-worker/node_modules/@brigadecore/brigadier/out/events.d.ts
@@ -51,6 +51,12 @@ export declare class BrigadeEvent {
      */
     provider?: string;
     /**
+     * cloneURL is an optional URL for cloning the source code to be built.
+     * If set, it overrides the project-level cloneURL. This is useful for
+     * builds that need to build source from a fork.
+     */
+    cloneURL?: string;
+    /**
      * revision describes a vcs revision.
      */
     revision?: Revision;

--- a/brigade-worker/node_modules/@brigadecore/brigadier/package.json
+++ b/brigade-worker/node_modules/@brigadecore/brigadier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brigadecore/brigadier",
-  "version": "0.6.1",
+  "version": "0.8.0",
   "description": "Brigade library for pipelines and events",
   "main": "out/index.js",
   "types": "out/index.d.ts",

--- a/brigade-worker/package.json
+++ b/brigade-worker/package.json
@@ -38,7 +38,7 @@
     "typescript": "^3.2.2"
   },
   "dependencies": {
-    "@brigadecore/brigadier": "^0.6.1",
+    "@brigadecore/brigadier": "^0.8.0",
     "@kubernetes/client-node": "^0.10.1",
     "byline": "^5.0.0",
     "child-process-promise": "^2.2.1",

--- a/brigade-worker/src/index.ts
+++ b/brigade-worker/src/index.ts
@@ -8,6 +8,9 @@
  * - `BRIGADE_EVENT_PROVIDER`: The name of the event provider, such as `github` or `dockerhub`
  * - `BRIGADE_PROJECT_ID`: The project ID. This is used to load the Project
  *   object from configuration.
+ * - `BRIGADE_REMOTE_URL`: The URL from which to obtain source code to be built.
+ *   This is optional. If left unset by the controller, the worker will fall
+ *   back to a project-level URL.
  * - `BRIGADE_COMMIT_ID`: The VCS commit ID (e.g. the Git commit)
  * - `BRIGADE_COMMIT_REF`: The VCS full reference, defaults to
  *   `refs/heads/master`
@@ -107,6 +110,7 @@ let e: events.BrigadeEvent = {
   workerID: process.env.BRIGADE_BUILD_NAME || `unknown-${defaultULID}`,
   type: process.env.BRIGADE_EVENT_TYPE || "ping",
   provider: process.env.BRIGADE_EVENT_PROVIDER || "unknown",
+  cloneURL: process.env.BRIGADE_REMOTE_URL,
   revision: {
     commit: process.env.BRIGADE_COMMIT_ID,
     ref: process.env.BRIGADE_COMMIT_REF

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -839,6 +839,15 @@ function sidecarSpec(
     imageTag = "brigadecore/git-sidecar:latest";
   }
 
+  // Try to get cloneURL from the event first. This allows gateways to override
+	// the project-level cloneURL if the commit that should be built, for
+	// instance, exists only within a fork. If this isn't set at the event-level,
+	// fall back to the project-level default.
+  let cloneURL = e.cloneURL;
+  if (cloneURL == "") {
+    cloneURL = project.repo.cloneURL
+  }
+
   let spec = new kubernetes.V1Container();
   (spec.name = "vcs-sidecar"),
     (spec.env = [
@@ -849,7 +858,7 @@ function sidecarSpec(
       envVar("BRIGADE_EVENT_PROVIDER", e.provider),
       envVar("BRIGADE_EVENT_TYPE", e.type),
       envVar("BRIGADE_PROJECT_ID", project.id),
-      envVar("BRIGADE_REMOTE_URL", project.repo.cloneURL),
+      envVar("BRIGADE_REMOTE_URL", cloneURL),
       envVar("BRIGADE_WORKSPACE", local),
       envVar("BRIGADE_PROJECT_NAMESPACE", project.kubernetes.namespace),
       envVar("BRIGADE_SUBMODULES", initGitSubmodules.toString()),

--- a/brigade-worker/yarn.lock
+++ b/brigade-worker/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@brigadecore/brigadier@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@brigadecore/brigadier/-/brigadier-0.6.1.tgz#deb4174de9314c5997521a1b3e2a7c6bcfeddc68"
-  integrity sha512-95U96JnRhobKZUMJtTVtT0+EWQ8zgJw7MAFYdzd0K4ajkGZAahJdXGbFrey4R3JZbcJZhwCh3Ny+pLP7EjLgCQ==
+"@brigadecore/brigadier@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@brigadecore/brigadier/-/brigadier-0.8.0.tgz#8ef41ff5ee13a18a8fbe7c8621fa39d21bc7e266"
+  integrity sha512-lZWDpuVAwrcYFpbNlAjwjsEGom2KEAxg3xAR+BZT9h7Syd8Nu2KIVBKs8sfKgEl1Fhy4DWhg+m2QZMa4sXjwxg==
   dependencies:
     "@kubernetes/client-node" "^0.10.1"
     child-process-promise "^2.2.1"

--- a/pkg/brigade/build.go
+++ b/pkg/brigade/build.go
@@ -12,6 +12,10 @@ type Build struct {
 	Type string `json:"type"`
 	// Provider is the name of the service that caused the event (github, vsts, cron, ...)
 	Provider string `json:"provider"`
+	// CloneURL is the URL at which the repository can be cloned.
+	// This is optional at the build-level. If set, it overrides the same setting
+	// at the projet-level.
+	CloneURL string `json:"clone_url"`
 	// Revision describes a vcs revision.
 	Revision *Revision `json:"revision"`
 	// Payload is the raw data as received by the webhook.

--- a/pkg/storage/kube/build.go
+++ b/pkg/storage/kube/build.go
@@ -108,6 +108,7 @@ func (s *store) CreateBuild(build *brigade.Build) error {
 		StringData: map[string]string{
 			"build_id":       buildName,
 			"build_name":     buildName,
+			"clone_url":      build.CloneURL,
 			"commit_id":      build.Revision.Commit,
 			"commit_ref":     build.Revision.Ref,
 			"event_provider": build.Provider,
@@ -203,6 +204,7 @@ func NewBuildFromSecret(secret v1.Secret) *brigade.Build {
 		ProjectID: lbs["project"],
 		Type:      sv.String("event_type"),
 		Provider:  sv.String("event_provider"),
+		CloneURL:  sv.String("clone_url"),
 		Revision: &brigade.Revision{
 			Commit: sv.String("commit_id"),
 			Ref:    sv.String("commit_ref"),


### PR DESCRIPTION
Fixes #973

This will give gateways the power to be more specific about where source code for a build is obtained from-- i.e. it creates the possibility of getting source code from forks. This isn't necessary for github (because of how github implements pull requests behind the scenes), but may be necessary for other VCS-- notably, bitbucket.