### PR TITLE
fix(brigade-worker): return no logs found if job canceled and pod undefined or pending

### DIFF
--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -474,7 +474,7 @@ export class JobRunner implements jobs.JobRunner {
       this.secret.data["main.sh"] = b64enc(newCmd);
     }
 
-    // If the job askes for privileged mode and the project allows this, enable it.
+    // If the job asks for privileged mode and the project allows this, enable it.
     if (job.privileged && project.allowPrivilegedJobs) {
       for (let i = 0; i < this.runner.spec.containers.length; i++) {
         this.runner.spec.containers[i].securityContext.privileged = true;
@@ -500,6 +500,10 @@ export class JobRunner implements jobs.JobRunner {
     let podName = this.name;
     let k = this.client;
     let ns = this.project.kubernetes.namespace;
+    if (this.cancel && this.pod == undefined || this.pod.status.phase == "Pending") {
+      return Promise.resolve<string>(
+        "pod " + podName + " still unscheduled or pending when job was canceled; no logs to return.")
+    }
     return Promise.resolve<string>(
       k.readNamespacedPodLog(podName, ns).then(result => {
         return result.body;
@@ -785,7 +789,7 @@ export class JobRunner implements jobs.JobRunner {
     let timer = new Promise((solve, reject) => {
       waiter = setTimeout(() => {
         this.cancel = true;
-        reject("time limit exceeded");
+        reject(new Error("time limit (" + timeout + " ms) exceeded"));
       }, timeout);
     });
 

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -4,7 +4,7 @@ import * as mock from "./mock";
 
 import * as k8s from "../src/k8s";
 import { BrigadeEvent, Project } from "@brigadecore/brigadier/out/events";
-import { Job, Result, brigadeCachePath, brigadeStoragePath } from "@brigadecore/brigadier/out/job";
+import { Job, Result, brigadeCachePath, brigadeStoragePath, JobResourceLimit } from "@brigadecore/brigadier/out/job";
 
 import * as kubernetes from "@kubernetes/client-node";
 
@@ -722,6 +722,14 @@ describe("k8s", function () {
         it("shell is /bin/bash", function () {
           let jr = new k8s.JobRunner().init(j, e, p);
           assert.deepEqual(jr.runner.spec.containers[0].command, ['/bin/bash', '/hook/main.sh']);
+        });
+      });
+      context("when logs is called", function() {
+        it("when the job has been canceled", async function () {
+          let jr = new k8s.JobRunner().init(j, e, p);
+          jr.cancel = true;
+          let logs = await jr.logs();
+          assert.equal("pod pequod-1234567890abcdef still unscheduled or pending when job was canceled; no logs to return.", logs);
         });
       });
     });


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a bit of logic to return early (resolve the js promise) on a job.logs() call if the job has been canceled while the pod itself is either unscheduled or still in Pending.  Otherwise, the call to the k8s api to get logs will hang and/or error out.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
