### PR TITLE
fix(brig): fix printing of deployment statuses in brig check

### DIFF
--- a/brig/cmd/brig/commands/check.go
+++ b/brig/cmd/brig/commands/check.go
@@ -76,7 +76,7 @@ func checkBrigadeSystem() error {
 	}
 
 	if !apiDeploymentFound {
-		fmt.Printf("Info: Brigade API Server Deployment not found")
+		fmt.Println("Info: Brigade API Server Deployment not found")
 	}
 	if !controllerDeploymentFound {
 		fmt.Println("Error: Brigade Controller Deployment not found")
@@ -114,7 +114,7 @@ func checkBrigadeSystem() error {
 }
 
 func reportDeployStatus(deployment apps_v1.Deployment, name string) {
-	fmt.Print(deployment, name)
+	fmt.Print(getDeployStatusString(deployment, name))
 }
 
 func getDeployStatusString(deployment apps_v1.Deployment, name string) string {


### PR DESCRIPTION
**What this PR does / why we need it**:

`brig check` was printing the raw k8s deployment objects instead of using the pre-existing status printer helper.

The previous behavior can be seen in #1084 

With this fix, we appear to be back to normal/expected:
```
 $ brig check
✔️ Brigade API Server replicas: Desired 1, Ready 1, Updated 1, Available 1, Unavailable 0
✔️ Brigade Controller replicas: Desired 1, Ready 1, Updated 1, Available 1, Unavailable 0
✔️ Kashti replicas: Desired 1, Ready 1, Updated 1, Available 1, Unavailable 0
Info: Vacuum is healthy (not suspended and its schedule is non-empty)
```
Or, if Brigade not installed:
```
 $ brig check
Info: Brigade API Server Deployment not found
Error: Brigade Controller Deployment not found
Info: Kashti deployment not found
```

Fixes https://github.com/brigadecore/brigade/issues/1084

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
