### PR TITLE
service account management features

### DIFF
--- a/v2/apiserver/internal/authx/mongodb/service_accounts_store.go
+++ b/v2/apiserver/internal/authx/mongodb/service_accounts_store.go
@@ -1,0 +1,188 @@
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/brigadecore/brigade/v2/apiserver/internal/authx"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/mongodb"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// serviceAccountsStore is a MongoDB-based implementation of the
+// authx.ServiceAccountsStore interface.
+type serviceAccountsStore struct {
+	collection mongodb.Collection
+}
+
+// NewServiceAccountsStore returns a MongoDB-based implementation of the
+// authx.ServiceAccountsStore interface.
+func NewServiceAccountsStore(
+	database *mongo.Database,
+) (authx.ServiceAccountsStore, error) {
+	ctx, cancel :=
+		context.WithTimeout(context.Background(), createIndexTimeout)
+	defer cancel()
+	unique := true
+	collection := database.Collection("service-accounts")
+	if _, err := collection.Indexes().CreateOne(
+		ctx,
+		mongo.IndexModel{
+			Keys: bson.M{
+				"id": 1,
+			},
+			Options: &options.IndexOptions{
+				Unique: &unique,
+			},
+		},
+	); err != nil {
+		return nil, errors.Wrap(
+			err,
+			"error adding index to service accounts collection",
+		)
+	}
+	return &serviceAccountsStore{
+		collection: database.Collection("service-accounts"),
+	}, nil
+}
+
+func (s *serviceAccountsStore) Create(
+	ctx context.Context,
+	serviceAccount authx.ServiceAccount,
+) error {
+	if _, err := s.collection.InsertOne(ctx, serviceAccount); err != nil {
+		if mongodb.IsDuplicateKeyError(err) {
+			return &meta.ErrConflict{
+				Type: "ServiceAccount",
+				ID:   serviceAccount.ID,
+				Reason: fmt.Sprintf(
+					"A service account with the ID %q already exists.",
+					serviceAccount.ID,
+				),
+			}
+		}
+		return errors.Wrapf(
+			err,
+			"error inserting new service account %q",
+			serviceAccount.ID,
+		)
+	}
+	return nil
+}
+
+func (s *serviceAccountsStore) List(
+	ctx context.Context,
+	opts meta.ListOptions,
+) (authx.ServiceAccountList, error) {
+	serviceAccounts := authx.ServiceAccountList{}
+
+	criteria := bson.M{}
+	if opts.Continue != "" {
+		criteria["id"] = bson.M{"$gt": opts.Continue}
+	}
+
+	findOptions := options.Find()
+	findOptions.SetSort(bson.M{"id": 1})
+	findOptions.SetLimit(opts.Limit)
+	cur, err := s.collection.Find(ctx, criteria, findOptions)
+	if err != nil {
+		return serviceAccounts,
+			errors.Wrap(err, "error finding service accounts")
+	}
+	if err := cur.All(ctx, &serviceAccounts.Items); err != nil {
+		return serviceAccounts,
+			errors.Wrap(err, "error decoding service accounts")
+	}
+
+	if int64(len(serviceAccounts.Items)) == opts.Limit {
+		continueID := serviceAccounts.Items[opts.Limit-1].ID
+		criteria["id"] = bson.M{"$gt": continueID}
+		remaining, err := s.collection.CountDocuments(ctx, criteria)
+		if err != nil {
+			return serviceAccounts,
+				errors.Wrap(err, "error counting remaining service accounts")
+		}
+		if remaining > 0 {
+			serviceAccounts.Continue = continueID
+			serviceAccounts.RemainingItemCount = remaining
+		}
+	}
+
+	return serviceAccounts, nil
+}
+
+func (s *serviceAccountsStore) Get(
+	ctx context.Context,
+	id string,
+) (authx.ServiceAccount, error) {
+	serviceAccount := authx.ServiceAccount{}
+	res := s.collection.FindOne(ctx, bson.M{"id": id})
+	err := res.Decode(&serviceAccount)
+	if err == mongo.ErrNoDocuments {
+		return serviceAccount, &meta.ErrNotFound{
+			Type: "ServiceAccount",
+			ID:   id,
+		}
+	}
+	if err != nil {
+		return serviceAccount,
+			errors.Wrapf(res.Err(), "error finding/decoding service account %q", id)
+	}
+	return serviceAccount, nil
+}
+
+func (s *serviceAccountsStore) Lock(ctx context.Context, id string) error {
+	res, err := s.collection.UpdateOne(
+		ctx,
+		bson.M{"id": id},
+		bson.M{
+			"$set": bson.M{
+				"locked": time.Now().UTC(),
+			},
+		},
+	)
+	if err != nil {
+		return errors.Wrapf(err, "error updating service account %q", id)
+	}
+	if res.MatchedCount == 0 {
+		return &meta.ErrNotFound{
+			Type: "ServiceAccount",
+			ID:   id,
+		}
+	}
+	// Note, there are no sessions to delete because service accounts use
+	// non-expiring, sessionless tokens.
+	return nil
+}
+
+func (s *serviceAccountsStore) Unlock(
+	ctx context.Context,
+	id string,
+	newHashedToken string,
+) error {
+	res, err := s.collection.UpdateOne(
+		ctx,
+		bson.M{"id": id},
+		bson.M{
+			"$set": bson.M{
+				"locked":      nil,
+				"hashedToken": newHashedToken,
+			},
+		},
+	)
+	if err != nil {
+		return errors.Wrapf(err, "error updating service account %q", id)
+	}
+	if res.MatchedCount == 0 {
+		return &meta.ErrNotFound{
+			Type: "ServiceAccount",
+			ID:   id,
+		}
+	}
+	return nil
+}

