### PR TITLE
Revert "take default command from image instead of controller"

### DIFF
--- a/brigade-controller/cmd/brigade-controller/controller/controller_test.go
+++ b/brigade-controller/cmd/brigade-controller/controller/controller_test.go
@@ -115,8 +115,10 @@ func TestController(t *testing.T) {
 		}
 	}
 
-	if len(c.Command) > 0 {
-		t.Errorf("Expected command to be empty, got %q", c.Command)
+	for i, term := range []string{"yarn", "-s", "start"} {
+		if c.Command[i] != term {
+			t.Errorf("Expected command %d to be %q, got %q", i, term, c.Command[i])
+		}
 	}
 
 	if c.VolumeMounts[0].Name != "brigade-build" {

--- a/brigade-controller/cmd/brigade-controller/controller/handler.go
+++ b/brigade-controller/cmd/brigade-controller/controller/handler.go
@@ -81,7 +81,7 @@ func (c *Controller) updateBuildStatus(build *v1.Secret) error {
 func NewWorkerPod(build, project *v1.Secret, config *Config) v1.Pod {
 	env := workerEnv(project, build, config)
 
-	var cmd []string
+	cmd := []string{"yarn", "-s", "start"}
 	if config.WorkerCommand != "" {
 		cmd = strings.Split(config.WorkerCommand, " ")
 	}

--- a/brigade-controller/cmd/brigade-controller/controller/handler_test.go
+++ b/brigade-controller/cmd/brigade-controller/controller/handler_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -51,8 +52,8 @@ func TestNewWorkerPod_Defaults(t *testing.T) {
 		t.Error("Expected vcs-sidecar volume mount to exist")
 	}
 
-	if len(container.Command) > 0 {
-		t.Errorf("Unexpected command: %q", container.Command)
+	if cmd := strings.Join(container.Command, " "); cmd != "yarn -s start" {
+		t.Errorf("Unexpected command: %s", cmd)
 	}
 
 	if len(container.Resources.Limits) != 0 {

--- a/brigade-worker/Dockerfile
+++ b/brigade-worker/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /home/src
 COPY brigade-worker/ /home/src/
 RUN yarn build
 
-CMD yarn -s start
+CMD yarn run test

--- a/docs/content/topics/projects.md
+++ b/docs/content/topics/projects.md
@@ -77,7 +77,7 @@ You can optionally customize a bunch of advanced options during `brig project cr
 - *Worker image name*: The name of the worker image, e.g. workerImage
 - *Custom worker image tag*: The worker image tag to pull, e.g. 1.2.3 or latest
 - *Worker image pull policy*: The image pull policy determines how often Kubernetes will try to refresh this image
-- *Worker command*: Override the worker image's default command
+- *Worker command*: Override the worker's default command (yarn -s start)
 - *Initialize Git submodules*: For repos that have submodules, initialize them on each clone. Not recommended on public repos
 - *Allow host mounts*: Allow host-mounted volumes for worker and jobs. Not recommended in multi-tenant clusters
 - *Allow privileged jobs*: Allow jobs to mount the Docker socket or perform other privileged operations. Not recommended for multi-tenant clusters

--- a/pkg/brigade/project.go
+++ b/pkg/brigade/project.go
@@ -46,8 +46,8 @@ type Project struct {
 	ImagePullSecrets string `json:"imagePullSecrets"`
 
 	// WorkerCommand is a string command that can be issued to the worker image.
-	// This is an alternative to the image's default command (or other, globally
-	// configured command) usually issued.
+	// This is an alternative to the default 'yarn -s start' command (or other
+	// globally configured command) usually issued.
 	WorkerCommand string `json:"workerCommand"`
 
 	// BrigadejsPath contains the path for the Brigade.js file in the source repo


### PR DESCRIPTION
This reverts #1019  because it has been determined to have caused a breaking change in cases where a custom worker might be extended from an older version of our default worker-- in which case its `CMD` remains `yarn run test`. In such cases, that will run unexpectedly since the controller will no longer be overriding it. All such builds will pass with no jobs being executed.

We should be sure to re-apply #1019 in the next major release.