### PR TITLE
add optional title fields to build type

### DIFF
--- a/pkg/brigade/build.go
+++ b/pkg/brigade/build.go
@@ -12,6 +12,18 @@ type Build struct {
 	Type string `json:"type"`
 	// Provider is the name of the service that caused the event (github, vsts, cron, ...)
 	Provider string `json:"provider"`
+	// ShortTitle is an optional field for a short (and not necessarily unique)
+	// string value that can be added to a build by a gateway to ascribe context
+	// that may be meaningful to human users. For instance, the GitHub gateway
+	// COULD label a build triggered by a pull request with the title or number of
+	// that pull request.
+	ShortTitle string `json:"short_title"`
+	// LongTitle is an optional field for a longer (and not necessarily unique)
+	// string value that can be added to a build by a gateway to ascribe context
+	// that may be meaningful to human users. For instance, the GitHub gateway
+	// COULD label a build triggered by a pull request with the title or number of
+	// that pull request.
+	LongTitle string `json:"long_title"`
 	// CloneURL is the URL at which the repository can be cloned.
 	// This is optional at the build-level. If set, it overrides the same setting
 	// at the projet-level.

--- a/pkg/storage/kube/build.go
+++ b/pkg/storage/kube/build.go
@@ -109,6 +109,8 @@ func (s *store) CreateBuild(build *brigade.Build) error {
 		StringData: map[string]string{
 			"build_id":       buildName,
 			"build_name":     buildName,
+			"short_title":    build.ShortTitle,
+			"long_title":     build.LongTitle,
 			"clone_url":      build.CloneURL,
 			"commit_id":      build.Revision.Commit,
 			"commit_ref":     build.Revision.Ref,
@@ -201,11 +203,13 @@ func NewBuildFromSecret(secret v1.Secret) *brigade.Build {
 	lbs := secret.ObjectMeta.Labels
 	sv := SecretValues(secret.Data)
 	return &brigade.Build{
-		ID:        lbs["build"],
-		ProjectID: lbs["project"],
-		Type:      sv.String("event_type"),
-		Provider:  sv.String("event_provider"),
-		CloneURL:  sv.String("clone_url"),
+		ID:         lbs["build"],
+		ProjectID:  lbs["project"],
+		Type:       sv.String("event_type"),
+		Provider:   sv.String("event_provider"),
+		ShortTitle: sv.String("short_title"),
+		LongTitle:  sv.String("long_title"),
+		CloneURL:   sv.String("clone_url"),
 		Revision: &brigade.Revision{
 			Commit: sv.String("commit_id"),
 			Ref:    sv.String("commit_ref"),

--- a/pkg/storage/kube/build_test.go
+++ b/pkg/storage/kube/build_test.go
@@ -23,6 +23,8 @@ func TestNewBuildFromSecret(t *testing.T) {
 		Data: map[string][]byte{
 			"event_type":     []byte("foo"),
 			"event_provider": []byte("bar"),
+			"short_title":    []byte("this is a short title"),
+			"long_title":     []byte("this is a long title"),
 			"payload":        []byte("this is a payload"),
 			"script":         []byte("ohai"),
 			"commit_id":      []byte("abc123"),

--- a/pkg/storage/kube/store_test.go
+++ b/pkg/storage/kube/store_test.go
@@ -127,8 +127,10 @@ var (
 
 	// stubBuild is a build
 	stubBuild = &brigade.Build{
-		ID:        stubBuildID,
-		ProjectID: stubProjectID,
+		ID:         stubBuildID,
+		ProjectID:  stubProjectID,
+		ShortTitle: "this is a short title",
+		LongTitle:  "this is a long title",
 		Revision: &brigade.Revision{
 			Commit: "abc123",
 			Ref:    "refs/heads/master",


### PR DESCRIPTION
Fixes #976 

This adds fields to the build that gateways can _optionally_ populate. Follow-up changes to the gateways and to Kashti can make good use of these fields.