### PR TITLE
feat(project): enable complex secret values

### DIFF
--- a/brig/cmd/brig/commands/project_create.go
+++ b/brig/cmd/brig/commands/project_create.go
@@ -63,7 +63,7 @@ var defaultProjectVCS = brigade.Project{
 		Name:     "github.com/brigadecore/empty-testbed",
 		CloneURL: "https://github.com/brigadecore/empty-testbed.git",
 	},
-	Secrets: map[string]string{},
+	Secrets: map[string]interface{}{},
 	Worker: brigade.WorkerConfig{
 		PullPolicy: "IfNotPresent",
 	},

--- a/pkg/brigade/project.go
+++ b/pkg/brigade/project.go
@@ -56,10 +56,10 @@ type Project struct {
 	GenericGatewaySecret string `json:"genericGatewaySecret"`
 }
 
-// SecretsMap is a map[string]string for storing secrets.
+// SecretsMap is a map[string]interface{} for storing secrets.
 //
 // When secrets are marshaled, values will be redacted.
-type SecretsMap map[string]string
+type SecretsMap map[string]interface{}
 
 const redacted = "REDACTED"
 

--- a/pkg/brigade/project_test.go
+++ b/pkg/brigade/project_test.go
@@ -19,7 +19,7 @@ func TestShortSHA(t *testing.T) {
 func TestProjectSecrets(t *testing.T) {
 	proj := Project{
 		SharedSecret: "wisper",
-		Secrets:      map[string]string{"foo": "bar"},
+		Secrets:      map[string]interface{}{"foo": "bar"},
 		Repo: Repo{SSHKey: "noop",
 			SSHCert: "noop"},
 	}

--- a/pkg/storage/kube/project.go
+++ b/pkg/storage/kube/project.go
@@ -50,8 +50,8 @@ func SecretFromProject(project *brigade.Project) (v1.Secret, error) {
 	}
 
 	// The marshal on SecretsMap redacts secrets, so we cast and marshal as a raw
-	// map[string]string
-	var secrets map[string]string = project.Secrets
+	// map[string]interface{}
+	var secrets map[string]interface{} = project.Secrets
 	secretsJSON, err := json.Marshal(secrets)
 	if err != nil {
 		return v1.Secret{}, err
@@ -202,7 +202,7 @@ func NewProjectFromSecret(secret *v1.Secret, namespace string) (*brigade.Project
 		CloneURL: sv.String("cloneURL"),
 	}
 
-	envVars := map[string]string{}
+	envVars := map[string]interface{}{}
 	if d := sv.Bytes("secrets"); len(d) > 0 {
 		if err := json.Unmarshal(d, &envVars); err != nil {
 			return nil, err

--- a/pkg/storage/kube/project_test.go
+++ b/pkg/storage/kube/project_test.go
@@ -38,7 +38,16 @@ func TestGetProject(t *testing.T) {
 
 func TestCreateProject(t *testing.T) {
 	k, s := fakeStore()
-	secretsMap := map[string]string{"username": "hello", "password": "world"}
+	secretsMap := map[string]interface{}{
+		"username": "hello",
+		"password": "world",
+		"data": map[string]interface{}{
+			"nested": "value",
+			"deeply": map[string]string{
+				"nested": "value",
+			},
+		},
+	}
 	n := "tennyson/light-brigade"
 	proj := &brigade.Project{
 		Name:         n,
@@ -275,7 +284,7 @@ func TestConfigureProject(t *testing.T) {
 	}
 	if v, ok := proj.Secrets["NO SUCH KEY"]; ok {
 		t.Fatal("unexpected key")
-	} else if v != "" {
+	} else if v != nil {
 		t.Fatal("Expected empty string for non-existent key")
 	}
 	if proj.Worker.Registry != "brigadecore" {

--- a/pkg/storage/mock/storage.go
+++ b/pkg/storage/mock/storage.go
@@ -19,7 +19,7 @@ var (
 		ID:           "project-id",
 		Name:         "project-name",
 		SharedSecret: "shared-secre3t",
-		Secrets:      map[string]string{"key": "value"},
+		Secrets:      map[string]interface{}{"key": "value"},
 	}
 	// StubWorker1 is a stub Worker. It is used in StubBuild1, too.
 	StubWorker1 = &brigade.Worker{

--- a/pkg/storage/mock/storage_test.go
+++ b/pkg/storage/mock/storage_test.go
@@ -80,7 +80,7 @@ func TestStore(t *testing.T) {
 	extraProj = &brigade.Project{
 		Name:    "extra",
 		ID:      "extra",
-		Secrets: map[string]string{},
+		Secrets: map[string]interface{}{},
 	}
 	if err := m.CreateProject(extraProj); err != nil {
 		t.Fatal(err)

--- a/pkg/webhook/dockerhub_test.go
+++ b/pkg/webhook/dockerhub_test.go
@@ -19,7 +19,7 @@ func newProject() *brigade.Project {
 			VCSSidecar:       "sidecar:latest",
 			BuildStorageSize: "50Mi",
 		},
-		Secrets: map[string]string{
+		Secrets: map[string]interface{}{
 			"mysecret": "value",
 		},
 	}

--- a/pkg/webhook/genericsimpleevent_test.go
+++ b/pkg/webhook/genericsimpleevent_test.go
@@ -26,7 +26,7 @@ func newGenericProject() *brigade.Project {
 			Name:     "github.com/dgkanatsios/o365-notify",
 			CloneURL: "https://github.com/dgkanatsios/o365-notify",
 		},
-		Secrets: map[string]string{
+		Secrets: map[string]interface{}{
 			"mysecret": "value",
 		},
 		DefaultScript: `const { events, Job } = require("brigadier")


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows for more complex/non-string/nested secrets as mentioned in https://github.com/brigadecore/brigade/issues/486 and https://github.com/brigadecore/brigade/issues/470.

Closes https://github.com/brigadecore/brigade/issues/486

**Special notes for your reviewer**:

I tested this via `brig project get <project>` where `<project>` had secrets along the lines of:
```
secrets:
  number: 9
  deeply:
    - deeply:
        nested: "{\"foo\":\"bar\"}"
  environments:
    - name: dev
      serverName: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
...
```
As well as running a build from a brigade.js file such as:
```
const { events, Job } = require("brigadier")

events.on("exec", (event, project) => {
  var job = new Job("job", "alpine");

  job.env = {
    DEEPLY_NESTED: project.secrets.deeply[0].deeply.nested
  };

  job.tasks = [
    "apk update && apk add jq",
    'echo "${DEEPLY_NESTED}" | jq -r .'
  ];
  
  return job.run();
})
```

Other considerations/tests we'd want to look at?

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
