### PR TITLE
Add abstraction for writing to a messaging system

### DIFF
--- a/charts/brigade/templates/_helpers.tpl
+++ b/charts/brigade/templates/_helpers.tpl
@@ -24,6 +24,10 @@ If release name contains chart name it will be used as a full name.
 {{ include "brigade.fullname" . | printf "%s-apiserver" }}
 {{- end -}}
 
+{{- define "brigade.artemis.fullname" -}}
+{{ include "brigade.fullname" . | printf "%s-artemis" }}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}
@@ -53,6 +57,20 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "brigade.apiserver.labels" -}}
 app.kubernetes.io/component: apiserver
+{{- end -}}
+
+{{- define "brigade.artemis.labels" -}}
+app.kubernetes.io/component: artemis
+{{- end -}}
+
+{{- define "brigade.artemis.primary.labels" -}}
+{{ include "brigade.artemis.labels" . }}
+app.kubernetes.io/role: primary
+{{- end -}}
+
+{{- define "brigade.artemis.secondary.labels" -}}
+{{ include "brigade.artemis.labels" . }}
+app.kubernetes.io/role: secondary
 {{- end -}}
 
 {{- define "call-nested" }}

--- a/charts/brigade/templates/apiserver/deployment.yaml
+++ b/charts/brigade/templates/apiserver/deployment.yaml
@@ -97,6 +97,15 @@ spec:
         - name: DATABASE_NAME
           value: {{ .Values.externalMongodb.database }}
         {{- end }}
+        - name: AMQP_ADDRESS
+          value: amqp://{{ include "brigade.artemis.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5672
+        - name: AMQP_USERNAME
+          value: {{ .Values.artemis.username }}
+        - name: AMQP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "brigade.artemis.fullname" . }}
+              key: password
         {{- if .Values.apiserver.tls.enabled }}
         volumeMounts:
         - name: cert

--- a/charts/brigade/templates/artemis/common-config.yaml
+++ b/charts/brigade/templates/artemis/common-config.yaml
@@ -1,0 +1,93 @@
+{{- $root := . }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "brigade.artemis.fullname" . }}-common-config
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.artemis.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  common-config-template.xml: |-
+    <configuration xmlns="urn:activemq" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+      <core xmlns="urn:activemq:core" xsi:schemaLocation="urn:activemq:core ">
+
+        <cluster-user>exampleUser</cluster-user>
+        <cluster-password>secret</cluster-password>
+
+        <connectors>
+          {{- range $i,$t := until (int .Values.artemis.replicas) }}
+          {{- if not $root.Values.artemis.ha.enabled }}
+          <connector name="{{ include "brigade.artemis.fullname" $root }}-{{ $i }}">
+            tcp://{{ include "brigade.artemis.fullname" $root }}-{{ $i }}.{{ include "brigade.artemis.fullname" $root }}-internal.{{ $root.Release.Namespace }}.svc.cluster.local:61616
+          </connector>
+          {{- else }}
+          {{- range tuple "primary" "secondary" }}
+          <connector name="{{ include "brigade.artemis.fullname" $root }}-{{ . }}-{{ $i }}">
+            tcp://{{ include "brigade.artemis.fullname" $root }}-{{ . }}-{{ $i }}.{{ include "brigade.artemis.fullname" $root }}-{{ . }}.{{ $root.Release.Namespace }}.svc.cluster.local:61616
+          </connector>
+          {{- end }}
+          {{- end }}
+          {{- end }}
+        </connectors>
+
+        <cluster-connections>
+          <cluster-connection name="{{ include "brigade.artemis.fullname" . }}">
+            <connector-ref>netty-connector</connector-ref>
+            <retry-interval>500</retry-interval>
+            <retry-interval-multiplier>1.1</retry-interval-multiplier>
+            <max-retry-interval>5000</max-retry-interval>
+            <initial-connect-attempts>-1</initial-connect-attempts>
+            <reconnect-attempts>-1</reconnect-attempts>
+
+            <message-load-balancing>ON_DEMAND</message-load-balancing>
+            <max-hops>1</max-hops>
+
+            <static-connectors>
+            {{- range $i,$t := until (int .Values.artemis.replicas) }}
+              {{- if not $root.Values.artemis.ha.enabled }}
+              <connector-ref>{{ include "brigade.artemis.fullname" $root }}-{{ $i }}</connector-ref>
+              {{- else }}
+              {{- range tuple "primary" "secondary" }}
+              <connector-ref>{{ include "brigade.artemis.fullname" $root }}-{{ . }}-{{ $i }}</connector-ref>
+              {{- end }}
+              {{- end }}
+            {{- end }}
+            </static-connectors>
+
+          </cluster-connection>
+        </cluster-connections>
+
+        <address-settings>
+          <address-setting match="workers.#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <default-queue-routing-type>ANYCAST</default-queue-routing-type>
+            <auto-create-addresses>true</auto-create-addresses>
+            <default-address-routing-type>ANYCAST</default-address-routing-type>
+            <redistribution-delay>0</redistribution-delay>
+          </address-setting>
+          <address-setting match="jobs.#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <default-queue-routing-type>ANYCAST</default-queue-routing-type>
+            <auto-create-addresses>true</auto-create-addresses>
+            <default-address-routing-type>ANYCAST</default-address-routing-type>
+            <redistribution-delay>0</redistribution-delay>
+          </address-setting>
+        </address-settings>
+
+      </core>
+    </configuration>

--- a/charts/brigade/templates/artemis/config.yaml
+++ b/charts/brigade/templates/artemis/config.yaml
@@ -1,0 +1,24 @@
+{{- if not .Values.artemis.ha.enabled }}
+{{- $root := . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "brigade.artemis.fullname" . }}
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.artemis.labels" . | nindent 4 }}
+data:
+
+  configure-node.sh: |-
+    set -e
+
+    echo Copying common configuration
+    cp /opt/common-config/common-config-template.xml /var/lib/artemis/etc-override/broker-10.xml
+
+    echo Setting the connector-ref to ${HOSTNAME}
+          xmlstarlet ed -L \
+            -N activemq="urn:activemq" \
+            -N core="urn:activemq:core" \
+            -u "/activemq:configuration/core:core/core:cluster-connections/core:cluster-connection[@name='{{ include "brigade.artemis.fullname" $root }}']/core:connector-ref" \
+            -v "${HOSTNAME}" /var/lib/artemis/etc-override/broker-10.xml
+{{- end }}

--- a/charts/brigade/templates/artemis/internal-service.yaml
+++ b/charts/brigade/templates/artemis/internal-service.yaml
@@ -1,0 +1,21 @@
+{{- if not .Values.artemis.ha.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "brigade.artemis.fullname" . }}-internal
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.artemis.labels" . | nindent 4 }}
+  annotations:
+    # Make sure DNS is resolvable during initialization.
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None
+  selector:
+    {{- include "brigade.selectorLabels" . | nindent 8 }}
+    {{- include "brigade.artemis.labels" . | nindent 8 }}
+  ports:
+  - name: core
+    port: 61616
+    targetPort: core
+{{- end }}

