### PR TITLE
fix test schema uri

### DIFF
--- a/v2/apiserver/internal/lib/restmachinery/endpoints_test.go
+++ b/v2/apiserver/internal/lib/restmachinery/endpoints_test.go
@@ -18,7 +18,7 @@ var testSchema = gojsonschema.NewBytesLoader(
 	[]byte(`
 		{
 			"$schema": "http://json-schema.org/draft-07/schema#",
-			"$id": "github.com/lovethedrake/drakecore/config.schema.json",
+			"$id": "github.com/brigadecore/brigade/v2/test.schema.json",
 
 			"title": "Project",
 			"type": "object",


### PR DESCRIPTION
This is just a vanity fix. Some code involved in testing the server-side `restmachinery` uses a fake JSON schema that was copied from another project of mine, and as a result of the careless copy/paste, the `$id` for that schema looks funky. This PR fixes that.