--- a/v2/apiserver/internal/authx/mongodb/service_accounts_store_test.go
+++ b/v2/apiserver/internal/authx/mongodb/service_accounts_store_test.go
@@ -1,0 +1,442 @@
+package mongodb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/brigadecore/brigade/v2/apiserver/internal/authx"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/mongodb"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestServiceAccountsStoreCreate(t *testing.T) {
+	testServiceAccount := authx.ServiceAccount{
+		ObjectMeta: meta.ObjectMeta{
+			ID: "jarvis",
+		},
+	}
+	testCases := []struct {
+		name       string
+		collection mongodb.Collection
+		assertions func(err error)
+	}{
+
+		{
+			name: "id already exists",
+			collection: &mockCollection{
+				InsertOneFn: func(
+					ctx context.Context,
+					document interface{},
+					opts ...*options.InsertOneOptions,
+				) (*mongo.InsertOneResult, error) {
+					return nil, mockWriteException
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrConflict{}, err)
+				require.Equal(t, "ServiceAccount", err.(*meta.ErrConflict).Type)
+				require.Equal(t, testServiceAccount.ID, err.(*meta.ErrConflict).ID)
+				require.Contains(t, err.(*meta.ErrConflict).Reason, "already exists")
+			},
+		},
+
+		{
+			name: "unanticipated error",
+			collection: &mockCollection{
+				InsertOneFn: func(
+					ctx context.Context,
+					document interface{},
+					opts ...*options.InsertOneOptions,
+				) (*mongo.InsertOneResult, error) {
+					return nil, errors.New("something went wrong")
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error inserting new service account")
+			},
+		},
+
+		{
+			name: "successful creation",
+			collection: &mockCollection{
+				InsertOneFn: func(
+					ctx context.Context,
+					document interface{},
+					opts ...*options.InsertOneOptions,
+				) (*mongo.InsertOneResult, error) {
+					return nil, nil
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := &serviceAccountsStore{
+				collection: testCase.collection,
+			}
+			err := store.Create(context.Background(), testServiceAccount)
+			testCase.assertions(err)
+		})
+	}
+}
+
+func TestServiceAccountsStoreList(t *testing.T) {
+	testServiceAccount := authx.ServiceAccount{
+		ObjectMeta: meta.ObjectMeta{
+			ID: "jarvis",
+		},
+	}
+
+	testCases := []struct {
+		name       string
+		collection mongodb.Collection
+		assertions func(serviceAccounts authx.ServiceAccountList, err error)
+	}{
+
+		{
+			name: "error finding service accounts",
+			collection: &mockCollection{
+				FindFn: func(
+					ctx context.Context,
+					filter interface{},
+					opts ...*options.FindOptions,
+				) (*mongo.Cursor, error) {
+					return nil, errors.New("something went wrong")
+				},
+			},
+			assertions: func(_ authx.ServiceAccountList, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error finding service accounts")
+			},
+		},
+
+		{
+			name: "service accounts found; no more pages of results exist",
+			collection: &mockCollection{
+				FindFn: func(
+					ctx context.Context,
+					filter interface{},
+					opts ...*options.FindOptions,
+				) (*mongo.Cursor, error) {
+					cursor, err := mockCursor(testServiceAccount)
+					require.NoError(t, err)
+					return cursor, nil
+				},
+				CountDocumentsFn: func(
+					ctx context.Context,
+					filter interface{},
+					opts ...*options.CountOptions,
+				) (int64, error) {
+					return 0, nil
+				},
+			},
+			assertions: func(serviceAccounts authx.ServiceAccountList, err error) {
+				require.NoError(t, err)
+				require.Empty(t, serviceAccounts.Continue)
+				require.Zero(t, serviceAccounts.RemainingItemCount)
+			},
+		},
+
+		{
+			name: "service accounts found; more pages of results exist",
+			collection: &mockCollection{
+				FindFn: func(
+					ctx context.Context,
+					filter interface{},
+					opts ...*options.FindOptions,
+				) (*mongo.Cursor, error) {
+					cursor, err := mockCursor(testServiceAccount)
+					require.NoError(t, err)
+					return cursor, nil
+				},
+				CountDocumentsFn: func(
+					ctx context.Context,
+					filter interface{},
+					opts ...*options.CountOptions,
+				) (int64, error) {
+					return 5, nil
+				},
+			},
+			assertions: func(serviceAccounts authx.ServiceAccountList, err error) {
+				require.NoError(t, err)
+				require.Equal(t, testServiceAccount.ID, serviceAccounts.Continue)
+				require.Equal(t, int64(5), serviceAccounts.RemainingItemCount)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := &serviceAccountsStore{
+				collection: testCase.collection,
+			}
+			serviceAccounts, err := store.List(
+				context.Background(),
+				meta.ListOptions{
+					Limit:    1,
+					Continue: "blue-book",
+				},
+			)
+			testCase.assertions(serviceAccounts, err)
+		})
+	}
+}
+
+func TestServiceAccountsStoreGet(t *testing.T) {
+	const testServiceAccountID = "jarvis"
+	testCases := []struct {
+		name       string
+		collection mongodb.Collection
+		assertions func(authx.ServiceAccount, error)
+	}{
+
+		{
+			name: "service account not found",
+			collection: &mockCollection{
+				FindOneFn: func(
+					ctx context.Context,
+					filter interface{},
+					opts ...*options.FindOneOptions,
+				) *mongo.SingleResult {
+					res, err := mockSingleResult(mongo.ErrNoDocuments)
+					require.NoError(t, err)
+					return res
+				},
+			},
+			assertions: func(_ authx.ServiceAccount, err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrNotFound{}, err)
+				require.Equal(t, "ServiceAccount", err.(*meta.ErrNotFound).Type)
+				require.Equal(t, testServiceAccountID, err.(*meta.ErrNotFound).ID)
+			},
+		},
+
+		{
+			name: "unanticipated error",
+			collection: &mockCollection{
+				FindOneFn: func(
+					ctx context.Context,
+					filter interface{},
+					opts ...*options.FindOneOptions,
+				) *mongo.SingleResult {
+					res, err := mockSingleResult(errors.New("something went wrong"))
+					require.NoError(t, err)
+					return res
+				},
+			},
+			assertions: func(_ authx.ServiceAccount, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(
+					t,
+					err.Error(),
+					"error finding/decoding service account",
+				)
+			},
+		},
+
+		{
+			name: "service account found",
+			collection: &mockCollection{
+				FindOneFn: func(
+					ctx context.Context,
+					filter interface{},
+					opts ...*options.FindOneOptions,
+				) *mongo.SingleResult {
+					res, err := mockSingleResult(
+						authx.ServiceAccount{
+							ObjectMeta: meta.ObjectMeta{
+								ID: testServiceAccountID,
+							},
+						},
+					)
+					require.NoError(t, err)
+					return res
+				},
+			},
+			assertions: func(serviceAccount authx.ServiceAccount, err error) {
+				require.NoError(t, err)
+				require.Equal(t, testServiceAccountID, serviceAccount.ID)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := &serviceAccountsStore{
+				collection: testCase.collection,
+			}
+			serviceAccount, err :=
+				store.Get(context.Background(), testServiceAccountID)
+			testCase.assertions(serviceAccount, err)
+		})
+	}
+}
+
+func TestServiceAccountsLock(t *testing.T) {
+	const testServiceAccountID = "jarvis"
+
+	testCases := []struct {
+		name       string
+		collection mongodb.Collection
+		assertions func(error)
+	}{
+		{
+			name: "service account not found",
+			collection: &mockCollection{
+				UpdateOneFn: func(
+					context.Context,
+					interface{},
+					interface{},
+					...*options.UpdateOptions,
+				) (*mongo.UpdateResult, error) {
+					return &mongo.UpdateResult{MatchedCount: 0}, nil
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrNotFound{}, err)
+				require.Equal(t, "ServiceAccount", err.(*meta.ErrNotFound).Type)
+				require.Equal(t, testServiceAccountID, err.(*meta.ErrNotFound).ID)
+			},
+		},
+
+		{
+			name: "unanticipated error",
+			collection: &mockCollection{
+				UpdateOneFn: func(
+					context.Context,
+					interface{},
+					interface{},
+					...*options.UpdateOptions,
+				) (*mongo.UpdateResult, error) {
+					return nil, errors.New("something went wrong")
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error updating service account")
+			},
+		},
+
+		{
+			name: "success",
+			collection: &mockCollection{
+				UpdateOneFn: func(
+					context.Context,
+					interface{},
+					interface{},
+					...*options.UpdateOptions,
+				) (*mongo.UpdateResult, error) {
+					return &mongo.UpdateResult{MatchedCount: 1}, nil
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := &serviceAccountsStore{
+				collection: testCase.collection,
+			}
+			err := store.Lock(context.Background(), testServiceAccountID)
+			testCase.assertions(err)
+		})
+	}
+}
+
+func TestServiceAccountsUnLock(t *testing.T) {
+	const testServiceAccountID = "jarvis"
+
+	testCases := []struct {
+		name       string
+		collection mongodb.Collection
+		assertions func(error)
+	}{
+		{
+			name: "service account not found",
+			collection: &mockCollection{
+				UpdateOneFn: func(
+					context.Context,
+					interface{},
+					interface{},
+					...*options.UpdateOptions,
+				) (*mongo.UpdateResult, error) {
+					return &mongo.UpdateResult{MatchedCount: 0}, nil
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrNotFound{}, err)
+				require.Equal(t, "ServiceAccount", err.(*meta.ErrNotFound).Type)
+				require.Equal(t, testServiceAccountID, err.(*meta.ErrNotFound).ID)
+			},
+		},
+
+		{
+			name: "unanticipated error",
+			collection: &mockCollection{
+				UpdateOneFn: func(
+					context.Context,
+					interface{},
+					interface{},
+					...*options.UpdateOptions,
+				) (*mongo.UpdateResult, error) {
+					return nil, errors.New("something went wrong")
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error updating service account")
+			},
+		},
+
+		{
+			name: "success",
+			collection: &mockCollection{
+				UpdateOneFn: func(
+					context.Context,
+					interface{},
+					interface{},
+					...*options.UpdateOptions,
+				) (*mongo.UpdateResult, error) {
+					return &mongo.UpdateResult{MatchedCount: 1}, nil
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := &serviceAccountsStore{
+				collection: testCase.collection,
+			}
+			err := store.Unlock(
+				context.Background(),
+				testServiceAccountID,
+				"123456789", // New hashed-token
+			)
+			testCase.assertions(err)
+		})
+	}
+}

--- a/v2/apiserver/internal/authx/rest/service_account_endpoints.go
+++ b/v2/apiserver/internal/authx/rest/service_account_endpoints.go
@@ -1,0 +1,144 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/brigadecore/brigade/v2/apiserver/internal/authx"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/restmachinery"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
+	"github.com/gorilla/mux"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+type ServiceAccountEndpoints struct {
+	AuthFilter                 restmachinery.Filter
+	ServiceAccountSchemaLoader gojsonschema.JSONLoader
+	Service                    authx.ServiceAccountsService
+}
+
+func (s *ServiceAccountEndpoints) Register(router *mux.Router) {
+	// Create service account
+	router.HandleFunc(
+		"/v2/service-accounts",
+		s.AuthFilter.Decorate(s.create),
+	).Methods(http.MethodPost)
+
+	// List service accounts
+	router.HandleFunc(
+		"/v2/service-accounts",
+		s.AuthFilter.Decorate(s.list),
+	).Methods(http.MethodGet)
+
+	// Get service account
+	router.HandleFunc(
+		"/v2/service-accounts/{id}",
+		s.AuthFilter.Decorate(s.get),
+	).Methods(http.MethodGet)
+
+	// Lock service account
+	router.HandleFunc(
+		"/v2/service-accounts/{id}/lock",
+		s.AuthFilter.Decorate(s.lock),
+	).Methods(http.MethodPut)
+
+	// Unlock service account
+	router.HandleFunc(
+		"/v2/service-accounts/{id}/lock",
+		s.AuthFilter.Decorate(s.unlock),
+	).Methods(http.MethodDelete)
+}
+
+func (s *ServiceAccountEndpoints) create(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	serviceAccount := authx.ServiceAccount{}
+	restmachinery.ServeRequest(
+		restmachinery.InboundRequest{
+			W:                   w,
+			R:                   r,
+			ReqBodySchemaLoader: s.ServiceAccountSchemaLoader,
+			ReqBodyObj:          &serviceAccount,
+			EndpointLogic: func() (interface{}, error) {
+				return s.Service.Create(r.Context(), serviceAccount)
+			},
+			SuccessCode: http.StatusCreated,
+		},
+	)
+}
+
+func (s *ServiceAccountEndpoints) list(w http.ResponseWriter, r *http.Request) {
+	opts := meta.ListOptions{
+		Continue: r.URL.Query().Get("continue"),
+	}
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		var err error
+		if opts.Limit, err = strconv.ParseInt(limitStr, 10, 64); err != nil ||
+			opts.Limit < 1 || opts.Limit > 100 {
+			restmachinery.WriteAPIResponse(
+				w,
+				http.StatusBadRequest,
+				&meta.ErrBadRequest{
+					Reason: fmt.Sprintf(
+						`Invalid value %q for "limit" query parameter`,
+						limitStr,
+					),
+				},
+			)
+			return
+		}
+	}
+	restmachinery.ServeRequest(
+		restmachinery.InboundRequest{
+			W: w,
+			R: r,
+			EndpointLogic: func() (interface{}, error) {
+				return s.Service.List(r.Context(), opts)
+			},
+			SuccessCode: http.StatusOK,
+		},
+	)
+}
+
+func (s *ServiceAccountEndpoints) get(w http.ResponseWriter, r *http.Request) {
+	restmachinery.ServeRequest(
+		restmachinery.InboundRequest{
+			W: w,
+			R: r,
+			EndpointLogic: func() (interface{}, error) {
+				return s.Service.Get(r.Context(), mux.Vars(r)["id"])
+			},
+			SuccessCode: http.StatusOK,
+		})
+}
+
+func (s *ServiceAccountEndpoints) lock(w http.ResponseWriter, r *http.Request) {
+	restmachinery.ServeRequest(
+		restmachinery.InboundRequest{
+			W: w,
+			R: r,
+			EndpointLogic: func() (interface{}, error) {
+				return nil, s.Service.Lock(r.Context(), mux.Vars(r)["id"])
+			},
+			SuccessCode: http.StatusOK,
+		},
+	)
+}
+
+func (s *ServiceAccountEndpoints) unlock(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	restmachinery.ServeRequest(
+		restmachinery.InboundRequest{
+			W: w,
+			R: r,
+			EndpointLogic: func() (interface{}, error) {
+				return s.Service.Unlock(r.Context(), mux.Vars(r)["id"])
+			},
+			SuccessCode: http.StatusOK,
+		},
+	)
+}

--- a/v2/apiserver/internal/authx/service_accounts.go
+++ b/v2/apiserver/internal/authx/service_accounts.go
@@ -1,0 +1,219 @@
+package authx
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/crypto"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
+	"github.com/pkg/errors"
+)
+
+// ServiceAccount represents a non-human Brigade user, such as an Event
+// gateway.
+type ServiceAccount struct {
+	// ObjectMeta encapsulates ServiceAccount metadata.
+	meta.ObjectMeta `json:"metadata" bson:",inline"`
+	// Description is a natural language description of the ServiceAccount's
+	// purpose.
+	Description string `json:"description" bson:"description"`
+	// HashedToken is a secure, one-way hash of the ServiceAccount's token.
+	HashedToken string `json:"-" bson:"hashedToken"`
+	// Locked indicates when the ServiceAccount has been locked out of the system
+	// by an administrator. If this field's value is nil, the ServiceAccount is
+	// not locked.
+	Locked *time.Time `json:"locked,omitempty" bson:"locked"`
+}
+
+// MarshalJSON amends ServiceAccount instances with type metadata.
+func (s ServiceAccount) MarshalJSON() ([]byte, error) {
+	type Alias ServiceAccount
+	return json.Marshal(
+		struct {
+			meta.TypeMeta `json:",inline"`
+			Alias         `json:",inline"`
+		}{
+			TypeMeta: meta.TypeMeta{
+				APIVersion: meta.APIVersion,
+				Kind:       "ServiceAccount",
+			},
+			Alias: (Alias)(s),
+		},
+	)
+}
+
+// ServiceAccountList is an ordered and pageable list of ServiceAccounts.
+type ServiceAccountList struct {
+	// ListMeta contains list metadata.
+	meta.ListMeta `json:"metadata"`
+	// Items is a slice of ServiceAccounts.
+	Items []ServiceAccount `json:"items,omitempty"`
+}
+
+// MarshalJSON amends ServiceAccountList instances with type metadata.
+func (s ServiceAccountList) MarshalJSON() ([]byte, error) {
+	type Alias ServiceAccountList
+	return json.Marshal(
+		struct {
+			meta.TypeMeta `json:",inline"`
+			Alias         `json:",inline"`
+		}{
+			TypeMeta: meta.TypeMeta{
+				APIVersion: meta.APIVersion,
+				Kind:       "ServiceAccountList",
+			},
+			Alias: (Alias)(s),
+		},
+	)
+}
+
+// ServiceAccountsService is the specialized interface for managing
+// ServiceAccounts. It's decoupled from underlying technology choices (e.g. data
+// store) to keep business logic reusable and consistent while the underlying
+// tech stack remains free to change.
+type ServiceAccountsService interface {
+	// Create creates a new ServiceAccount. If a ServiceAccount having the same ID
+	// already exists, implementations MUST return a *meta.ErrConflict error.
+	Create(context.Context, ServiceAccount) (Token, error)
+	// List retrieves a ServiceAccountList.
+	List(context.Context, meta.ListOptions) (ServiceAccountList, error)
+	// Get retrieves a single ServiceAccount specified by its identifier. If the
+	// specified ServiceAccount does not exist, implementations MUST return a
+	// *meta.ErrNotFound error.
+	Get(context.Context, string) (ServiceAccount, error)
+
+	// Lock revokes system access for a single ServiceAccount specified by its
+	// identifier. If the specified ServiceAccount does not exist, implementations
+	// MUST return a *meta.ErrNotFound error.
+	Lock(context.Context, string) error
+	// Unlock restores system access for a single ServiceAccount (after presumably
+	// having been revoked) specified by its identifier. It returns a new Token.
+	// If the specified ServiceAccount does not exist, implementations MUST return
+	// a *meta.ErrNotFound error.
+	Unlock(context.Context, string) (Token, error)
+}
+
+type serviceAccountsService struct {
+	store ServiceAccountsStore
+}
+
+// NewServiceAccountsService returns a specialized interface for managing
+// ServiceAccounts.
+func NewServiceAccountsService(
+	store ServiceAccountsStore,
+) ServiceAccountsService {
+	return &serviceAccountsService{
+		store: store,
+	}
+}
+
+func (s *serviceAccountsService) Create(
+	ctx context.Context,
+	serviceAccount ServiceAccount,
+) (Token, error) {
+	token := Token{
+		Value: crypto.NewToken(256),
+	}
+	now := time.Now().UTC()
+	serviceAccount.Created = &now
+	serviceAccount.HashedToken = crypto.Hash("", token.Value)
+	if err := s.store.Create(ctx, serviceAccount); err != nil {
+		return token, errors.Wrapf(
+			err,
+			"error storing new service account %q",
+			serviceAccount.ID,
+		)
+	}
+	return token, nil
+}
+
+func (s *serviceAccountsService) List(
+	ctx context.Context,
+	opts meta.ListOptions,
+) (ServiceAccountList, error) {
+	if opts.Limit == 0 {
+		opts.Limit = 20
+	}
+	serviceAccounts, err := s.store.List(ctx, opts)
+	if err != nil {
+		return serviceAccounts,
+			errors.Wrap(err, "error retrieving service accounts from store")
+	}
+	return serviceAccounts, nil
+}
+
+func (s *serviceAccountsService) Get(
+	ctx context.Context,
+	id string,
+) (ServiceAccount, error) {
+	serviceAccount, err := s.store.Get(ctx, id)
+	if err != nil {
+		return serviceAccount, errors.Wrapf(
+			err,
+			"error retrieving service account %q from store",
+			id,
+		)
+	}
+	return serviceAccount, nil
+}
+
+func (s *serviceAccountsService) Lock(ctx context.Context, id string) error {
+	if err := s.store.Lock(ctx, id); err != nil {
+		return errors.Wrapf(
+			err,
+			"error locking service account %q in the store",
+			id,
+		)
+	}
+	return nil
+}
+
+func (s *serviceAccountsService) Unlock(
+	ctx context.Context,
+	id string,
+) (Token, error) {
+	newToken := Token{
+		Value: crypto.NewToken(256),
+	}
+	if err := s.store.Unlock(
+		ctx,
+		id,
+		crypto.Hash("", newToken.Value),
+	); err != nil {
+		return newToken, errors.Wrapf(
+			err,
+			"error unlocking service account %q in the store",
+			id,
+		)
+	}
+	return newToken, nil
+}
+
+// ServiceAccountsStore is an interface for components that implement
+// ServiceAccount persistence concerns.
+type ServiceAccountsStore interface {
+	// Create persists a new ServiceAccount in the underlying data store. If a
+	// ServiceAccount having the same ID already exists, implementations MUST
+	// return a *meta.ErrConflict error.
+	Create(context.Context, ServiceAccount) error
+	// List retrieves a ServiceAccountList from the underlying data store, with
+	// its Items (ServiceAccounts) ordered by ID.
+	List(context.Context, meta.ListOptions) (ServiceAccountList, error)
+	// Get retrieves a single ServiceAccount from the underlying data store. If
+	// the specified ServiceAccount does not exist, implementations MUST return
+	// a *meta.ErrNotFound error.
+	Get(context.Context, string) (ServiceAccount, error)
+
+	// Lock updates the specified ServiceAccount in the underlying data store to
+	// reflect that it has been locked out of the system. If the specified
+	// ServiceAccount does not exist, implementations MUST return a
+	// *meta.ErrNotFound error.
+	Lock(context.Context, string) error
+	// Unlock updates the specified ServiceAccount in the underlying data store to
+	// reflect that it's system access (after presumably having been revoked) has
+	// been restored. A hashed token must be provided as a replacement for the
+	// existing token. If the specified ServiceAccount does not exist,
+	// implementations MUST return a *meta.ErrNotFound error.
+	Unlock(ctx context.Context, id string, newHashedToken string) error
+}

--- a/v2/apiserver/internal/authx/service_accounts_test.go
+++ b/v2/apiserver/internal/authx/service_accounts_test.go
@@ -1,0 +1,294 @@
+package authx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceAccountMarshalJSON(t *testing.T) {
+	requireAPIVersionAndType(t, ServiceAccount{}, "ServiceAccount")
+}
+
+func TestServiceAccountListMarshalJSON(t *testing.T) {
+	requireAPIVersionAndType(t, ServiceAccountList{}, "ServiceAccountList")
+}
+
+func TestNewServiceAccountService(t *testing.T) {
+	store := &mockServiceAccountStore{}
+	svc := NewServiceAccountsService(store)
+	require.Same(t, store, svc.(*serviceAccountsService).store)
+}
+
+func TestServiceAccountsServiceCreate(t *testing.T) {
+	testCases := []struct {
+		name       string
+		service    ServiceAccountsService
+		assertions func(error)
+	}{
+		{
+			name: "error creating service account in store",
+			service: &serviceAccountsService{
+				store: &mockServiceAccountStore{
+					CreateFn: func(context.Context, ServiceAccount) error {
+						return errors.New("store error")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "store error")
+				require.Contains(t, err.Error(), "error storing new service account")
+			},
+		},
+		{
+			name: "success",
+			service: &serviceAccountsService{
+				store: &mockServiceAccountStore{
+					CreateFn: func(context.Context, ServiceAccount) error {
+						return nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := testCase.service.Create(context.Background(), ServiceAccount{})
+			testCase.assertions(err)
+		})
+	}
+}
+
+func TestServiceAccountsServiceList(t *testing.T) {
+	testCases := []struct {
+		name       string
+		service    ServiceAccountsService
+		assertions func(error)
+	}{
+		{
+			name: "error getting service accounts from store",
+			service: &serviceAccountsService{
+				store: &mockServiceAccountStore{
+					ListFn: func(
+						context.Context,
+						meta.ListOptions,
+					) (ServiceAccountList, error) {
+						return ServiceAccountList{},
+							errors.New("error listing service accounts")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "error listing service accounts")
+				require.Contains(
+					t,
+					err.Error(),
+					"error retrieving service accounts from store",
+				)
+			},
+		},
+		{
+			name: "success",
+			service: &serviceAccountsService{
+				store: &mockServiceAccountStore{
+					ListFn: func(
+						context.Context,
+						meta.ListOptions,
+					) (ServiceAccountList, error) {
+						return ServiceAccountList{}, nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err :=
+				testCase.service.List(context.Background(), meta.ListOptions{})
+			testCase.assertions(err)
+		})
+	}
+}
+
+type mockServiceAccountStore struct {
+	CreateFn func(context.Context, ServiceAccount) error
+	ListFn   func(context.Context, meta.ListOptions) (ServiceAccountList, error)
+	GetFn    func(context.Context, string) (ServiceAccount, error)
+	LockFn   func(context.Context, string) error
+	UnlockFn func(ctx context.Context, id string, newHashedToken string) error
+}
+
+func (m *mockServiceAccountStore) Create(
+	ctx context.Context,
+	serviceAccount ServiceAccount,
+) error {
+	return m.CreateFn(ctx, serviceAccount)
+}
+
+func (m *mockServiceAccountStore) List(
+	ctx context.Context,
+	opts meta.ListOptions,
+) (ServiceAccountList, error) {
+	return m.ListFn(ctx, opts)
+}
+
+func (m *mockServiceAccountStore) Get(
+	ctx context.Context,
+	id string,
+) (ServiceAccount, error) {
+	return m.GetFn(ctx, id)
+}
+
+func (m *mockServiceAccountStore) Lock(ctx context.Context, id string) error {
+	return m.LockFn(ctx, id)
+}
+
+func (m *mockServiceAccountStore) Unlock(
+	ctx context.Context,
+	id string,
+	newHashedToken string,
+) error {
+	return m.UnlockFn(ctx, id, newHashedToken)
+}
+
+func TestServiceAccountsServiceGet(t *testing.T) {
+	testCases := []struct {
+		name       string
+		service    ServiceAccountsService
+		assertions func(error)
+	}{
+		{
+			name: "error getting service account from store",
+			service: &serviceAccountsService{
+				store: &mockServiceAccountStore{
+					GetFn: func(context.Context, string) (ServiceAccount, error) {
+						return ServiceAccount{}, errors.New("error getting service account")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "error getting service account")
+				require.Contains(t, err.Error(), "error retrieving service account")
+			},
+		},
+		{
+			name: "success",
+			service: &serviceAccountsService{
+				store: &mockServiceAccountStore{
+					GetFn: func(context.Context, string) (ServiceAccount, error) {
+						return ServiceAccount{}, nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err :=
+				testCase.service.Get(context.Background(), "jarvis")
+			testCase.assertions(err)
+		})
+	}
+}
+
+func TestServiceAccountsLock(t *testing.T) {
+	testCases := []struct {
+		name       string
+		service    ServiceAccountsService
+		assertions func(error)
+	}{
+		{
+			name: "error updating service account in store",
+			service: &serviceAccountsService{
+				store: &mockServiceAccountStore{
+					LockFn: func(context.Context, string) error {
+						return errors.New("store error")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "store error")
+				require.Contains(t, err.Error(), "error locking service account")
+			},
+		},
+		{
+			name: "success",
+			service: &serviceAccountsService{
+				store: &mockServiceAccountStore{
+					LockFn: func(context.Context, string) error {
+						return nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.service.Lock(context.Background(), "jarvis")
+			testCase.assertions(err)
+		})
+	}
+}
+
+func TestServiceAccountsUnlock(t *testing.T) {
+	testCases := []struct {
+		name       string
+		service    ServiceAccountsService
+		assertions func(token Token, err error)
+	}{
+		{
+			name: "error updating service account in store",
+			service: &serviceAccountsService{
+				store: &mockServiceAccountStore{
+					UnlockFn: func(context.Context, string, string) error {
+						return errors.New("store error")
+					},
+				},
+			},
+			assertions: func(_ Token, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "store error")
+				require.Contains(t, err.Error(), "error unlocking service account")
+			},
+		},
+		{
+			name: "success",
+			service: &serviceAccountsService{
+				store: &mockServiceAccountStore{
+					UnlockFn: func(context.Context, string, string) error {
+						return nil
+					},
+				},
+			},
+			assertions: func(token Token, err error) {
+				require.NoError(t, err)
+				require.NotEmpty(t, token.Value)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			token, err := testCase.service.Unlock(context.Background(), "jarvis")
+			testCase.assertions(token, err)
+		})
+	}
+}

--- a/v2/apiserver/schemas/service-account.json
+++ b/v2/apiserver/schemas/service-account.json
@@ -1,0 +1,73 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "github.com/lovethedrake/drakecore/config.schema.json",
+
+	"definitions": {
+
+		"identifier": {
+			"type": "string",
+			"pattern": "^[a-z][a-z\\d-]*[a-z\\d]$",
+			"minLength": 3,
+			"maxLength": 50
+		},
+
+		"description": {
+			"type": "string",
+			"minLength": 3,
+			"maxLength": 80
+		},
+
+		"apiVersion": {
+			"type": "string",
+			"description": "The major version of the Brigade API with which this object conforms",
+			"enum": ["brigade.sh/v2"]
+		},
+
+		"kind": {
+			"type": "string",
+			"description": "The type of object represented by the document",
+			"enum": ["ServiceAccount"]
+		},
+
+		"objectMeta": {
+			"type": "object",
+			"description": "Service account metadata",
+			"required": ["id"],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"allOf": [
+						{
+							"$ref": "#/definitions/identifier"
+						}
+					],
+					"description": "A meaningful identifier for the service account"
+				}
+			}
+		}
+	},
+
+	"title": "ServiceAccount",
+	"type": "object",
+	"required": ["apiVersion", "kind", "metadata", "description"],
+	"additionalProperties": false,
+	"properties": {
+		"apiVersion": {
+			"$ref": "#/definitions/apiVersion"
+		},
+		"kind": {
+			"$ref": "#/definitions/kind"
+		},
+		"metadata": {
+			"$ref": "#/definitions/objectMeta"
+		},
+		"description": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/description"
+				}
+			],
+			"description": "A brief description of the service account"
+		}
+	}
+}

--- a/v2/cli/flags.go
+++ b/v2/cli/flags.go
@@ -7,6 +7,7 @@ const (
 	flagAnyPhase    = "any-phase"
 	flagBrowse      = "browse"
 	flagCanceled    = "canceled"
+	flagDescription = "description"
 	flagFailed      = "failed"
 	flagFile        = "file"
 	flagID          = "id"

--- a/v2/cli/main.go
+++ b/v2/cli/main.go
@@ -30,6 +30,7 @@ func main() {
 		loginCommand,
 		logoutCommand,
 		projectCommand,
+		serviceAccountCommand,
 	}
 	fmt.Println()
 	if err := app.RunContext(signals.Context(), os.Args); err != nil {

--- a/v2/cli/service_account_commands.go
+++ b/v2/cli/service_account_commands.go
@@ -158,7 +158,7 @@ func serviceAccountList(c *cli.Context) error {
 		}
 
 		switch strings.ToLower(output) {
-		case "table":
+		case flagOutputTable:
 			table := uitable.New()
 			table.AddRow("ID", "DESCRIPTION", "AGE", "LOCKED?")
 			for _, serviceAccounts := range serviceAccounts.Items {
@@ -171,7 +171,7 @@ func serviceAccountList(c *cli.Context) error {
 			}
 			fmt.Println(table)
 
-		case "yaml":
+		case flagOutputYAML:
 			yamlBytes, err := yaml.Marshal(serviceAccounts)
 			if err != nil {
 				return errors.Wrap(
@@ -181,7 +181,7 @@ func serviceAccountList(c *cli.Context) error {
 			}
 			fmt.Println(string(yamlBytes))
 
-		case "json":
+		case flagOutputJSON:
 			prettyJSON, err := json.MarshalIndent(serviceAccounts, "", "  ")
 			if err != nil {
 				return errors.Wrap(
@@ -234,7 +234,7 @@ func serviceAccountGet(c *cli.Context) error {
 	}
 
 	switch strings.ToLower(output) {
-	case "table":
+	case flagOutputTable:
 		table := uitable.New()
 		table.AddRow("ID", "DESCRIPTION", "AGE", "LOCKED?")
 		var age string
@@ -249,7 +249,7 @@ func serviceAccountGet(c *cli.Context) error {
 		)
 		fmt.Println(table)
 
-	case "yaml":
+	case flagOutputYAML:
 		yamlBytes, err := yaml.Marshal(serviceAccount)
 		if err != nil {
 			return errors.Wrap(
@@ -259,7 +259,7 @@ func serviceAccountGet(c *cli.Context) error {
 		}
 		fmt.Println(string(yamlBytes))
 
-	case "json":
+	case flagOutputJSON:
 		prettyJSON, err := json.MarshalIndent(serviceAccount, "", "  ")
 		if err != nil {
 			return errors.Wrap(

--- a/v2/cli/service_account_commands.go
+++ b/v2/cli/service_account_commands.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/brigadecore/brigade/sdk/v2/authx"
+	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/ghodss/yaml"
+	"github.com/gosuri/uitable"
+	"golang.org/x/crypto/ssh/terminal"
+	"k8s.io/apimachinery/pkg/util/duration"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+)
+
+var serviceAccountCommand = &cli.Command{
+	Name:    "service-account",
+	Aliases: []string{"sa"},
+	Usage:   "Manage service accounts",
+	Subcommands: []*cli.Command{
+		{
+			Name:  "create",
+			Usage: "Create a new service account",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:    flagID,
+					Aliases: []string{"i"},
+					Usage: "Create a service account with the specified ID " +
+						"(required)",
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:    flagDescription,
+					Aliases: []string{"d"},
+					Usage: "Create a service account with the specified " +
+						"description (required)",
+					Required: true,
+				},
+			},
+			Action: serviceAccountCreate,
+		},
+		{
+			Name:  "get",
+			Usage: "Retrieve a service account",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     flagID,
+					Aliases:  []string{"i"},
+					Usage:    "Retrieve the specified service account (required)",
+					Required: true,
+				},
+				cliFlagOutput,
+			},
+			Action: serviceAccountGet,
+		},
+		{
+			Name:    "list",
+			Aliases: []string{"ls"},
+			Usage:   "List service accounts",
+			Flags: []cli.Flag{
+				cliFlagOutput,
+			},
+			Action: serviceAccountList,
+		},
+		{
+			Name:  "lock",
+			Usage: "Lock a service account out of Brigade",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     flagID,
+					Aliases:  []string{"i"},
+					Usage:    "Lock the specified service account (required)",
+					Required: true,
+				},
+			},
+			Action: serviceAccountLock,
+		},
+		{
+			Name:  "unlock",
+			Usage: "Restore a service account's access to Brigade",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     flagID,
+					Aliases:  []string{"i"},
+					Usage:    "Unlock the specified service account (required)",
+					Required: true,
+				},
+			},
+			Action: serviceAccountUnlock,
+		},
+	},
+}
+
+func serviceAccountCreate(c *cli.Context) error {
+	description := c.String(flagDescription)
+	id := c.String(flagID)
+
+	client, err := getClient(c)
+	if err != nil {
+		return err
+	}
+
+	token, err := client.Authx().ServiceAccounts().Create(
+		c.Context,
+		authx.ServiceAccount{
+			ObjectMeta: meta.ObjectMeta{
+				ID: id,
+			},
+			Description: description,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("\nService account %q created with token:\n", id)
+	fmt.Printf("\n\t%s\n", token.Value)
+	fmt.Println(
+		"\nStore this token someplace secure NOW. It cannot be retrieved " +
+			"later through any other means.",
+	)
+
+	return nil
+}
+
+func serviceAccountList(c *cli.Context) error {
+	output := c.String(flagOutput)
+
+	if err := validateOutputFormat(output); err != nil {
+		return err
+	}
+
+	client, err := getClient(c)
+	if err != nil {
+		return err
+	}
+
+	opts := meta.ListOptions{}
+
+	for {
+		serviceAccounts, err := client.Authx().ServiceAccounts().List(
+			c.Context,
+			nil,
+			&opts,
+		)
+		if err != nil {
+			return err
+		}
+
+		if len(serviceAccounts.Items) == 0 {
+			fmt.Println("No service accounts found.")
+			return nil
+		}
+
+		switch strings.ToLower(output) {
+		case "table":
+			table := uitable.New()
+			table.AddRow("ID", "DESCRIPTION", "AGE", "LOCKED?")
+			for _, serviceAccounts := range serviceAccounts.Items {
+				table.AddRow(
+					serviceAccounts.ID,
+					serviceAccounts.Description,
+					duration.ShortHumanDuration(time.Since(*serviceAccounts.Created)),
+					serviceAccounts.Locked != nil,
+				)
+			}
+			fmt.Println(table)
+
+		case "yaml":
+			yamlBytes, err := yaml.Marshal(serviceAccounts)
+			if err != nil {
+				return errors.Wrap(
+					err,
+					"error formatting output from get service accounts operation",
+				)
+			}
+			fmt.Println(string(yamlBytes))
+
+		case "json":
+			prettyJSON, err := json.MarshalIndent(serviceAccounts, "", "  ")
+			if err != nil {
+				return errors.Wrap(
+					err,
+					"error formatting output from get service accounts operation",
+				)
+			}
+			fmt.Println(string(prettyJSON))
+		}
+
+		if serviceAccounts.RemainingItemCount < 1 ||
+			serviceAccounts.Continue == "" {
+			break
+		}
+
+		// Exit after one page of output if this isn't a terminal
+		if !terminal.IsTerminal(int(os.Stdout.Fd())) {
+			break
+		}
+
+		if shouldContinue, err :=
+			shouldContinue(serviceAccounts.RemainingItemCount); err != nil {
+			return err
+		} else if !shouldContinue {
+			break
+		}
+
+		opts.Continue = serviceAccounts.Continue
+	}
+
+	return nil
+}
+
+func serviceAccountGet(c *cli.Context) error {
+	id := c.String(flagID)
+	output := c.String(flagOutput)
+
+	if err := validateOutputFormat(output); err != nil {
+		return err
+	}
+
+	client, err := getClient(c)
+	if err != nil {
+		return err
+	}
+
+	serviceAccount, err := client.Authx().ServiceAccounts().Get(c.Context, id)
+	if err != nil {
+		return err
+	}
+
+	switch strings.ToLower(output) {
+	case "table":
+		table := uitable.New()
+		table.AddRow("ID", "DESCRIPTION", "AGE", "LOCKED?")
+		var age string
+		if serviceAccount.Created != nil {
+			age = duration.ShortHumanDuration(time.Since(*serviceAccount.Created))
+		}
+		table.AddRow(
+			serviceAccount.ID,
+			serviceAccount.Description,
+			age,
+			serviceAccount.Locked != nil,
+		)
+		fmt.Println(table)
+
+	case "yaml":
+		yamlBytes, err := yaml.Marshal(serviceAccount)
+		if err != nil {
+			return errors.Wrap(
+				err,
+				"error formatting output from get service account operation",
+			)
+		}
+		fmt.Println(string(yamlBytes))
+
+	case "json":
+		prettyJSON, err := json.MarshalIndent(serviceAccount, "", "  ")
+		if err != nil {
+			return errors.Wrap(
+				err,
+				"error formatting output from get service account operation",
+			)
+		}
+		fmt.Println(string(prettyJSON))
+	}
+
+	return nil
+}
+
+func serviceAccountLock(c *cli.Context) error {
+	id := c.String(flagID)
+
+	client, err := getClient(c)
+	if err != nil {
+		return err
+	}
+
+	if err := client.Authx().ServiceAccounts().Lock(c.Context, id); err != nil {
+		return err
+	}
+
+	fmt.Printf("Service account %q locked.\n", id)
+
+	return nil
+}
+
+func serviceAccountUnlock(c *cli.Context) error {
+	id := c.String(flagID)
+
+	client, err := getClient(c)
+	if err != nil {
+		return err
+	}
+
+	token, err := client.Authx().ServiceAccounts().Unlock(c.Context, id)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf(
+		"\nService account %q unlocked and a new token has been issued:\n",
+		id,
+	)
+	fmt.Printf("\n\t%s\n", token.Value)
+	fmt.Println(
+		"\nStore this token someplace secure NOW. It cannot be retrieved " +
+			"later through any other means.",
+	)
+
+	return nil
+}


### PR DESCRIPTION
This adds create, list, lock, and unlock for service accounts.

Note the tokens that get generated for service accounts won't be usable yet. To keep this PR on the smaller side, the modifications to authz required in order to honor those tokens will be in a separate PR.