--- a/charts/brigade/templates/artemis/primary-config.yaml
+++ b/charts/brigade/templates/artemis/primary-config.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.artemis.ha.enabled }}
+{{- $root := . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "brigade.artemis.fullname" . }}-primary
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.artemis.primary.labels" . | nindent 4 }}
+data:
+
+  primary-config-template.xml: |
+    <configuration xmlns="urn:activemq" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+      <core xmlns="urn:activemq:core" xsi:schemaLocation="urn:activemq:core ">
+
+        <ha-policy>
+          <replication>
+            <master>
+              <group-name>to-be-set-by-configure-primary-node.sh</group-name>
+              <check-for-live-server>true</check-for-live-server>
+            </master>
+          </replication>
+        </ha-policy>
+
+      </core>
+    </configuration>
+  
+  configure-primary-node.sh: |-
+    set -e
+    echo Copying common configuration
+    cp /opt/common-config/common-config-template.xml /var/lib/artemis/etc-override/broker-10.xml
+
+    echo Assigning node as primary
+    cp /opt/primary-config/primary-config-template.xml /var/lib/artemis/etc-override/broker-20.xml
+
+    GROUPNAME=$(echo ${HOSTNAME} | sed -re 's/(-primary|-secondary)//')
+    echo Setting the group-name for primary to ${GROUPNAME}
+    xmlstarlet ed -L \
+    -N activemq="urn:activemq" \
+    -N core="urn:activemq:core" \
+    -u "/activemq:configuration/core:core/core:ha-policy/core:replication/core:master/core:group-name" \
+    -v "${GROUPNAME}" /var/lib/artemis/etc-override/broker-20.xml
+
+    echo Setting the connector-ref to ${HOSTNAME}
+          xmlstarlet ed -L \
+            -N activemq="urn:activemq" \
+            -N core="urn:activemq:core" \
+            -u "/activemq:configuration/core:core/core:cluster-connections/core:cluster-connection[@name='{{ include "brigade.artemis.fullname" $root }}']/core:connector-ref" \
+            -v "${HOSTNAME}" /var/lib/artemis/etc-override/broker-10.xml
+{{- end }}

--- a/charts/brigade/templates/artemis/primary-service.yaml
+++ b/charts/brigade/templates/artemis/primary-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.artemis.ha.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "brigade.artemis.fullname" . }}-primary
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.artemis.primary.labels" . | nindent 4 }}
+  annotations:
+    # Make sure DNS is resolvable during initialization.
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None
+  selector:
+    {{- include "brigade.selectorLabels" . | nindent 8 }}
+    {{- include "brigade.artemis.primary.labels" . | nindent 8 }}
+  ports:
+  - name: core
+    port: 61616
+    targetPort: core
+{{- end }}

