### PR TITLE
return to break outer for loop instead of inner select loop

### DIFF
--- a/pkg/webhook/genericsimpleevent_test.go
+++ b/pkg/webhook/genericsimpleevent_test.go
@@ -191,7 +191,7 @@ func checkBuild(t *testing.T, store *mock.Store, expectedRef string, expectedCom
 					time.Sleep(50 * time.Millisecond)
 				} else {
 					c <- struct{}{} // signal that we do have a Build
-					break
+					return
 				}
 			case <-stopChan: // calling goroutine signals that we should exit, so return
 				return


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR (https://github.com/brigadecore/brigade/blob/master/docs/topics/developers.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).

2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
-->

**What this PR does / why we need it**:
Break just break the inner select clause, in this case the goroutine will run till main process exit. Use  return to immediately exit this goroutiine when it work is done.
