### PR TITLE
move APIClientOptions out of package that was under internal

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -21,14 +21,19 @@ $ go get github.com/brigadecore/brigade/sdk/v2
 In your gateway code:
 
 ```golang
-import "github.com/brigadecore/brigade/sdk/v2"
+import (
+	"github.com/brigadecore/brigade/sdk/v2"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
+)
 
 // ...
 
 client, err := sdk.NewAPIClient(
 	apiAddress, // The address of the Brigade 2 Prototype API server, beginning with http:// or https//
 	apiToken, // An API token obtained using the Brigade 2 Prototype CLI
-	insecure, // boolean indicating whether TLS errors (if applicable) are tolerated
+	&restmachinery.APIClientOptions {
+		AllowInsecureConnections: false, // Do not ignore SSL errors
+	},
 )
 if err != nil {
 	// ...
@@ -53,14 +58,19 @@ would make sense for gateways (whose job is simply to broker events from
 upstream systems):
 
 ```golang
-import "github.com/brigadecore/brigade/sdk/v2/core"
+import (
+	"github.com/brigadecore/brigade/sdk/v2"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
+)
 
 // ...
 
 client, err := core.NewEventsClient(
 	apiAddress, // The address of the Brigade 2 Prototype API server, beginning with http:// or https://
 	apiToken, // An API token obtained using the Brigade 2 Prototype CLI
-	insecure, // boolean indicating whether TLS errors (if applicable) are tolerated
+	&restmachinery.APIClientOptions {
+		AllowInsecureConnections: false, // Do not ignore SSL errors
+	},
 )
 if err != nil {
 	// ...

--- a/sdk/v2/api_client.go
+++ b/sdk/v2/api_client.go
@@ -3,7 +3,7 @@ package sdk
 import (
 	"github.com/brigadecore/brigade/sdk/v2/authx"
 	"github.com/brigadecore/brigade/sdk/v2/core"
-	"github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 	"github.com/brigadecore/brigade/sdk/v2/system"
 )
 

--- a/sdk/v2/authx/api_client.go
+++ b/sdk/v2/authx/api_client.go
@@ -1,6 +1,6 @@
 package authx
 
-import "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+import "github.com/brigadecore/brigade/sdk/v2/restmachinery"
 
 // APIClient is the root of a tree of more specialized API clients within the
 // authx package.

--- a/sdk/v2/authx/common_test.go
+++ b/sdk/v2/authx/common_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
 	"github.com/brigadecore/brigade/sdk/v2/meta"
 	"github.com/stretchr/testify/require"
 )
@@ -37,7 +37,7 @@ func requireAPIVersionAndType(
 	require.Equal(t, expectedType, objMap["kind"])
 }
 
