### PR TITLE
fix(brigade-controller): update the service account regex if service account overridden

### DIFF
--- a/brigade-controller/cmd/brigade-controller/controller/controller.go
+++ b/brigade-controller/cmd/brigade-controller/controller/controller.go
@@ -13,6 +13,13 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
+const (
+	// DefaultWorkerServiceAccountName is the default Kubernetes worker service account name
+	DefaultWorkerServiceAccountName = "brigade-worker"
+	// DefaultJobServiceAccountName is the default Brigade project service account name
+	DefaultJobServiceAccountName = "brigade-worker"
+)
+
 // Config is config for setting Controller
 type Config struct {
 	Namespace                  string

--- a/brigade-controller/cmd/brigade-controller/controller/handler.go
+++ b/brigade-controller/cmd/brigade-controller/controller/handler.go
@@ -247,6 +247,10 @@ func workerEnv(project, build *v1.Secret, config *Config) []v1.EnvVar {
 	serviceAccount := config.ProjectServiceAccount
 	if string(project.Data["serviceAccount"]) != "" {
 		serviceAccount = string(project.Data["serviceAccount"])
+		// Update the service account regex if previously set to the default
+		if config.ProjectServiceAccountRegex == DefaultJobServiceAccountName {
+			config.ProjectServiceAccountRegex = serviceAccount
+		}
 	}
 
 	// Try to get cloneURL from the build first. This allows gateways to override

--- a/brigade-controller/cmd/brigade-controller/main.go
+++ b/brigade-controller/cmd/brigade-controller/main.go
@@ -12,9 +12,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const defaultWorkerServiceAccountName = "brigade-worker"
-const defaultJobServiceAccountName = "brigade-worker"
-
 func init() {
 	log.SetFlags(log.Lshortfile)
 }
@@ -94,14 +91,14 @@ func defaultWorkerServiceAccount() string {
 	if pp, ok := os.LookupEnv("BRIGADE_WORKER_SERVICE_ACCOUNT"); ok {
 		return pp
 	}
-	return defaultWorkerServiceAccountName
+	return controller.DefaultWorkerServiceAccountName
 }
 
 func defaultProjectServiceAccount() string {
 	if pp, ok := os.LookupEnv("BRIGADE_JOB_SERVICE_ACCOUNT"); ok {
 		return pp
 	}
-	return defaultJobServiceAccountName
+	return controller.DefaultJobServiceAccountName
 }
 
 func defaultNamespace() string {


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an issue wherein a service account override is provided at the project-level (as in the advanced options during `brig project create`) but the default service account regex isn't properly updated, causing the following error:

```
 $ brig project create
? VCS or no-VCS project? VCS
? Project Name brigadecore/empty-testbed
...
? Project Service Account my-sa
...

 $ brig run brigadecore/empty-testbed
Event created. Waiting for worker pod named "brigade-worker-01dzyr4zgsbw80hah4s5tdw1zd".
Build: 01dzyr4zgsbw80hah4s5tdw1zd, Worker: brigade-worker-01dzyr4zgsbw80hah4s5tdw1zd
prestart: no dependencies file found
[brigade] brigade-worker version: 1.2.1
[brigade] Service Account my-sa does not match regex brigade-worker
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
