### PR TITLE
enable service accounts to authenticate

### DIFF
--- a/v2/apiserver/main.go
+++ b/v2/apiserver/main.go
@@ -111,6 +111,7 @@ func main() {
 			log.Fatal(err)
 		}
 		authFilter := authn.NewTokenAuthFilter(
+			serviceAccountsService.GetByToken,
 			sessionsService.GetByToken,
 			&authFilterConfig,
 		)


### PR DESCRIPTION
This is a follow-up to #1142, which added service accounts to Brigade v2. This PR amends the token auth filter to permit service accounts to authenticate.

Note, this PR also updates all tests for the auth filter to be table-driven since they weren't previously.