-func requireBaseClient(t *testing.T, baseClient *restmachinery.BaseClient) {
+func requireBaseClient(t *testing.T, baseClient *rm.BaseClient) {
 	require.NotNil(t, baseClient)
 	require.Equal(t, testAPIAddress, baseClient.APIAddress)
 	require.Equal(t, testAPIToken, baseClient.APIToken)

--- a/sdk/v2/authx/service_accounts.go
+++ b/sdk/v2/authx/service_accounts.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
 	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
 // ServiceAccount represents a non-human Brigade user, such as an Event
@@ -100,7 +101,7 @@ type ServiceAccountsClient interface {
 }
 
 type serviceAccountsClient struct {
-	*restmachinery.BaseClient
+	*rm.BaseClient
 }
 
 // NewServiceAccountsClient returns a specialized client for managing
@@ -111,7 +112,7 @@ func NewServiceAccountsClient(
 	opts *restmachinery.APIClientOptions,
 ) ServiceAccountsClient {
 	return &serviceAccountsClient{
-		BaseClient: restmachinery.NewBaseClient(apiAddress, apiToken, opts),
+		BaseClient: rm.NewBaseClient(apiAddress, apiToken, opts),
 	}
 }
 
@@ -122,7 +123,7 @@ func (s *serviceAccountsClient) Create(
 	token := Token{}
 	return token, s.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/service-accounts",
 			AuthHeaders: s.BearerTokenAuthHeaders(),
@@ -141,7 +142,7 @@ func (s *serviceAccountsClient) List(
 	serviceAccounts := ServiceAccountList{}
 	return serviceAccounts, s.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        "v2/service-accounts",
 			AuthHeaders: s.BearerTokenAuthHeaders(),
@@ -159,7 +160,7 @@ func (s *serviceAccountsClient) Get(
 	serviceAccount := ServiceAccount{}
 	return serviceAccount, s.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/service-accounts/%s", id),
 			AuthHeaders: s.BearerTokenAuthHeaders(),
@@ -172,7 +173,7 @@ func (s *serviceAccountsClient) Get(
 func (s *serviceAccountsClient) Lock(ctx context.Context, id string) error {
 	return s.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/service-accounts/%s/lock", id),
 			AuthHeaders: s.BearerTokenAuthHeaders(),
@@ -188,7 +189,7 @@ func (s *serviceAccountsClient) Unlock(
 	token := Token{}
 	return token, s.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodDelete,
 			Path:        fmt.Sprintf("v2/service-accounts/%s/lock", id),
 			AuthHeaders: s.BearerTokenAuthHeaders(),

--- a/sdk/v2/authx/sessions.go
+++ b/sdk/v2/authx/sessions.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
 	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
 // OIDCAuthDetails encapsulates all information required for a client
@@ -72,7 +73,7 @@ type SessionsClient interface {
 }
 
 type sessionsClient struct {
-	*restmachinery.BaseClient
+	*rm.BaseClient
 }
 
 // NewSessionsClient returns a specialized client for managing Brigade API
@@ -83,7 +84,7 @@ func NewSessionsClient(
 	opts *restmachinery.APIClientOptions,
 ) SessionsClient {
 	return &sessionsClient{
-		BaseClient: restmachinery.NewBaseClient(apiAddress, apiToken, opts),
+		BaseClient: rm.NewBaseClient(apiAddress, apiToken, opts),
 	}
 }
 
@@ -94,7 +95,7 @@ func (s *sessionsClient) CreateRootSession(
 	token := Token{}
 	return token, s.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/sessions",
 			AuthHeaders: s.BasicAuthHeaders("root", password),
@@ -113,7 +114,7 @@ func (s *sessionsClient) CreateUserSession(
 	oidcAuthDetails := OIDCAuthDetails{}
 	return oidcAuthDetails, s.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/sessions",
 			SuccessCode: http.StatusCreated,
@@ -125,7 +126,7 @@ func (s *sessionsClient) CreateUserSession(
 func (s *sessionsClient) Delete(ctx context.Context) error {
 	return s.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodDelete,
 			Path:        "v2/session",
 			AuthHeaders: s.BearerTokenAuthHeaders(),

--- a/sdk/v2/authx/users.go
+++ b/sdk/v2/authx/users.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
 	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
 // User represents a (human) Brigade user.
@@ -92,7 +93,7 @@ type UsersClient interface {
 }
 
 type usersClient struct {
-	*restmachinery.BaseClient
+	*rm.BaseClient
 }
 
 // NewUsersClient returns a specialized client for managing Users.
@@ -102,7 +103,7 @@ func NewUsersClient(
 	opts *restmachinery.APIClientOptions,
 ) UsersClient {
 	return &usersClient{
-		BaseClient: restmachinery.NewBaseClient(apiAddress, apiToken, opts),
+		BaseClient: rm.NewBaseClient(apiAddress, apiToken, opts),
 	}
 }
 
@@ -114,7 +115,7 @@ func (u *usersClient) List(
 	users := UserList{}
 	return users, u.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        "v2/users",
 			AuthHeaders: u.BearerTokenAuthHeaders(),
@@ -129,7 +130,7 @@ func (u *usersClient) Get(ctx context.Context, id string) (User, error) {
 	user := User{}
 	return user, u.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/users/%s", id),
 			AuthHeaders: u.BearerTokenAuthHeaders(),
@@ -142,7 +143,7 @@ func (u *usersClient) Get(ctx context.Context, id string) (User, error) {
 func (u *usersClient) Lock(ctx context.Context, id string) error {
 	return u.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/users/%s/lock", id),
 			AuthHeaders: u.BearerTokenAuthHeaders(),
@@ -154,7 +155,7 @@ func (u *usersClient) Lock(ctx context.Context, id string) error {
 func (u *usersClient) Unlock(ctx context.Context, id string) error {
 	return u.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodDelete,
 			Path:        fmt.Sprintf("v2/users/%s/lock", id),
 			AuthHeaders: u.BearerTokenAuthHeaders(),

--- a/sdk/v2/core/api_client.go
+++ b/sdk/v2/core/api_client.go
@@ -1,6 +1,6 @@
 package core
 
-import "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+import "github.com/brigadecore/brigade/sdk/v2/restmachinery"
 
 // APIClient is the root of a tree of more specialized API clients within the
 // core package.

--- a/sdk/v2/core/events.go
+++ b/sdk/v2/core/events.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
 	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
 // Event represents an occurrence in some upstream system. Once accepted into
@@ -179,7 +180,7 @@ type EventsClient interface {
 }
 
 type eventsClient struct {
-	*restmachinery.BaseClient
+	*rm.BaseClient
 	workersClient WorkersClient
 	logsClient    LogsClient
 }
@@ -191,7 +192,7 @@ func NewEventsClient(
 	opts *restmachinery.APIClientOptions,
 ) EventsClient {
 	return &eventsClient{
-		BaseClient:    restmachinery.NewBaseClient(apiAddress, apiToken, opts),
+		BaseClient:    rm.NewBaseClient(apiAddress, apiToken, opts),
 		workersClient: NewWorkersClient(apiAddress, apiToken, opts),
 		logsClient:    NewLogsClient(apiAddress, apiToken, opts),
 	}
@@ -204,7 +205,7 @@ func (e *eventsClient) Create(
 	events := EventList{}
 	return events, e.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/events",
 			AuthHeaders: e.BearerTokenAuthHeaders(),
@@ -234,7 +235,7 @@ func (e *eventsClient) List(
 	events := EventList{}
 	return events, e.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        "v2/events",
 			AuthHeaders: e.BearerTokenAuthHeaders(),
@@ -252,7 +253,7 @@ func (e *eventsClient) Get(
 	event := Event{}
 	return event, e.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/events/%s", id),
 			AuthHeaders: e.BearerTokenAuthHeaders(),
@@ -265,7 +266,7 @@ func (e *eventsClient) Get(
 func (e *eventsClient) Cancel(ctx context.Context, id string) error {
 	return e.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/events/%s/cancellation", id),
 			AuthHeaders: e.BearerTokenAuthHeaders(),
@@ -292,7 +293,7 @@ func (e *eventsClient) CancelMany(
 	result := CancelManyEventsResult{}
 	return result, e.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/events/cancellations",
 			AuthHeaders: e.BearerTokenAuthHeaders(),
@@ -306,7 +307,7 @@ func (e *eventsClient) CancelMany(
 func (e *eventsClient) Delete(ctx context.Context, id string) error {
 	return e.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodDelete,
 			Path:        fmt.Sprintf("v2/events/%s", id),
 			AuthHeaders: e.BearerTokenAuthHeaders(),
@@ -333,7 +334,7 @@ func (e *eventsClient) DeleteMany(
 	result := DeleteManyEventsResult{}
 	return result, e.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodDelete,
 			Path:        "v2/events",
 			AuthHeaders: e.BearerTokenAuthHeaders(),

--- a/sdk/v2/core/jobs.go
+++ b/sdk/v2/core/jobs.go
@@ -8,8 +8,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
 	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
 // JobPhase represents where a Job is within its lifecycle.
@@ -215,7 +216,7 @@ type JobsClient interface {
 }
 
 type jobsClient struct {
-	*restmachinery.BaseClient
+	*rm.BaseClient
 }
 
 // NewJobsClient returns a specialized client for managing Event Jobs.
@@ -225,7 +226,7 @@ func NewJobsClient(
 	opts *restmachinery.APIClientOptions,
 ) JobsClient {
 	return &jobsClient{
-		BaseClient: restmachinery.NewBaseClient(apiAddress, apiToken, opts),
+		BaseClient: rm.NewBaseClient(apiAddress, apiToken, opts),
 	}
 }
 
@@ -237,7 +238,7 @@ func (j *jobsClient) Create(
 ) error {
 	return j.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/events/%s/worker/jobs/%s", eventID, jobName),
 			AuthHeaders: j.BearerTokenAuthHeaders(),
@@ -254,7 +255,7 @@ func (j *jobsClient) Start(
 ) error {
 	return j.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method: http.MethodPut,
 			Path: fmt.Sprintf(
 				"v2/events/%s/worker/jobs/%s/start",
@@ -275,7 +276,7 @@ func (j *jobsClient) GetStatus(
 	status := JobStatus{}
 	return status, j.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method: http.MethodGet,
 			Path: fmt.Sprintf(
 				"v2/events/%s/worker/jobs/%s/status",
@@ -296,7 +297,7 @@ func (j *jobsClient) WatchStatus(
 ) (<-chan JobStatus, <-chan error, error) {
 	resp, err := j.SubmitRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method: http.MethodGet,
 			Path: fmt.Sprintf(
 				"v2/events/%s/worker/jobs/%s/status",
@@ -330,7 +331,7 @@ func (j *jobsClient) UpdateStatus(
 ) error {
 	return j.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method: http.MethodPut,
 			Path: fmt.Sprintf(
 				"v2/events/%s/worker/jobs/%s/status",

--- a/sdk/v2/core/logs.go
+++ b/sdk/v2/core/logs.go
@@ -8,7 +8,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
 // LogEntry represents one line of output from an OCI container.
@@ -57,7 +58,7 @@ type LogsClient interface {
 }
 
 type logsClient struct {
-	*restmachinery.BaseClient
+	*rm.BaseClient
 }
 
 // NewLogsClient returns a specialized client for managing Event Logs.
@@ -67,7 +68,7 @@ func NewLogsClient(
 	opts *restmachinery.APIClientOptions,
 ) LogsClient {
 	return &logsClient{
-		BaseClient: restmachinery.NewBaseClient(apiAddress, apiToken, opts),
+		BaseClient: rm.NewBaseClient(apiAddress, apiToken, opts),
 	}
 }
 
@@ -92,7 +93,7 @@ func (l *logsClient) Stream(
 
 	resp, err := l.SubmitRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/events/%s/logs", eventID),
 			AuthHeaders: l.BearerTokenAuthHeaders(),

--- a/sdk/v2/core/project_roles.go
+++ b/sdk/v2/core/project_roles.go
@@ -6,7 +6,8 @@ import (
 	"net/http"
 
 	"github.com/brigadecore/brigade/sdk/v2/authx"
-	"github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
 // RoleTypeProject represents a project-level Role.
@@ -51,7 +52,7 @@ type ProjectRolesClient interface {
 }
 
 type projectRolesClient struct {
-	*restmachinery.BaseClient
+	*rm.BaseClient
 }
 
 // NewProjectRolesClient returns a specialized client for managing Project
@@ -62,7 +63,7 @@ func NewProjectRolesClient(
 	opts *restmachinery.APIClientOptions,
 ) ProjectRolesClient {
 	return &projectRolesClient{
-		BaseClient: restmachinery.NewBaseClient(apiAddress, apiToken, opts),
+		BaseClient: rm.NewBaseClient(apiAddress, apiToken, opts),
 	}
 }
 
@@ -73,7 +74,7 @@ func (p *projectRolesClient) Grant(
 ) error {
 	return p.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method: http.MethodPost,
 			Path: fmt.Sprintf(
 				"v2/projects/%s/role-assignments",
@@ -98,7 +99,7 @@ func (p *projectRolesClient) Revoke(
 	}
 	return p.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method: http.MethodDelete,
 			Path: fmt.Sprintf(
 				"v2/projects/%s/role-assignments",

--- a/sdk/v2/core/projects.go
+++ b/sdk/v2/core/projects.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
 	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
 // Project is Brigade's fundamental configuration, management, and isolation
@@ -179,7 +180,7 @@ type ProjectsClient interface {
 }
 
 type projectsClient struct {
-	*restmachinery.BaseClient
+	*rm.BaseClient
 	// rolesClient is a specialized client for Project Role management.
 	rolesClient ProjectRolesClient
 	// secretsClient is a specialized client for Secret management.
@@ -193,7 +194,7 @@ func NewProjectsClient(
 	opts *restmachinery.APIClientOptions,
 ) ProjectsClient {
 	return &projectsClient{
-		BaseClient:    restmachinery.NewBaseClient(apiAddress, apiToken, opts),
+		BaseClient:    rm.NewBaseClient(apiAddress, apiToken, opts),
 		rolesClient:   NewProjectRolesClient(apiAddress, apiToken, opts),
 		secretsClient: NewSecretsClient(apiAddress, apiToken, opts),
 	}
@@ -206,7 +207,7 @@ func (p *projectsClient) Create(
 	createdProject := Project{}
 	return createdProject, p.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/projects",
 			AuthHeaders: p.BearerTokenAuthHeaders(),
@@ -224,7 +225,7 @@ func (p *projectsClient) CreateFromBytes(
 	createdProject := Project{}
 	return createdProject, p.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/projects",
 			AuthHeaders: p.BearerTokenAuthHeaders(),
@@ -243,7 +244,7 @@ func (p *projectsClient) List(
 	projects := ProjectList{}
 	return projects, p.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        "v2/projects",
 			AuthHeaders: p.BearerTokenAuthHeaders(),
@@ -261,7 +262,7 @@ func (p *projectsClient) Get(
 	project := Project{}
 	return project, p.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/projects/%s", id),
 			AuthHeaders: p.BearerTokenAuthHeaders(),
@@ -278,7 +279,7 @@ func (p *projectsClient) Update(
 	updatedProject := Project{}
 	return updatedProject, p.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/projects/%s", project.ID),
 			AuthHeaders: p.BearerTokenAuthHeaders(),
@@ -297,7 +298,7 @@ func (p *projectsClient) UpdateFromBytes(
 	updatedProject := Project{}
 	return updatedProject, p.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/projects/%s", projectID),
 			AuthHeaders: p.BearerTokenAuthHeaders(),
@@ -311,7 +312,7 @@ func (p *projectsClient) UpdateFromBytes(
 func (p *projectsClient) Delete(ctx context.Context, id string) error {
 	return p.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodDelete,
 			Path:        fmt.Sprintf("v2/projects/%s", id),
 			AuthHeaders: p.BearerTokenAuthHeaders(),

--- a/sdk/v2/core/secrets.go
+++ b/sdk/v2/core/secrets.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
 	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
 // Secret represents Project-level sensitive information.
@@ -83,7 +84,7 @@ type SecretsClient interface {
 }
 
 type secretsClient struct {
-	*restmachinery.BaseClient
+	*rm.BaseClient
 }
 
 // NewSecretsClient returns a specialized client for managing
@@ -94,7 +95,7 @@ func NewSecretsClient(
 	opts *restmachinery.APIClientOptions,
 ) SecretsClient {
 	return &secretsClient{
-		BaseClient: restmachinery.NewBaseClient(apiAddress, apiToken, opts),
+		BaseClient: rm.NewBaseClient(apiAddress, apiToken, opts),
 	}
 }
 
@@ -106,7 +107,7 @@ func (s *secretsClient) List(
 	secrets := SecretList{}
 	return secrets, s.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/projects/%s/secrets", projectID),
 			AuthHeaders: s.BearerTokenAuthHeaders(),
@@ -124,7 +125,7 @@ func (s *secretsClient) Set(
 ) error {
 	return s.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method: http.MethodPut,
 			Path: fmt.Sprintf(
 				"v2/projects/%s/secrets/%s",
@@ -145,7 +146,7 @@ func (s *secretsClient) Unset(
 ) error {
 	return s.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method: http.MethodDelete,
 			Path: fmt.Sprintf(
 				"v2/projects/%s/secrets/%s",

--- a/sdk/v2/core/workers.go
+++ b/sdk/v2/core/workers.go
@@ -8,8 +8,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
 	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
 // LogLevel represents the desired granularity of Worker log output.
@@ -239,7 +240,7 @@ type WorkersClient interface {
 }
 
 type workersClient struct {
-	*restmachinery.BaseClient
+	*rm.BaseClient
 	jobsClient JobsClient
 }
 
@@ -250,7 +251,7 @@ func NewWorkersClient(
 	opts *restmachinery.APIClientOptions,
 ) WorkersClient {
 	return &workersClient{
-		BaseClient: restmachinery.NewBaseClient(apiAddress, apiToken, opts),
+		BaseClient: rm.NewBaseClient(apiAddress, apiToken, opts),
 		jobsClient: NewJobsClient(apiAddress, apiToken, opts),
 	}
 }
@@ -258,7 +259,7 @@ func NewWorkersClient(
 func (w *workersClient) Start(ctx context.Context, eventID string) error {
 	return w.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/events/%s/worker/start", eventID),
 			AuthHeaders: w.BearerTokenAuthHeaders(),
@@ -274,7 +275,7 @@ func (w *workersClient) GetStatus(
 	status := WorkerStatus{}
 	return status, w.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/events/%s/worker/status", eventID),
 			AuthHeaders: w.BearerTokenAuthHeaders(),
@@ -290,7 +291,7 @@ func (w *workersClient) WatchStatus(
 ) (<-chan WorkerStatus, <-chan error, error) {
 	resp, err := w.SubmitRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/events/%s/worker/status", eventID),
 			AuthHeaders: w.BearerTokenAuthHeaders(),
@@ -319,7 +320,7 @@ func (w *workersClient) UpdateStatus(
 ) error {
 	return w.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/events/%s/worker/status", eventID),
 			AuthHeaders: w.BearerTokenAuthHeaders(),

--- a/sdk/v2/internal/restmachinery/client.go
+++ b/sdk/v2/internal/restmachinery/client.go
@@ -13,15 +13,9 @@ import (
 	"strconv"
 
 	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 	"github.com/pkg/errors"
 )
-
-// APIClientOptions encapsulates optional API client configuration.
-type APIClientOptions struct {
-	// AllowInsecureConnections indicates whether SSL-related errors should be
-	// ignored when connecting to the API server.
-	AllowInsecureConnections bool
-}
 
 // BaseClient provides "API machinery" used by all the specialized API clients.
 // Its various functions remove the tedium from common API-related operations
@@ -37,10 +31,10 @@ type BaseClient struct {
 func NewBaseClient(
 	apiAddress string,
 	apiToken string,
-	opts *APIClientOptions,
+	opts *restmachinery.APIClientOptions,
 ) *BaseClient {
 	if opts == nil {
-		opts = &APIClientOptions{}
+		opts = &restmachinery.APIClientOptions{}
 	}
 	return &BaseClient{
 		APIAddress: apiAddress,

--- a/sdk/v2/restmachinery/client.go
+++ b/sdk/v2/restmachinery/client.go
@@ -1,0 +1,8 @@
+package restmachinery
+
+// APIClientOptions encapsulates optional API client configuration.
+type APIClientOptions struct {
+	// AllowInsecureConnections indicates whether SSL-related errors should be
+	// ignored when connecting to the API server.
+	AllowInsecureConnections bool
+}

--- a/sdk/v2/system/api_client.go
+++ b/sdk/v2/system/api_client.go
@@ -1,6 +1,6 @@
 package system
 
-import "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+import "github.com/brigadecore/brigade/sdk/v2/restmachinery"
 
 // APIClient is the root of a tree of more specialized API clients within the
 // system package.

--- a/sdk/v2/system/roles.go
+++ b/sdk/v2/system/roles.go
@@ -5,7 +5,8 @@ import (
 	"net/http"
 
 	"github.com/brigadecore/brigade/sdk/v2/authx"
-	"github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
 // RoleTypeSystem represents a system-level Role.
@@ -45,7 +46,7 @@ type RolesClient interface {
 }
 
 type rolesClient struct {
-	*restmachinery.BaseClient
+	*rm.BaseClient
 }
 
 // NewRolesClient returns a specialized client for managing System
@@ -56,7 +57,7 @@ func NewRolesClient(
 	opts *restmachinery.APIClientOptions,
 ) RolesClient {
 	return &rolesClient{
-		BaseClient: restmachinery.NewBaseClient(apiAddress, apiToken, opts),
+		BaseClient: rm.NewBaseClient(apiAddress, apiToken, opts),
 	}
 }
 
@@ -66,7 +67,7 @@ func (r *rolesClient) Grant(
 ) error {
 	return r.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/system/role-assignments",
 			AuthHeaders: r.BearerTokenAuthHeaders(),
@@ -87,7 +88,7 @@ func (r *rolesClient) Revoke(
 	}
 	return r.ExecuteRequest(
 		ctx,
-		restmachinery.OutboundRequest{
+		rm.OutboundRequest{
 			Method:      http.MethodDelete,
 			Path:        "v2/system/role-assignments",
 			AuthHeaders: r.BearerTokenAuthHeaders(),


### PR DESCRIPTION
This is a follow=up to #1118 

One bit of refactoring that @vdice and I collaborated (the creation of the `APIClientOptions` type) accidentally put that type in a package that was only available for internal consumption-- meaning third-party users of the SDK are unable to instantiate instances of that type.

This PR corrects that.