### PR TITLE
fix(Makefile): fix typo for 'go mod vendor'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ IMMUTABLE_DOCKER_TAG := $(VERSION)
 
 .PHONY: resolve-dependencies
 resolve-dependencies:
-	$(GO_DOCKER_CMD) sh -c 'go mod tidy && go vendor'
+	$(GO_DOCKER_CMD) sh -c 'go mod tidy && go mod vendor'
 
 .PHONY: format
 format: format-go format-js


### PR DESCRIPTION
**What this PR does / why we need it**:

* Fixes the `resolve-dependencies` Makefile target

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
