### PR TITLE
fix(brigade-worker): ensure set -o pipefail is set if shell is /bin/bash

### DIFF
--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -1016,8 +1016,19 @@ function generateScript(job: jobs.Job): string | null {
   let newCmd = "#!" + job.shell + "\n\n";
 
   // if shells that support the `set` command are selected, let's add some sane defaults
-  if (job.shell == "/bin/sh" || job.shell == "/bin/bash") {
-    newCmd += "set -e\n\n";
+  switch (job.shell) {
+    case "/bin/sh":
+      // The -e option will cause a bash script to exit immediately when a command fails
+      newCmd += "set -e\n\n";
+      break;
+    case "/bin/bash":
+      // The -e option will cause a bash script to exit immediately when a command fails
+      // The -o pipefail option sets the exit code of a pipeline to that of the rightmost command
+      // to exit with a non-zero status, or to zero if all commands of the pipeline exit successfully.
+      newCmd += "set -eo pipefail\n\n";
+      break;
+    default:
+      // No-op currently
   }
 
   // Join the tasks to make a new command:

--- a/docs/content/topics/javascript.md
+++ b/docs/content/topics/javascript.md
@@ -193,7 +193,8 @@ Properties of `Job`
 - `name: string`: The job name
 - `shell: string`: The shell in which to execute the tasks (`/bin/sh`)
 - `tasks: string[]`: Tasks to be run in the job, in order. Tasks are concatenated
-  together and packaged as a Borne (`/bin/sh`) shell script with `set -eo pipefail`.
+  together and, by default, packaged as a Bourne (`/bin/sh`) shell script with `set -e`.
+  If the Bourne Again Shell is used (`/bin/bash`), `set -eo pipefail` will be used.
 - `args: string[]`: Arguments to pass to the container's entrypoint. It is recommended,
   though not required, that implementors not use both `args` and `tasks`.
 - `imageForcePull: boolean`: Defines the container image pull policy: `Always` if `true` or `IfNotPresent` if `false` (defaults to `false`).


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes https://github.com/brigadecore/brigade/issues/802

Note that `-o pipefail` is not a valid option for `/bin/sh`, so we only currently add it for `/bin/bash` scripts.

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
