### PR TITLE
add helper for detecting mongodb duplicate key errors

### DIFF
--- a/v2/apiserver/internal/lib/mongodb/errors.go
+++ b/v2/apiserver/internal/lib/mongodb/errors.go
@@ -1,0 +1,15 @@
+package mongodb
+
+import (
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// IsDuplicateKeyError returns a bool indicating whether the provided error is a
+// MongoDB duplicate key error.
+func IsDuplicateKeyError(err error) bool {
+	if writeException, ok := err.(mongo.WriteException); ok {
+		return len(writeException.WriteErrors) == 1 &&
+			writeException.WriteErrors[0].Code == 11000
+	}
+	return false
+}

--- a/v2/apiserver/internal/lib/mongodb/errors_test.go
+++ b/v2/apiserver/internal/lib/mongodb/errors_test.go
@@ -1,0 +1,45 @@
+package mongodb
+
+import (
+	"errors"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestIsDuplicateKeyError(t *testing.T) {
+	testCases := []struct {
+		name                string
+		err                 error
+		isDuplicateKeyError bool
+	}{
+		{
+			name:                "is not write exception",
+			err:                 errors.New("some random error"),
+			isDuplicateKeyError: false,
+		},
+		{
+			name: "has wrong error code",
+			err: mongo.WriteErrors{
+				mongo.WriteError{
+					Code: 42,
+				},
+			},
+			isDuplicateKeyError: false,
+		},
+		{
+			name: "is a legitimate duplicate key error",
+			err: mongo.WriteErrors{
+				mongo.WriteError{
+					Code: 11000,
+				},
+			},
+			isDuplicateKeyError: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+		})
+	}
+}


### PR DESCRIPTION
This PR is in response to [this thread](https://github.com/brigadecore/brigade/pull/1142#discussion_r510449498) in #1142.

I'd like to get this in before #1142 so #1142 can be amended to use this.

Also, while working on this PR I noticed that we probably _shouldn't_ be checking for duplicate key errors in the first place when creating users. New users are created exclusively by the system so the possibility of a duplicate key error _should_ be non-existent and if it _were_ to occur, it should be treated as an internal server error instead of a conflict, since conflicts ultimately surface as _user errors_. I will address that in a follow-up PR...

That takes the number of locations in the code where this helper is currently useful down to just one-- two if you count pending work in #1142. This is still worth doing because there _will_ be more code imported from the prototype down the road where this helper will come in handy.