### PR TITLE
fix job marshaling issue in sdk

### DIFF
--- a/sdk/v2/core/jobs.go
+++ b/sdk/v2/core/jobs.go
@@ -51,6 +51,24 @@ type Job struct {
 	Status *JobStatus `json:"status"`
 }
 
+// MarshalJSON amends Job instances with type metadata so that clients do not
+// need to be concerned with the tedium of doing so.
+func (j Job) MarshalJSON() ([]byte, error) {
+	type Alias Job
+	return json.Marshal(
+		struct {
+			meta.TypeMeta `json:",inline"`
+			Alias         `json:",inline"`
+		}{
+			TypeMeta: meta.TypeMeta{
+				APIVersion: meta.APIVersion,
+				Kind:       "Job",
+			},
+			Alias: (Alias)(j),
+		},
+	)
+}
+
 // JobSpec is the technical blueprint for a Job.
 type JobSpec struct {
 	// PrimaryContainer specifies the details of an OCI container that forms the
@@ -74,24 +92,6 @@ type JobSpec struct {
 	// non-default operating system (i.e. Windows) or specific hardware (e.g. a
 	// GPU.)
 	Host *JobHost `json:"host,omitempty"`
-}
-
-// MarshalJSON amends JobSpec instances with type metadata so that clients do
-// not need to be concerned with the tedium of doing so.
-func (j JobSpec) MarshalJSON() ([]byte, error) {
-	type Alias JobSpec
-	return json.Marshal(
-		struct {
-			meta.TypeMeta `json:",inline"`
-			Alias         `json:",inline"`
-		}{
-			TypeMeta: meta.TypeMeta{
-				APIVersion: meta.APIVersion,
-				Kind:       "JobSpec",
-			},
-			Alias: (Alias)(j),
-		},
-	)
 }
 
 // JobContainerSpec amends the ContainerSpec type with additional Job-specific

--- a/sdk/v2/core/jobs_test.go
+++ b/sdk/v2/core/jobs_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestJobSpecMarshalJSON(t *testing.T) {
-	requireAPIVersionAndType(t, JobSpec{}, "JobSpec")
+func TestJobMarshalJSON(t *testing.T) {
+	requireAPIVersionAndType(t, Job{}, "Job")
 }
 
 func TestJobStatusMarshalJSON(t *testing.T) {


### PR DESCRIPTION
The API client was accidentally applying type metadata to outbound `JobSpec`s, but this is incorrect. `JobSpec`s are never sent directly from client to server, rather `Job`s _containing_ specs are sent. `Job` was lacking the correct application of that type metadata.

This mistake arose due to some refactoring that occurred as code was being imported from the prototype and cleaned up. It wasn't caught because job-related API server endpoints do not yet exist to integration test this part of the client against.