--- a/charts/brigade/templates/artemis/primary-stateful-set.yaml
+++ b/charts/brigade/templates/artemis/primary-stateful-set.yaml
@@ -1,0 +1,126 @@
+{{- if .Values.artemis.ha.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "brigade.artemis.fullname" . }}-primary
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.artemis.primary.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "brigade.artemis.fullname" . }}-primary
+  replicas: {{ .Values.artemis.replicas }}
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      {{- include "brigade.selectorLabels" . | nindent 6 }}
+      {{- include "brigade.artemis.primary.labels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "brigade.selectorLabels" . | nindent 8 }}
+        {{- include "brigade.artemis.primary.labels" . | nindent 8 }}
+      annotations:
+        checksum/common-config: {{ include (print $.Template.BasePath "/artemis/common-config.yaml") . | sha256sum }}
+        checksum/primary-config: {{ include (print $.Template.BasePath "/artemis/primary-config.yaml") . | sha256sum }}
+    spec:
+      affinity:
+        podAntiAffinity:
+          {{- if eq .Values.artemis.ha.antiAffinity "hard" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                {{- include "brigade.selectorLabels" . | nindent 16 }}
+                {{- include "brigade.artemis.secondary.labels" . | nindent 16 }}
+          {{- else if eq .Values.artemis.ha.antiAffinity "soft" }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 5
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  {{- include "brigade.selectorLabels" . | nindent 18 }}
+                  {{- include "brigade.artemis.secondary.labels" . | nindent 18 }}
+          {{- end }}
+      initContainers:
+      - name: config
+        image: {{ .Values.artemis.image.repository }}:{{ .Values.artemis.image.tag }}
+        imagePullPolicy: {{ .Values.artemis.image.pullPolicy }}
+        command: ["/bin/sh", "/opt/primary-config/configure-primary-node.sh"]
+        volumeMounts:
+          - name: common-config
+            mountPath: /opt/common-config
+          - name: primary-config
+            mountPath: /opt/primary-config
+          - name: config-overrides
+            mountPath: /var/lib/artemis/etc-override
+      containers:
+      - name: artemis
+        image: {{ .Values.artemis.image.repository }}:{{ .Values.artemis.image.tag }}
+        imagePullPolicy: {{ .Values.artemis.image.pullPolicy }}
+        resources:
+          {{- toYaml .Values.artemis.resources | indent 10 }}
+        env:
+        - name: ARTEMIS_USERNAME
+          value: {{ .Values.artemis.username }}
+        - name: ARTEMIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "brigade.artemis.fullname" . }}
+              key: password
+        - name: ARTEMIS_PERF_JOURNAL
+          value: {{ .Values.artemis.persistence.testJournalPerformance }}
+        ports:
+        - name: http
+          containerPort: 8161
+        - name: core
+          containerPort: 61616
+        - name: amqp
+          containerPort: 5672
+        livenessProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: core
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        volumeMounts:
+        - name: config-overrides
+          mountPath: /var/lib/artemis/etc-override
+        - name: data
+          mountPath: /var/lib/artemis/data
+      volumes:
+      - name: config-overrides
+        emptyDir: {}
+      - name: common-config
+        secret:
+          secretName: {{ include "brigade.artemis.fullname" . }}-common-config
+      - name: primary-config
+        configMap:
+          name: {{ include "brigade.artemis.fullname" . }}-primary
+      {{- if not .Values.artemis.persistence.enabled }}
+      - name: data
+        emptyDir: {}
+      {{- end }}
+      {{- if .Values.artemis.persistence.enabled }}
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsNonRoot: true
+      {{- end }}
+  {{- if .Values.artemis.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      storageClassName: {{ .Values.artemis.persistence.storageClass }}
+      accessModes: [ {{ .Values.artemis.persistence.accessMode }} ]
+      resources:
+        requests:
+          storage: {{ .Values.artemis.persistence.size }}
+  {{- end }}
+{{- end }}

--- a/charts/brigade/templates/artemis/secondary-config.yaml
+++ b/charts/brigade/templates/artemis/secondary-config.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.artemis.ha.enabled }}
+{{- $root := . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "brigade.artemis.fullname" . }}-secondary
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.artemis.secondary.labels" . | nindent 4 }}
+data:
+
+  secondary-config-template.xml: |
+    <configuration xmlns="urn:activemq" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+      <core xmlns="urn:activemq:core" xsi:schemaLocation="urn:activemq:core ">
+
+        <ha-policy>
+          <replication>
+            <slave>
+              <group-name>to-be-set-by-configure-secondary-node.sh</group-name>
+              <allow-failback>true</allow-failback>
+            </slave>
+          </replication>
+        </ha-policy>
+
+      </core>
+    </configuration>
+
+  configure-secondary-node.sh: |-
+    set -e
+    echo Copying common configuration
+    cp /opt/common-config/common-config-template.xml /var/lib/artemis/etc-override/broker-10.xml
+
+    echo Assigning node as secondary
+    cp /opt/secondary-config/secondary-config-template.xml /var/lib/artemis/etc-override/broker-20.xml 
+
+    GROUPNAME=$(echo ${HOSTNAME} | sed -re 's/(-primary|-secondary)//')
+    echo Setting the group-name for secondary to ${GROUPNAME}
+    xmlstarlet ed -L \
+    -N activemq="urn:activemq" \
+    -N core="urn:activemq:core" \
+    -u "/activemq:configuration/core:core/core:ha-policy/core:replication/core:slave/core:group-name" \
+    -v "${GROUPNAME}" /var/lib/artemis/etc-override/broker-20.xml
+
+    echo Setting the connector-ref to ${HOSTNAME}
+    xmlstarlet ed -L \
+    -N activemq="urn:activemq" \
+    -N core="urn:activemq:core" \
+    -u "/activemq:configuration/core:core/core:cluster-connections/core:cluster-connection[@name='{{ include "brigade.artemis.fullname" $root }}']/core:connector-ref" \
+    -v "${HOSTNAME}" /var/lib/artemis/etc-override/broker-10.xml
+{{- end }}

--- a/charts/brigade/templates/artemis/secondary-service.yaml
+++ b/charts/brigade/templates/artemis/secondary-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.artemis.ha.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "brigade.artemis.fullname" . }}-secondary
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.artemis.secondary.labels" . | nindent 4 }}
+  annotations:
+    # Make sure DNS is resolvable during initialization.
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  clusterIP: None
+  selector:
+    {{- include "brigade.selectorLabels" . | nindent 8 }}
+    {{- include "brigade.artemis.secondary.labels" . | nindent 8 }}
+  ports:
+  - name: core
+    port: 61616
+    targetPort: core
+{{- end }}

--- a/charts/brigade/templates/artemis/secondary-stateful-set.yaml
+++ b/charts/brigade/templates/artemis/secondary-stateful-set.yaml
@@ -1,0 +1,126 @@
+{{- if .Values.artemis.ha.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "brigade.artemis.fullname" . }}-secondary
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.artemis.secondary.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "brigade.artemis.fullname" . }}-secondary
+  replicas: {{ .Values.artemis.replicas }}
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      {{- include "brigade.selectorLabels" . | nindent 6 }}
+      {{- include "brigade.artemis.secondary.labels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "brigade.selectorLabels" . | nindent 8 }}
+        {{- include "brigade.artemis.secondary.labels" . | nindent 8 }}
+      annotations:
+        checksum/common-config: {{ include (print $.Template.BasePath "/artemis/common-config.yaml") . | sha256sum }}
+        checksum/secondary-config: {{ include (print $.Template.BasePath "/artemis/secondary-config.yaml") . | sha256sum }}
+    spec:
+      affinity:
+        podAntiAffinity:
+          {{- if eq .Values.artemis.ha.antiAffinity "hard" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                {{- include "brigade.selectorLabels" . | nindent 16 }}
+                {{- include "brigade.artemis.primary.labels" . | nindent 16 }}
+          {{- else if eq .Values.artemis.ha.antiAffinity "soft" }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 5
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  {{- include "brigade.selectorLabels" . | nindent 18 }}
+                  {{- include "brigade.artemis.primary.labels" . | nindent 18 }}
+          {{- end }}
+      initContainers:
+      - name: config
+        image: {{ .Values.artemis.image.repository }}:{{ .Values.artemis.image.tag }}
+        imagePullPolicy: {{ .Values.artemis.image.pullPolicy }}
+        command: ["/bin/sh", "/opt/secondary-config/configure-secondary-node.sh"]
+        volumeMounts:
+          - name: common-config
+            mountPath: /opt/common-config
+          - name: secondary-config
+            mountPath: /opt/secondary-config
+          - name: config-overrides
+            mountPath: /var/lib/artemis/etc-override
+      containers:
+      - name: artemis
+        image: {{ .Values.artemis.image.repository }}:{{ .Values.artemis.image.tag }}
+        imagePullPolicy: {{ .Values.artemis.image.pullPolicy }}
+        resources:
+          {{- toYaml .Values.artemis.resources | indent 10 }}
+        env:
+        - name: ARTEMIS_USERNAME
+          value: {{ .Values.artemis.username }}
+        - name: ARTEMIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "brigade.artemis.fullname" . }}
+              key: password
+        - name: ARTEMIS_PERF_JOURNAL
+          value: {{ .Values.artemis.persistence.testJournalPerformance }}
+        ports:
+        - name: http
+          containerPort: 8161
+        - name: core
+          containerPort: 61616
+        - name: amqp
+          containerPort: 5672
+        livenessProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: core
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        volumeMounts:
+        - name: config-overrides
+          mountPath: /var/lib/artemis/etc-override
+        - name: data
+          mountPath: /var/lib/artemis/data
+      volumes:
+      - name: config-overrides
+        emptyDir: {}
+      - name: common-config
+        secret:
+          secretName: {{ include "brigade.artemis.fullname" . }}-common-config
+      - name: secondary-config
+        configMap:
+          name: {{ include "brigade.artemis.fullname" . }}-secondary
+      {{- if not .Values.artemis.persistence.enabled }}
+      - name: data
+        emptyDir: {}
+      {{- end }}
+      {{- if .Values.artemis.persistence.enabled }}
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsNonRoot: true
+      {{- end }}
+  {{- if .Values.artemis.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      storageClassName: {{ .Values.artemis.persistence.storageClass }}
+      accessModes: [ {{ .Values.artemis.persistence.accessMode }} ]
+      resources:
+        requests:
+          storage: {{ .Values.artemis.persistence.size }}
+  {{- end}}
+{{- end }}

--- a/charts/brigade/templates/artemis/secrets.yaml
+++ b/charts/brigade/templates/artemis/secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "brigade.artemis.fullname" . }}
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.artemis.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if .Values.artemis.password }}
+  password:  {{ quote .Values.artemis.password }}
+  {{- else }}
+  password: {{ randAlphaNum 20 }}
+  {{- end }}

--- a/charts/brigade/templates/artemis/service.yaml
+++ b/charts/brigade/templates/artemis/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "brigade.artemis.fullname" . }}
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.artemis.labels" . | nindent 4 }}
+  {{- if .Values.artemis.ha.enabled }}
+  annotations:
+    # Exclude unready secondary nodes from DNS
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "false"
+  {{- end }}
+spec:
+  type: {{ .Values.artemis.service.type }}
+  ports:
+  - port: 5672
+    targetPort: 5672
+  selector:
+    {{- include "brigade.selectorLabels" . | nindent 8 }}
+    {{- include "brigade.artemis.labels" . | nindent 8 }}

