### PR TITLE
fix(brigade-worker): bump handlebars resolution per yarn audit

### DIFF
--- a/brigade-worker/package.json
+++ b/brigade-worker/package.json
@@ -47,6 +47,6 @@
     "ulid": "^0.2.0"
   },
   "resolutions": {
-    "handlebars": "^4.3.0"
+    "handlebars": "^4.4.5"
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes CI (`yarn audit` failure on master) via a `handlebars` version bump.

Error from `make yarn-audit`:
```
sh -c 'cd brigade-worker && yarn audit'
yarn audit v1.16.0
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ moderate      │ Denial of Service                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ handlebars                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.4.5                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ typedoc                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ typedoc > handlebars                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1300                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
1 vulnerabilities found - Packages audited: 668
Severity: 1 Moderate
Done in 0.54s.
Makefile:99: recipe for target 'yarn-audit' failed
make: *** [yarn-audit] Error 4
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
