### PR TITLE
Affinities support

### DIFF
--- a/brigade-controller/cmd/brigade-controller/controller/controller.go
+++ b/brigade-controller/cmd/brigade-controller/controller/controller.go
@@ -32,6 +32,8 @@ type Config struct {
 	WorkerRequestsCPU          string
 	WorkerRequestsMemory       string
 	WorkerLimitsCPU            string
+	WorkerNodePoolKey          string
+	WorkerNodePoolValue        string
 	WorkerLimitsMemory         string
 	DefaultBuildStorageClass   string
 	DefaultCacheStorageClass   string

--- a/brigade-controller/cmd/brigade-controller/main.go
+++ b/brigade-controller/cmd/brigade-controller/main.go
@@ -26,6 +26,8 @@ func main() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.StringVar(&master, "master", "", "master url")
 	flag.StringVar(&ctrConfig.Namespace, "namespace", defaultNamespace(), "kubernetes namespace")
+	flag.StringVar(&ctrConfig.WorkerNodePoolKey, "worker-node-pool-key", "", "worker nodepool key name")
+	flag.StringVar(&ctrConfig.WorkerNodePoolValue, "worker-node-pool-value", "", "worker nodepool key value")
 	flag.StringVar(&ctrConfig.WorkerImage, "worker-image", defaultWorkerImage(), "kubernetes worker image")
 	flag.StringVar(&ctrConfig.WorkerCommand, "worker-command", defaultWorkerCommand(), "kubernetes worker command")
 	flag.StringVar(&ctrConfig.WorkerPullPolicy, "worker-pull-policy", defaultWorkerPullPolicy(), "kubernetes worker image pull policy")

--- a/brigade-worker/src/index.ts
+++ b/brigade-worker/src/index.ts
@@ -168,10 +168,10 @@ if (process.env.BRIGADE_DEFAULT_CACHE_STORAGE_CLASS) {
 }
 if (process.env.BRIGADE_WORKER_NODEPOOL_KEY) {
     options.workerNodePoolKey = process.env.BRIGADE_WORKER_NODEPOOL_KEY
- }
+}
 if (process.env.BRIGADE_WORKER_NODEPOOL_VALUE) {
     options.workerNodePoolValue = process.env.BRIGADE_WORKER_NODEPOOL_VALUE
- }
+}
  
 
 // Run the app.

--- a/brigade-worker/src/index.ts
+++ b/brigade-worker/src/index.ts
@@ -166,6 +166,13 @@ if (process.env.BRIGADE_DEFAULT_BUILD_STORAGE_CLASS) {
 if (process.env.BRIGADE_DEFAULT_CACHE_STORAGE_CLASS) {
   options.defaultCacheStorageClass = process.env.BRIGADE_DEFAULT_CACHE_STORAGE_CLASS
 }
+if (process.env.BRIGADE_WORKER_NODEPOOL_KEY) {
+    options.workerNodePoolKey = process.env.BRIGADE_WORKER_NODEPOOL_KEY
+ }
+if (process.env.BRIGADE_WORKER_NODEPOOL_VALUE) {
+    options.workerNodePoolValue = process.env.BRIGADE_WORKER_NODEPOOL_VALUE
+ }
+ 
 
 // Run the app.
 new App(projectID, projectNamespace).run(e);

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -486,7 +486,8 @@ export class JobRunner implements jobs.JobRunner {
     }
 
     // Checking if we need to create an affinity
-    // Azure specific
+
+    // Azure specific example (other providers will have different value for a key)
     // affinity:
     //   nodeAffinity:
     //     requiredDuringSchedulingIgnoredDuringExecution:

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -789,7 +789,34 @@ describe("k8s", function () {
         });
       });
     });
+    describe("nodepool support", () => {
+      let j = new mock.MockJob("pequod", "whaler", ["echo hello"]);
+      let p = mock.mockProject();
+      let e = mock.mockEvent();
+      const nodePoolKey = "test-nodepool-key";
+      const nodePoolValue = "test-nodepool-value";
+      it("creates JobRunner with affinity", function () {
+          k8s.options.workerNodePoolKey = nodePoolKey
+          k8s.options.workerNodePoolValue = nodePoolValue
+          let jr = new k8s.JobRunner().init(j, e, p);
+          assert.isDefined(jr.runner.spec.affinity.nodeAffinity)
+          assert.equal(jr.runner.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key, nodePoolKey)
+          assert.equal(jr.runner.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0], nodePoolValue)
+      });
+      it("creates JobRunner without affinity workerNodePoolKey is empty", function () {
+          k8s.options.workerNodePoolKey = ""
+          k8s.options.workerNodePoolValue = nodePoolValue
+          let jr = new k8s.JobRunner().init(j, e, p);
+          assert.isUndefined(jr.runner.spec.affinity)
+      });
+      it("creates JobRunner without affinity workerNodePoolValue is empty", function () {
+          k8s.options.workerNodePoolKey = nodePoolKey
+          k8s.options.workerNodePoolValue = ""
+          let jr = new k8s.JobRunner().init(j, e, p);
+          assert.isUndefined(jr.runner.spec.affinity)
+      });
   });
+});
 
   describe("BuildStorage", () => {
     describe("buildPVC", () => {


### PR DESCRIPTION
Adding support for brigade worker affnities.
This allows to schedule workers to the specific nodepool, for example:

Cluster X
nodepools:
-default
-workers
-something-else

Brigade components are running on nodes in nodepool default, but brigade workers, are utilising more powerful nodes in workers nodepool


**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