--- a/charts/brigade/templates/artemis/stateful-set.yaml
+++ b/charts/brigade/templates/artemis/stateful-set.yaml
@@ -1,0 +1,107 @@
+{{- if not .Values.artemis.ha.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "brigade.artemis.fullname" . }}
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.artemis.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "brigade.artemis.fullname" . }}-internal
+  replicas: {{ .Values.artemis.replicas }}
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      {{- include "brigade.selectorLabels" . | nindent 6 }}
+      {{- include "brigade.artemis.labels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "brigade.selectorLabels" . | nindent 8 }}
+        {{- include "brigade.artemis.labels" . | nindent 8 }}
+      annotations:
+        checksum/common-config: {{ include (print $.Template.BasePath "/artemis/common-config.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/artemis/config.yaml") . | sha256sum }}
+    spec:
+      initContainers:
+      - name: config
+        image: {{ .Values.artemis.image.repository }}:{{ .Values.artemis.image.tag }}
+        imagePullPolicy: {{ .Values.artemis.image.pullPolicy }}
+        command: ["/bin/sh", "/opt/config/configure-node.sh"]
+        volumeMounts:
+          - name: common-config
+            mountPath: /opt/common-config
+          - name: config
+            mountPath: /opt/config
+          - name: config-overrides
+            mountPath: /var/lib/artemis/etc-override
+      containers:
+      - name: artemis
+        image: {{ .Values.artemis.image.repository }}:{{ .Values.artemis.image.tag }}
+        imagePullPolicy: {{ .Values.artemis.image.pullPolicy }}
+        resources:
+          {{- toYaml .Values.artemis.resources | indent 10 }}
+        env:
+        - name: ARTEMIS_USERNAME
+          value: {{ .Values.artemis.username }}
+        - name: ARTEMIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "brigade.artemis.fullname" . }}
+              key: password
+        - name: ARTEMIS_PERF_JOURNAL
+          value: {{ .Values.artemis.persistence.testJournalPerformance }}
+        ports:
+        - name: http
+          containerPort: 8161
+        - name: core
+          containerPort: 61616
+        - name: amqp
+          containerPort: 5672
+        livenessProbe:
+          tcpSocket:
+            port: core
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: core
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        volumeMounts:
+        - name: config-overrides
+          mountPath: /var/lib/artemis/etc-override
+        - name: data
+          mountPath: /var/lib/artemis/data
+      volumes:
+      - name: config-overrides
+        emptyDir: {}
+      - name: common-config
+        secret:
+          secretName: {{ include "brigade.artemis.fullname" . }}-common-config
+      - name: config
+        configMap:
+          name: {{ include "brigade.artemis.fullname" . }}
+      {{- if not .Values.artemis.persistence.enabled }}
+      - name: data
+        emptyDir: {}
+      {{- end }}
+      {{- if .Values.artemis.persistence.enabled }}
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsNonRoot: true
+      {{- end }}
+  {{- if .Values.artemis.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      storageClassName: {{ .Values.artemis.persistence.storageClass }}
+      accessModes: [ {{ .Values.artemis.persistence.accessMode }} ]
+      resources:
+        requests:
+          storage: {{ .Values.artemis.persistence.size }}
+  {{- end}}
+{{- end }}

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -601,3 +601,78 @@ mongodb:
         ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Prometheus Rules to work with
         ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
         additionalLabels: {}
+
+artemis:
+
+  ## It is recommended NOT to scale Artemis beyond a single node. While
+  ## Brigade's architecture can tolerate queues distributed across multiple
+  ## nodes, it also derives no specific benefit from that topology. This being
+  ## the case, there is a benefit to using only a single Artemis node-- namely
+  ## that non-distributed queues are guaranteed to be properly FIFO, whilst no
+  ## such guarantee can be made with respect to distributed queues. Using a
+  ## single node therefore results in improved fairness in scheduling.
+  ##
+  ## The option to scale beyond a single node is preserved to account for
+  ## operators who may eventually transition to an EXTERNAL AMQP 1.0 message
+  ## broker that uses distributed queues and who may wish to experiment with
+  ## such a configuration in advance.
+  replicas: 1
+
+  image:
+    repository: vromero/activemq-artemis
+    tag: 2.15.0
+    pullPolicy: IfNotPresent
+
+  username: brigade
+  ## If not specified, a random password is automatically selected. It will
+  ## change on every upgrade, so choosing one up front may improve availability
+  ## during upgrades.
+  password: artemis
+
+  ## Persist data to a volume
+  persistence:
+    enabled: true
+    testJournalPerformance: AUTO
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass:
+    accessMode: ReadWriteOnce
+    size: 8Gi
+
+  ## Whether to run in a highly available configuration. This would be a good
+  ## idea in a producton environment, but shouldn't be needed otherwise.
+  ha:
+    enabled: false
+    ## Valid values are "hard" and "soft"
+    antiAffinity: soft
+
+  resources: {}
+    ## We usually recommend not to specify default resources and to leave this
+    ## as a conscious choice for the user. This also increases chances charts
+    ## run on environments with little resources, such as Minikube. If you do
+    ## want to specify resources, uncomment the following lines, adjust them as
+    ## necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  service:
+    type: NodePort
+
+externalAMQP:
+  address:
+  username:
+  password:
+
+azureServiceBus:
+  address:
+  username:
+  password:

--- a/v2/apiserver/internal/core/kubernetes/substrate.go
+++ b/v2/apiserver/internal/core/kubernetes/substrate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/brigadecore/brigade/v2/apiserver/internal/core"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/queue"
 	myk8s "github.com/brigadecore/brigade/v2/internal/kubernetes"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
@@ -21,16 +22,19 @@ import (
 type substrate struct {
 	generateNewNamespaceFn func(projectID string) string
 	kubeClient             kubernetes.Interface
+	queueWriterFactory     queue.WriterFactory
 }
 
 // NewSubstrate returns a Kubernetes-based implementation of the core.Substrate
 // interface.
 func NewSubstrate(
 	kubeClient kubernetes.Interface,
+	queueWriterFactory queue.WriterFactory,
 ) core.Substrate {
 	return &substrate{
 		generateNewNamespaceFn: generateNewNamespace,
 		kubeClient:             kubeClient,
+		queueWriterFactory:     queueWriterFactory,
 	}
 }
 

--- a/v2/apiserver/internal/lib/amqp/client.go
+++ b/v2/apiserver/internal/lib/amqp/client.go
@@ -1,0 +1,44 @@
+package amqp
+
+import (
+	"github.com/Azure/go-amqp"
+)
+
+// Client is an interface for the subset of go-amqp *Client functions that we
+// actually use, adapted slightly to also interact with our own custom Session
+// interface. Using these interfaces in our messaging abstraction, instead of
+// using the go-amqp types directly, allows for the possibility of utilizing
+// mock implementations for testing purposes. Adding only the subset of
+// functions that we actually use limits the effort involved in creating such
+// mocks.
+type Client interface {
+	// NewSession opens a new AMQP session to the server.
+	NewSession(opts ...amqp.SessionOption) (Session, error)
+	// Close disconnects the connection.
+	Close() error
+}
+
+// client is an implementation of the Client interface that delegates all work
+// to an underlying go-amqp *Client.
+type client struct {
+	client *amqp.Client
+}
+
+func (c *client) NewSession(opts ...amqp.SessionOption) (Session, error) {
+	s, err := c.client.NewSession(opts...)
+	return &session{
+		session: s,
+	}, err
+}
+
+func (c *client) Close() error {
+	return c.client.Close()
+}
+
+// Dial connects to an AMQP server.
+func Dial(addr string, opts ...amqp.ConnOption) (Client, error) {
+	c, err := amqp.Dial(addr, opts...)
+	return &client{
+		client: c,
+	}, err
+}

--- a/v2/apiserver/internal/lib/amqp/sender.go
+++ b/v2/apiserver/internal/lib/amqp/sender.go
@@ -1,0 +1,31 @@
+package amqp
+
+import (
+	"context"
+
+	"github.com/Azure/go-amqp"
+)
+
+// Sender is an interface for the subset of go-amqp *Sender functions that we
+// actually use. Using this interface in our messaging abstraction, instead of
+// using the go-amqp type directly, allows for the possibility of utilizing mock
+// implementations for testing purposes. Adding only the subset of functions
+// that we actually use limits the effort involved in creating such mocks.
+type Sender interface {
+	// Send sends a Message.
+	Send(ctx context.Context, msg *amqp.Message) error
+	// Close closes the Sender and AMQP link.
+	Close(ctx context.Context) error
+}
+
+type sender struct {
+	sender *amqp.Sender
+}
+
+func (s *sender) Send(ctx context.Context, msg *amqp.Message) error {
+	return s.sender.Send(ctx, msg)
+}
+
+func (s *sender) Close(ctx context.Context) error {
+	return s.sender.Close(ctx)
+}

--- a/v2/apiserver/internal/lib/amqp/session.go
+++ b/v2/apiserver/internal/lib/amqp/session.go
@@ -1,0 +1,36 @@
+package amqp
+
+import (
+	"context"
+
+	"github.com/Azure/go-amqp"
+)
+
+// Session is an interface for the subset of go-amqp *Session functions that we
+// actually use, adapted slightly to also interact with our own custom Sender
+// interface. Using these interfaces in our messaging abstraction, instead of
+// using the go-amqp types directly, allows for the possibility of utilizing
+// mock implementations for testing purposes. Adding only the subset of
+// functions that we actually use limits the effort involved in creating such
+// mocks.
+type Session interface {
+	// NewSender opens a new sender link on the session.
+	NewSender(opts ...amqp.LinkOption) (Sender, error)
+	// Close gracefully closes the session.
+	Close(ctx context.Context) error
+}
+
+type session struct {
+	session *amqp.Session
+}
+
+func (s *session) NewSender(opts ...amqp.LinkOption) (Sender, error) {
+	sndr, err := s.session.NewSender(opts...)
+	return &sender{
+		sender: sndr,
+	}, err
+}
+
+func (s *session) Close(ctx context.Context) error {
+	return s.session.Close(ctx)
+}

--- a/v2/apiserver/internal/lib/queue/amqp/writer.go
+++ b/v2/apiserver/internal/lib/queue/amqp/writer.go
@@ -1,0 +1,200 @@
+package amqp
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	amqp "github.com/Azure/go-amqp"
+	myamqp "github.com/brigadecore/brigade/v2/apiserver/internal/lib/amqp"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/queue"
+	"github.com/brigadecore/brigade/v2/internal/os"
+	"github.com/brigadecore/brigade/v2/internal/retries"
+	"github.com/pkg/errors"
+)
+
+// WriterFactoryConfig encapsulates details required for connecting an
+// AMQP-based implementation of the queue.WriterFactory interface to an
+// underlying AMQP-based messaging service.
+type WriterFactoryConfig struct {
+	// Address is the address of the AMQP-based messaging server.
+	Address string
+	// Username is the SASL username to use when connecting to the AMQP-based
+	// messaging server.
+	Username string
+	// Password is the SASL password to use when connection to the AMQP-based
+	// messaging server.
+	Password string
+}
+
+// GetWriterFactoryConfig returns WriterFactoryConfig based on configuration
+// obtained from environment variables.
+func GetWriterFactoryConfig() (WriterFactoryConfig, error) {
+	config := WriterFactoryConfig{}
+	var err error
+	config.Address, err = os.GetRequiredEnvVar("AMQP_ADDRESS")
+	if err != nil {
+		return config, err
+	}
+	config.Username, err = os.GetRequiredEnvVar("AMQP_USERNAME")
+	if err != nil {
+		return config, err
+	}
+	config.Password, err = os.GetRequiredEnvVar("AMQP_PASSWORD")
+	return config, err
+}
+
+// writerFactory is an AMQP-based implementation of the queue.WriterFactory
+// interface.
+type writerFactory struct {
+	address      string
+	dialOpts     []amqp.ConnOption
+	amqpClient   myamqp.Client
+	amqpClientMu *sync.Mutex
+	connectFn    func() error
+}
+
+// NewWriterFactory returns an an AMQP-based implementation of the
+// queue.WriterFactory.
+func NewWriterFactory(config WriterFactoryConfig) queue.WriterFactory {
+	w := &writerFactory{
+		address: config.Address,
+		dialOpts: []amqp.ConnOption{
+			amqp.ConnSASLPlain(config.Username, config.Password),
+		},
+		amqpClientMu: &sync.Mutex{},
+	}
+	w.connectFn = w.connect
+	return w
+}
+
+// connect connects (or reconnects) to the underlying AMQP-based messaging
+// server. This function is NOT concurrency safe and callers should take
+// measures to ensure they are the exclusive caller of this function.
+func (w *writerFactory) connect() error {
+	return retries.ManageRetries(
+		context.Background(),
+		"connect",
+		10,
+		10*time.Second,
+		func() (bool, error) {
+			if w.amqpClient != nil {
+				w.amqpClient.Close()
+			}
+			var err error
+			if w.amqpClient, err = myamqp.Dial(w.address, w.dialOpts...); err != nil {
+				return true, errors.Wrap(err, "error dialing endpoint")
+			}
+			return false, nil
+		},
+	)
+}
+
+func (w *writerFactory) NewWriter(queueName string) (queue.Writer, error) {
+	// This entire function is a critical section of code so that we don't
+	// possibly have multiple callers looking for a new Writer opening multiple
+	// underlying connections to the messaging server.
+	w.amqpClientMu.Lock()
+	defer w.amqpClientMu.Unlock()
+
+	if w.amqpClient == nil {
+		if err := w.connectFn(); err != nil {
+			return nil, err
+		}
+	}
+
+	linkOpts := []amqp.LinkOption{
+		amqp.LinkTargetAddress(queueName),
+	}
+
+	// Every Writer will get its own Session and Sender
+	var amqpSession myamqp.Session
+	var amqpSender myamqp.Sender
+	var err error
+	for {
+		// If we've been through the loop before, try cleaning up the session and/or
+		// sender that we never ended up using.
+		if amqpSender != nil {
+			amqpSender.Close(context.TODO()) // nolint: errcheck
+		}
+		if amqpSession != nil {
+			amqpSession.Close(context.TODO()) // nolint: errcheck
+		}
+
+		if amqpSession, err = w.amqpClient.NewSession(); err != nil {
+			// Assume this happened because the existing connection is no good. Try
+			// to reconnect.
+			if err = w.connectFn(); err != nil {
+				// The connection function handles its own retries. If we got an error
+				// here, it's pretty serious. Bail.
+				return nil, err
+			}
+			// We're reconnected now, so loop around to try getting a session again.
+			continue
+		}
+		if amqpSender, err = amqpSession.NewSender(linkOpts...); err != nil {
+			// Assume this happened because the existing connection is no good.
+			// Just loop around now because we not only need a new connection, but
+			// also a new session.
+			continue
+		}
+		break
+	}
+
+	return &writer{
+		queueName:   queueName,
+		amqpSession: amqpSession,
+		amqpSender:  amqpSender,
+	}, nil
+}
+
+func (w *writerFactory) Close(context.Context) error {
+	if err := w.amqpClient.Close(); err != nil {
+		return errors.Wrapf(err, "error closing AMQP client")
+	}
+	return nil
+}
+
+// writer is an AMQP-based implementation of the queue.Writer interface.
+type writer struct {
+	queueName   string
+	amqpSession myamqp.Session
+	amqpSender  myamqp.Sender
+}
+
+func (w *writer) Write(ctx context.Context, message string) error {
+	msg := &amqp.Message{
+		Header: &amqp.MessageHeader{
+			Durable: true,
+		},
+		Data: [][]byte{
+			[]byte(message),
+		},
+	}
+	if err := w.amqpSender.Send(ctx, msg); err != nil {
+		return errors.Wrapf(
+			err,
+			"error sending amqp message for queue %q",
+			w.queueName,
+		)
+	}
+	return nil
+}
+
+func (w *writer) Close(ctx context.Context) error {
+	if err := w.amqpSender.Close(ctx); err != nil {
+		return errors.Wrapf(
+			err,
+			"error closing AMQP sender for queue %q",
+			w.queueName,
+		)
+	}
+	if err := w.amqpSession.Close(ctx); err != nil {
+		return errors.Wrapf(
+			err,
+			"error closing AMQP session for queue %q",
+			w.queueName,
+		)
+	}
+	return nil
+}

--- a/v2/apiserver/internal/lib/queue/amqp/writer_test.go
+++ b/v2/apiserver/internal/lib/queue/amqp/writer_test.go
@@ -1,0 +1,317 @@
+package amqp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/Azure/go-amqp"
+	myamqp "github.com/brigadecore/brigade/v2/apiserver/internal/lib/amqp"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/queue"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetWriterFactoryConfig(t *testing.T) {
+	// Note that unit testing in Go does NOT clear environment variables between
+	// tests, which can sometimes be a pain, but it's fine here-- so each of these
+	// test cases builds on the previous case.
+	testCases := []struct {
+		name       string
+		setup      func()
+		assertions func(WriterFactoryConfig, error)
+	}{
+		{
+			name:  "AMQP_ADDRESS not set",
+			setup: func() {},
+			assertions: func(_ WriterFactoryConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "AMQP_ADDRESS")
+			},
+		},
+		{
+			name: "AMQP_USERNAME not set",
+			setup: func() {
+				os.Setenv("AMQP_ADDRESS", "foo")
+			},
+			assertions: func(_ WriterFactoryConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "AMQP_USERNAME")
+			},
+		},
+		{
+			name: "AMQP_PASSWORD not set",
+			setup: func() {
+				os.Setenv("AMQP_USERNAME", "bar")
+			},
+			assertions: func(_ WriterFactoryConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "AMQP_PASSWORD")
+			},
+		},
+		{
+			name: "SUCCESS not set",
+			setup: func() {
+				os.Setenv("AMQP_PASSWORD", "bat")
+			},
+			assertions: func(config WriterFactoryConfig, err error) {
+				require.NoError(t, err)
+				require.Equal(
+					t,
+					WriterFactoryConfig{
+						Address:  "foo",
+						Username: "bar",
+						Password: "bat",
+					},
+					config,
+				)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.setup()
+			config, err := GetWriterFactoryConfig()
+			testCase.assertions(config, err)
+		})
+	}
+}
+
+func TestNewWriterFactory(t *testing.T) {
+	const testAddress = "foo"
+	wf := NewWriterFactory(
+		WriterFactoryConfig{
+			Address: testAddress,
+		},
+	)
+	require.IsType(t, &writerFactory{}, wf)
+	require.Equal(t, testAddress, wf.(*writerFactory).address)
+	require.NotEmpty(t, wf.(*writerFactory).dialOpts)
+	// Assert we're not connected yet. (It connects lazily.)
+	require.Nil(t, wf.(*writerFactory).amqpClient)
+	require.NotNil(t, wf.(*writerFactory).amqpClientMu)
+	require.NotNil(t, wf.(*writerFactory).connectFn)
+}
+
+func TestWriterFactoryNewWriter(t *testing.T) {
+	const testQueueName = "foo"
+	wf := &writerFactory{
+		amqpClient: &mockAMQPClient{
+			NewSessionFn: func(opts ...amqp.SessionOption) (myamqp.Session, error) {
+				return &mockAMQPSession{
+					NewSenderFn: func(opts ...amqp.LinkOption) (myamqp.Sender, error) {
+						return &mockAMQPSender{}, nil
+					},
+				}, nil
+			},
+		},
+		amqpClientMu: &sync.Mutex{},
+	}
+	w, err := wf.NewWriter(testQueueName)
+	require.NoError(t, err)
+	require.IsType(t, &writer{}, w)
+	require.Equal(t, testQueueName, w.(*writer).queueName)
+	require.NotNil(t, w.(*writer).amqpSession)
+	require.NotNil(t, w.(*writer).amqpSender)
+}
+
+func TestWriterFactoryClose(t *testing.T) {
+	testCases := []struct {
+		name          string
+		writerFactory queue.WriterFactory
+		assertions    func(error)
+	}{
+		{
+			name: "error closing underlying amqp connection",
+			writerFactory: &writerFactory{
+				amqpClient: &mockAMQPClient{
+					CloseFn: func() error {
+						return errors.New("something went wrong")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error closing AMQP client")
+			},
+		},
+		{
+			name: "success",
+			writerFactory: &writerFactory{
+				amqpClient: &mockAMQPClient{
+					CloseFn: func() error {
+						return nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.writerFactory.Close(context.Background())
+			testCase.assertions(err)
+		})
+	}
+}
+
+func TestWriterWrite(t *testing.T) {
+	testCases := []struct {
+		name       string
+		writer     queue.Writer
+		assertions func(error)
+	}{
+		{
+			name: "error sending message",
+			writer: &writer{
+				amqpSender: &mockAMQPSender{
+					SendFn: func(context.Context, *amqp.Message) error {
+						return errors.New("something went wrong")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error sending amqp message")
+			},
+		},
+		{
+			name: "success",
+			writer: &writer{
+				amqpSender: &mockAMQPSender{
+					SendFn: func(context.Context, *amqp.Message) error {
+						return nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.writer.Write(context.Background(), "message in a bottle")
+			testCase.assertions(err)
+		})
+	}
+}
+
+func TestWriterClose(t *testing.T) {
+	testCases := []struct {
+		name       string
+		writer     queue.Writer
+		assertions func(error)
+	}{
+		{
+			name: "error closing underlying sender",
+			writer: &writer{
+				amqpSender: &mockAMQPSender{
+					CloseFn: func(ctx context.Context) error {
+						return errors.New("something went wrong")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error closing AMQP sender")
+			},
+		},
+		{
+			name: "error closing underlying session",
+			writer: &writer{
+				amqpSender: &mockAMQPSender{
+					CloseFn: func(ctx context.Context) error {
+						return nil
+					},
+				},
+				amqpSession: &mockAMQPSession{
+					CloseFn: func(ctx context.Context) error {
+						return errors.New("something went wrong")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error closing AMQP session")
+			},
+		},
+		{
+			name: "success",
+			writer: &writer{
+				amqpSender: &mockAMQPSender{
+					CloseFn: func(ctx context.Context) error {
+						return nil
+					},
+				},
+				amqpSession: &mockAMQPSession{
+					CloseFn: func(ctx context.Context) error {
+						return nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.writer.Close(context.Background())
+			testCase.assertions(err)
+		})
+	}
+}
+
+type mockAMQPClient struct {
+	NewSessionFn func(opts ...amqp.SessionOption) (myamqp.Session, error)
+	CloseFn      func() error
+}
+
+func (m *mockAMQPClient) NewSession(
+	opts ...amqp.SessionOption,
+) (myamqp.Session, error) {
+	return m.NewSessionFn(opts...)
+}
+
+func (m *mockAMQPClient) Close() error {
+	return m.CloseFn()
+}
+
+type mockAMQPSession struct {
+	NewSenderFn func(opts ...amqp.LinkOption) (myamqp.Sender, error)
+	CloseFn     func(ctx context.Context) error
+}
+
+func (m *mockAMQPSession) NewSender(
+	opts ...amqp.LinkOption,
+) (myamqp.Sender, error) {
+	return m.NewSenderFn(opts...)
+}
+
+func (m *mockAMQPSession) Close(ctx context.Context) error {
+	return m.CloseFn(ctx)
+}
+
+type mockAMQPSender struct {
+	SendFn  func(ctx context.Context, msg *amqp.Message) error
+	CloseFn func(ctx context.Context) error
+}
+
+func (m *mockAMQPSender) Send(ctx context.Context, msg *amqp.Message) error {
+	return m.SendFn(ctx, msg)
+}
+
+func (m *mockAMQPSender) Close(ctx context.Context) error {
+	return m.CloseFn(ctx)
+}

--- a/v2/apiserver/internal/lib/queue/writer.go
+++ b/v2/apiserver/internal/lib/queue/writer.go
@@ -1,0 +1,30 @@
+package queue
+
+import "context"
+
+// WriterFactory is an interface for any component that can furnish an
+// implementation of the Writer interface capable of writing messages to a
+// specific queue (or similar channel) of some (presumably asynchronous)
+// messaging system.
+type WriterFactory interface {
+	// NewWriter returns an implementation of the Writer interface for capable of
+	// writing messages to a specific queue (or similar channel) of some
+	// (presumably asynchronous) messaging system.
+	NewWriter(queueName string) (Writer, error)
+	// Close executes implementation-specific cleanup. Clients MUST invoke this
+	// function when they are done with the WriterFactory.
+	Close(context.Context) error
+}
+
+// Writer is an interface used to abstract client code wishing to write messages
+// to a specific queue (or similar channel) of some (presumably asynchronous)
+// messaging system away from the underlying protocols and implementation of the
+// mesaging system in use.
+type Writer interface {
+	// Write writes the provided message to a specific queue (or similar channel)
+	// known to the implementation.
+	Write(ctx context.Context, message string) error
+	// Close executes implementation-specific cleanup. Clients MUST invoke this
+	// function when they are done with the Writer.
+	Close(context.Context) error
+}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -6,6 +6,7 @@ replace github.com/brigadecore/brigade/sdk/v2 => ../sdk/v2
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.0.7
+	github.com/Azure/go-amqp v0.13.1
 	github.com/bacongobbler/browser v1.1.0
 	github.com/brigadecore/brigade/sdk/v2 v2.0.0-20200923171232-9f56c474d8bf
 	github.com/coreos/go-oidc v2.2.1+incompatible

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -33,6 +33,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/AlecAivazis/survey/v2 v2.0.7 h1:+f825XHLse/hWd2tE/V5df04WFGimk34Eyg/z35w/rc=
 github.com/AlecAivazis/survey/v2 v2.0.7/go.mod h1:mlizQTaPjnR4jcpwRSaSlkbsRfYFEyKgLQvYTzxxiHA=
+github.com/Azure/go-amqp v0.13.1 h1:dXnEJ89Hf7wMkcBbLqvocZlM4a3uiX9uCxJIvU77+Oo=
+github.com/Azure/go-amqp v0.13.1/go.mod h1:qj+o8xPCz9tMSbQ83Vp8boHahuRDl5mkNHyt1xlxUTs=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
@@ -76,6 +78,8 @@ github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
+github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/v2/internal/rand/seeded.go
+++ b/v2/internal/rand/seeded.go
@@ -11,6 +11,8 @@ type Seeded interface {
 	// Intn returns, as an int, a non-negative pseudo-random number in [0,n). It
 	// panics if n <= 0.
 	Intn(max int) int
+	// Float64 returns, as a float64, a pseudo-random number in [0.0,1.0).
+	Float64() float64
 }
 
 type seeded struct {
@@ -31,4 +33,10 @@ func (s *seeded) Intn(max int) int {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 	return s.seededRand.Intn(max)
+}
+
+func (s *seeded) Float64() float64 {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+	return s.seededRand.Float64()
 }

--- a/v2/internal/rand/seeded_test.go
+++ b/v2/internal/rand/seeded_test.go
@@ -17,10 +17,16 @@ func TestNewSeeded(t *testing.T) {
 
 func TestIntn(t *testing.T) {
 	// We have no visibility into the underlying *mathrand.Rand, so we'll test
-	// that it is indeed seeded by comparing the results of Intn ro results from
-	// unseeded Rand. We use a very large n to reduce the liklihood of a
-	// coincidental match.
+	// that it is indeed seeded by comparing the results of Intn to results from
+	// the unseeded random number generator in the math/rand package. We use a
+	// very large n to reduce the likelihood of a coincidental match.
 	const n = 2147483647
-	seededRand := NewSeeded()
-	require.NotEqual(t, rand.Intn(n), seededRand.Intn(n))
+	require.NotEqual(t, rand.Intn(n), NewSeeded().Intn(n))
+}
+
+func TestFloat64(t *testing.T) {
+	// We have no visibility into the underlying *mathrand.Rand, so we'll test
+	// that it is indeed seeded by comparing the results of Float64 to results
+	// from the unseeded random number generator in the math/rand package.
+	require.NotEqual(t, rand.Float64(), NewSeeded().Float64())
 }

--- a/v2/internal/retries/retries.go
+++ b/v2/internal/retries/retries.go
@@ -1,0 +1,105 @@
+package retries
+
+import (
+	"context"
+	"log"
+	"math"
+	"time"
+
+	"github.com/brigadecore/brigade/v2/internal/rand"
+	"github.com/pkg/errors"
+)
+
+var seededRand = rand.NewSeeded()
+
+var jitteredExpBackoffFn = jitteredExpBackoff
+
+// ManageRetries executes the provided function until it "succeeds" or the
+// maximum number of attempts has been exhausted. The delay between attempts
+// increases exponentially, but is capped by the value of maxBackoff argument.
+// "Success" requires the provided function to return a bool indicating that no
+// retry should be attempted (false). The indication that a retry should or
+// should not be attempted is SEPARATE from whatever error the provided function
+// may return, with the decision to retry or not being made solely on the basis
+// of the bool value. This makes it possible to retry failures after the
+// provided function has done its own internal error handling. It also makes it
+// possible to circumvent retries in the event that the error encountered is
+// unrecoverable.
+//
+// Example usage:
+//
+// 	var client amqp.Client
+// 	err := retries.ManageRetries(ctx, "amqp connect", 10, 10 * time.Second,
+// 		func() (bool, error) {
+// 			var e error
+// 			if client, e = amqp.Dial(address); e != nil {
+// 				return true, errors.Wrap(e, "error dialing AMQP server")
+// 			}
+// 			return false, nil
+// 		},
+// 	)
+// 	// Handle err
+func ManageRetries(
+	ctx context.Context,
+	process string,
+	maxAttempts int,
+	maxBackoff time.Duration,
+	fn func() (bool, error),
+) error {
+	var failedAttempts int
+	for {
+		retry, err := fn()
+		if !retry {
+			return err
+		}
+		failedAttempts++
+		if failedAttempts == maxAttempts {
+			if err == nil {
+				return errors.Errorf(
+					"failed %d attempt(s) to %s",
+					maxAttempts,
+					process,
+				)
+			}
+			return errors.Wrapf(
+				err,
+				"failed %d attempt(s) to %s",
+				maxAttempts,
+				process,
+			)
+		}
+		delay := jitteredExpBackoffFn(failedAttempts, maxBackoff)
+		log.Printf(
+			"WARNING: failed %d attempts(s) to %s; will retry in %s: %s",
+			failedAttempts,
+			process,
+			delay,
+			err,
+		)
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// jitteredExpBackoff returns a time.Duration to wait before the next retry when
+// employing a "jittered" exponential backoff. The value returned is based,
+// in-part on the number of failures to date and the maximum desired retry
+// interval. This value is "jittered" before it is returned. The importance of
+// this is that if many failures of any sort occur in rapid succession, the
+// retries will be not only be staggered, but will become increasingly so as the
+// failure count increases. This strategy helps to mitigate further
+// complications in the event that the initial error was due to resource
+// contention of rate limiting.
+func jitteredExpBackoff(
+	failureCount int,
+	maxDelay time.Duration,
+) time.Duration {
+	base := math.Pow(2, float64(failureCount))
+	capped := math.Min(base, maxDelay.Seconds())
+	jittered := (1 + seededRand.Float64()) * (capped / 2)
+	scaled := jittered * float64(time.Second)
+	return time.Duration(scaled)
+}

--- a/v2/internal/retries/retries_test.go
+++ b/v2/internal/retries/retries_test.go
@@ -1,0 +1,164 @@
+package retries
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagedRetries(t *testing.T) {
+	const testMaxAttempts = 10
+	const testProcess = "foo"
+	// Override the function that returns the backoff intervals so that we
+	// can preempt long waits.
+	jitteredExpBackoffFn = func(int, time.Duration) time.Duration {
+		return time.Millisecond
+	}
+	testCases := []struct {
+		name       string
+		fn         func() (bool, error)
+		assertions func(err error)
+	}{
+		{
+			name: "unrecoverable error",
+			fn: func() (bool, error) {
+				return false, errors.New("don't bother") // A unrecoverable failure
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Equal(t, err.Error(), "don't bother")
+			},
+		},
+		{
+			name: "fn handled error internally, but requests retry",
+			fn: func() (bool, error) {
+				return true, nil // Always retry
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(
+					t, err.Error(),
+					fmt.Sprintf(
+						"failed %d attempt(s) to %s",
+						testMaxAttempts,
+						testProcess,
+					),
+				)
+			},
+		},
+		{
+			name: "fn returns error",
+			fn: func() (bool, error) {
+				return true, errors.New("something went wrong") // Always retry
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(
+					t, err.Error(),
+					fmt.Sprintf(
+						"failed %d attempt(s) to %s",
+						testMaxAttempts,
+						testProcess,
+					),
+				)
+				require.Contains(t, err.Error(), "something went wrong")
+			},
+		},
+		{
+			name: "fn succeeds",
+			fn: func() (bool, error) {
+				return false, nil // All good
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := ManageRetries(
+				context.Background(),
+				testProcess,
+				testMaxAttempts,
+				time.Minute,
+				testCase.fn,
+			)
+			testCase.assertions(err)
+		})
+	}
+}
+
+func TestJitteredExpBackoff(t *testing.T) {
+	testCases := []struct {
+		failureCount int
+		cap          time.Duration
+		expectedMin  time.Duration
+		expectedMax  time.Duration
+	}{
+		{
+			failureCount: 1,
+			cap:          time.Minute,
+			expectedMin:  time.Second,
+			expectedMax:  2 * time.Second,
+		},
+		{
+			failureCount: 2,
+			cap:          time.Minute,
+			expectedMin:  2 * time.Second,
+			expectedMax:  4 * time.Second,
+		},
+		{
+			failureCount: 3,
+			cap:          time.Minute,
+			expectedMin:  4 * time.Second,
+			expectedMax:  8 * time.Second,
+		},
+		{
+			failureCount: 4,
+			cap:          time.Minute,
+			expectedMin:  8 * time.Second,
+			expectedMax:  16 * time.Second,
+		},
+		{
+			failureCount: 5,
+			cap:          time.Minute,
+			expectedMin:  16 * time.Second,
+			expectedMax:  32 * time.Second,
+		},
+		{
+			failureCount: 6,
+			cap:          time.Minute,
+			expectedMin:  30 * time.Second,
+			expectedMax:  time.Minute,
+		},
+		{
+			failureCount: 7,
+			cap:          time.Minute,
+			expectedMin:  30 * time.Second,
+			expectedMax:  time.Minute,
+		},
+		{
+			failureCount: 8,
+			cap:          time.Minute,
+			expectedMin:  30 * time.Second,
+			expectedMax:  time.Minute,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(strconv.Itoa(testCase.failureCount), func(t *testing.T) {
+			delay1 := jitteredExpBackoff(testCase.failureCount, testCase.cap)
+
+			require.Less(t, testCase.expectedMin.Seconds(), delay1.Seconds())
+			require.Less(t, delay1.Seconds(), testCase.expectedMax.Seconds())
+
+			// Make sure the jitter works
+			delay2 := jitteredExpBackoff(testCase.failureCount, testCase.cap)
+			require.NotEqual(t, delay1, delay2)
+		})
+	}
+}


### PR DESCRIPTION
This will ultimately be what enables the substrate component to communicate asynchronously with the scheduler.

This PR stops just short of actually dropping messages onto the queue because more extensive substrate additions are required before that can be done. Expect those changes in my next PR.

As always, I've taken care to organize the commits in a way that should make each of them a smaller / easier unit to review.