### PR TITLE
docs(*): v1.2.0 release updates

### DIFF
--- a/brigade-api/cmd/brigade-api/main.go
+++ b/brigade-api/cmd/brigade-api/main.go
@@ -249,7 +249,7 @@ func enrichSwaggerObject(swo *spec.Swagger) {
 				Name: "Apache-2.0",
 				URL:  "https://www.apache.org/licenses/LICENSE-2.0",
 			},
-			Version: "1.1.0",
+			Version: "1.2.0",
 		},
 	}
 }

--- a/brigade-worker/package.json
+++ b/brigade-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brigade-worker",
-  "version": "1.1.0 ",
+  "version": "1.2.0 ",
   "description": "Brigade Worker",
   "main": "dist/index",
   "types": "dist/index",

--- a/docs/content/intro/quickstart.md
+++ b/docs/content/intro/quickstart.md
@@ -22,10 +22,10 @@ You will now have Brigade installed. [Kashti](https://github.com/brigadecore/kas
 
 ## Install brig
 
-Brig is the Brigade command line client. You can use `brig` to create/update/delete new brigade Projects, run Builds, etc. To get `brig`, navigate to the [Releases page](https://github.com/brigadecore/brigade/releases/) and then download the appropriate client for your platform. For example, if you're using Linux or WSL, you can get the 1.1.0 version in this way:
+Brig is the Brigade command line client. You can use `brig` to create/update/delete new brigade Projects, run Builds, etc. To get `brig`, navigate to the [Releases page](https://github.com/brigadecore/brigade/releases/) and then download the appropriate client for your platform. For example, if you're using Linux or WSL, you can get the 1.2.0 version in this way:
 
 ```bash
-wget -O brig https://github.com/brigadecore/brigade/releases/download/v1.1.0/brig-linux-amd64
+wget -O brig https://github.com/brigadecore/brigade/releases/download/v1.2.0/brig-linux-amd64
 chmod +x brig
 mv brig ~/bin
 ```
@@ -123,7 +123,7 @@ Event created. Waiting for worker pod named "brigade-worker-01d0y7bcxs6ke0yayrx6
 Build: 01d0y7bcxs6ke0yayrx6nbvm39, Worker: brigade-worker-01d0y7bcxs6ke0yayrx6nbvm39
 prestart: no dependencies file found
 prestart: loading script from /etc/brigade/script
-[brigade] brigade-worker version: 1.1.0
+[brigade] brigade-worker version: 1.2.0
 [brigade:k8s] Creating secret do-nothing-01d0y7bcxs6ke0yayrx6nbvm39
 [brigade:k8s] Creating pod do-nothing-01d0y7bcxs6ke0yayrx6nbvm39
 [brigade:k8s] Timeout set at 900000

--- a/docs/content/topics/developers.md
+++ b/docs/content/topics/developers.md
@@ -63,7 +63,7 @@ $ cd $GOPATH/src/github.com/brigadecore/brigade
 **Note**: this leaves you at the tip of **master** in the repository where active development
 is happening. You might prefer to checkout the most recent stable tag:
 
-- `$ git checkout v1.1.0`
+- `$ git checkout v1.2.0`
 
 After cloning the project locally, you should run this command to [configure the remote](https://help.github.com/articles/configuring-a-remote-for-a-fork/): 
 

--- a/docs/content/topics/releasing.md
+++ b/docs/content/topics/releasing.md
@@ -13,13 +13,13 @@ Once the intended commit has been tested and we have confidence to cut a release
 we can follow these steps to release Brigade:
 
 1. Issue a docs pull request with all `<current release>` strings updated to 
-`<anticipated release>`, e.g. `1.0.0` becomes `1.1.0`.
+`<anticipated release>`, e.g. `1.1.0` becomes `1.2.0`.
 
 1. Once this pull request is merged, create and push the git tag from the intended commit:
 
     ```console
-    $ git tag v1.1.0
-    $ git push origin v1.1.0
+    $ git tag v1.2.0
+    $ git push origin v1.2.0
     ```
 
     The release pipeline located in our [brigade.js](../../brigade.js) then takes over

--- a/docs/content/topics/workers.md
+++ b/docs/content/topics/workers.md
@@ -51,7 +51,7 @@ an XML parser library. This can be accomplished using the following
 `Dockerfile`:
 
 ```Dockerfile
-FROM brigadecore/brigade-worker:v1.1.0
+FROM brigadecore/brigade-worker:v1.2.0
 
 RUN yarn add xml-simple
 ```
@@ -83,7 +83,7 @@ exports.alpineJob = function(name) {
 We can build this file into our `Dockerfile` by copying it into the image:
 
 ```
-FROM brigadecore/brigade-worker:v1.1.0
+FROM brigadecore/brigade-worker:v1.2.0
 
 RUN yarn add xml-simple
 COPY mylib.js /home/src/dist


### PR DESCRIPTION
Updates documentation in anticipation of the forthcoming `v1.2.0` release, per https://docs.brigade.sh/topics/releasing/
