### PR TITLE
docs(install.md): fix brig guide link

### DIFF
--- a/docs/content/intro/install.md
+++ b/docs/content/intro/install.md
@@ -53,7 +53,7 @@ Note that this is just one way of configuring Brigade to receive inbound connect
 
 ## Brig
 
-We recommend using [Brig](https://github.com/brigadecore/brigade/tree/master/brig), a command line tool for interacting with Brigade. Read the [Brig guide](https://github.com/brigadecore/brigade/tree/master/brig) for installation and usage docs.
+We recommend using [Brig](https://github.com/brigadecore/brigade/tree/master/brig), a command line tool for interacting with Brigade. Read the [Brig guide](../topics/brig.md) for installation and usage docs.
 
 ## Notes for Minikube
 

--- a/docs/content/topics/brig.md
+++ b/docs/content/topics/brig.md
@@ -7,6 +7,7 @@ aliases:
   - /topics/cli/brig.md
   - /topics/dependencies/brig.md
   - /intro/brig.md
+  - /intro/topics/brig.md
 ---
 
 # Brig: The Brigade CLI


### PR DESCRIPTION
**What this PR does / why we need it**:

* Fixes the Brig guide link

Closes https://github.com/brigadecore/brigade/issues/1093

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
