### PR TITLE
Move brig README to docs page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,5 @@
 /bin/
-/brig/rootfs/brig
-/brigade-api/rootfs/brigade-api
-/brigade-controller/rootfs/brigade-controller
-/brigade-cr-gateway/rootfs/brigade-cr-gateway
-/brigade-generic-gateway/rootfs/brigade-generic-gateway
-/brigade-vacuum/rootfs/brigade-vacuum
+/**/rootfs
 /brigade-worker/dist/
 /brigade-worker/doc/
 /tests/testdata/*-generated.*

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -85,6 +85,11 @@ relativeURLs = "true"
     weight = 42
     parent = "topics"
     [[menu.index]]
+    name = "The Brig CLI"
+    url = "/topics/brig/"
+    weight = 42
+    parent = "topics"
+    [[menu.index]]
     name = "The Brigade.js API"
     url = "/topics/javascript/"
     weight = 43

--- a/docs/content/topics/_index.md
+++ b/docs/content/topics/_index.md
@@ -1,6 +1,6 @@
 ---
-title: 'Topic Guides'
-description: 'Deep dives into individual parts of Brigade'
+title: "Topic Guides"
+description: "Deep dives into individual parts of Brigade"
 aliases:
   - /topics.md
   - /topics/index.md
@@ -19,6 +19,7 @@ If you don't see a topic guide here and have a reasonable level of knowledge on 
   - [Brigade Design](design): A high-level explanation of how Brigade is designed.
 - Using Brigade (brigade.js, webhooks)
   - [Scripting Guide](scripting): How to write JavaScript for `brigade.js` files.
+  - [Using the Brigade CLI](brig)
   - [Brigade.js Reference](javascript): The API for brigade.js files.
   - [Scripting Guide - Advanced](scripting_advanced): Advanced examples for `brigade.js` files.
   - [Adding dependencies to `brigade.js`](dependencies): How to add local dependencies and NPM packages to your `brigade.js` files.
@@ -38,7 +39,5 @@ If you don't see a topic guide here and have a reasonable level of knowledge on 
     code.
 - Examples
   - [Example Projects](../index/#technical): Brigade-related projects.
-
-
 
 [write]: https://github.com/brigadecore/brigade/new/master/content/docs/topics

--- a/docs/content/topics/brig.md
+++ b/docs/content/topics/brig.md
@@ -1,3 +1,13 @@
+---
+title: The Brig CLI
+description: Using the Brigade CLI
+aliases:
+  - /brig.md
+  - /topics/brig.md
+  - /topics/cli/brig.md
+  - /intro/brig.md
+---
+
 # Brig: The Brigade CLI
 
 Brig is a command line tool for interacting with Brigade. It allows Brigade
@@ -49,11 +59,11 @@ By default, Brig requests that the event `exec` be run. You can override this by
 supplying a `--event=NAME` flag. For example, try executing the following script:
 
 ```javascript
-const { events } = require("brigadier")
+const { events } = require("brigadier");
 
 events.on("exec", () => {
-  console.log("Hello from brig!")
-})
+  console.log("Hello from brig!");
+});
 ```
 
 A more complete example:
@@ -67,13 +77,6 @@ the Kubernetes `my-builds` namespace. It executes within the project
 `technosophos/myproject`.
 
 The output of the master process is written to STDOUT.
-
-## Building Brig
-
-To build Brig, clone the [Brigade repository](https://github.com/brigadecore/brigade)
-to `$GOPATH/src/github.com/brigadecore/brigade` and then run `make bootstrap brig`.
-
-If you have $GOPATH issues, you may need to [add the Brigade binary](https://github.com/brigadecore/brigade/issues/447) to your path.
 
 ## How Brig Works
 


### PR DESCRIPTION
closes #830 
closes #970

- [x] add the Brig document in the sidebar menu

This simply migrates the content that was in the README of `brig` to its own docs page.