### PR TITLE
fix token issue in oidc auth

### DIFF
--- a/v2/apiserver/internal/authx/sessions.go
+++ b/v2/apiserver/internal/authx/sessions.go
@@ -360,7 +360,7 @@ func (s *sessionsService) CreateUserSession(
 		)
 	}
 	return OIDCAuthDetails{
-		Token:   crypto.NewToken(256),
+		Token:   token,
 		AuthURL: s.config.OAuth2Helper.AuthCodeURL(oauth2State),
 	}, nil
 }


### PR DESCRIPTION
When creating a new session for a user who has authenticated using OpenID connect, there has been a discrepancy between the token returned to the client and the token that is hashed and stored in the database. This PR corrects that.