### PR TITLE
fix(brigade.js): add git to e2e job

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -57,6 +57,7 @@ function e2e() {
   // by its main.go filepath
   kind.mountPath = localPath;
   kind.tasks.push(
+    "apk add --update --no-cache git",
     `cd ${localPath}`,
     "CREATE_KIND=false make e2e"
   );


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `git`, a necessary utility for running e2e, to the e2e job/pod.

(The KindJob base image updated and no longer contains `git` by default.)

See https://brigadecore.github.io/kashti/jobs/test-e2e-01e4ejkx1c1c0k2wqpawq0w8pb

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
