### PR TITLE
ci(Makefile): allow for easily building local OS brig binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,8 +162,13 @@ load-all-images: $(addsuffix -load-image,$(IMAGES))
 	@kind load docker-image $(DOCKER_IMAGE_PREFIX)$*:$(IMMUTABLE_DOCKER_TAG) \
 			|| echo >&2 "kind not installed or error loading image: $(DOCKER_IMAGE_PREFIX)$*:$(IMMUTABLE_DOCKER_TAG)"
 
-# Cross-compile binaries for brig
+# Build brig according to CLIENT_PLATFORM
 build-brig:
+	$(GO_DOCKER_CMD) bash -c \
+		'GOOS="$(CLIENT_PLATFORM)" GOARCH="$(CLIENT_ARCH)" CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o ./bin/brig ./brig/cmd/brig'
+
+# Cross-compile binaries for brig
+xbuild-brig:
 	$(GO_DOCKER_CMD) bash -c "LDFLAGS=\"$(LDFLAGS)\" scripts/build-brig.sh"
 
 .PHONY: push

--- a/brigade.js
+++ b/brigade.js
@@ -154,7 +154,7 @@ function buildBrig(tag) {
   job.mountPath = localPath;
   job.tasks = [
     `cd ${localPath}`,
-    `SKIP_DOCKER=true VERSION=${tag} make build-brig`,
+    `SKIP_DOCKER=true VERSION=${tag} make xbuild-brig`,
     `cp -r bin/* ${releaseStorage.path}`
   ];
   return job;

--- a/docs/content/topics/developers.md
+++ b/docs/content/topics/developers.md
@@ -164,11 +164,17 @@ To build just the Docker images, run:
 $ make build-all-images
 ```
 
-To build just the client binaries (for Mac, Linux, and Windows on amd64), run
-this:
+To build just the client binary for your OS, run this:
 
 ```console
 $ make build-brig
+```
+
+To build all the supported client binaries (for Mac, Linux, and Windows on amd64), run
+this:
+
+```console
+$ make xbuild-brig
 ```
 
 ## Pushing Images


### PR DESCRIPTION
**What this PR does / why we need it**:

I propose here to update the `build-brig` Makefile target to only build brig for the local user's OS (and place into `bin/brig`).  This enables a quicker dev cycle when testing changes to the CLI.  Then, the `xbuild-brig` target will be for building all of the supported OSes.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
