### PR TITLE
add scheduler component

### DIFF
--- a/charts/brigade/templates/scheduler/deployment.yaml
+++ b/charts/brigade/templates/scheduler/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "brigade.scheduler.fullname" . }}
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.scheduler.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "brigade.selectorLabels" . | nindent 6 }}
+      {{- include "brigade.scheduler.labels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "brigade.selectorLabels" . | nindent 8 }}
+        {{- include "brigade.scheduler.labels" . | nindent 8 }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/scheduler/secret.yaml") . | sha256sum }}
+    spec:
+      serviceAccount: {{ include "brigade.scheduler.fullname" . }}
+      containers:
+      - name: scheduler
+        image: {{ .Values.scheduler.image.repository }}:{{ default .Chart.AppVersion .Values.scheduler.image.tag }}
+        imagePullPolicy: {{ .Values.scheduler.image.pullPolicy }}
+        args:
+        - --logtostderr=true
+        env:
+        - name: API_ADDRESS
+          {{- if .Values.apiserver.tls.enabled }}
+          value: https://{{ include "brigade.apiserver.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+          {{- else }}
+          value: http://{{ include "brigade.apiserver.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+          {{- end }}
+        - name: API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "brigade.scheduler.fullname" . }}
+              key: api-token
+        - name: API_IGNORE_CERT_WARNINGS
+          value: {{ quote (and .Values.apiserver.tls.enabled .Values.scheduler.tls.ignoreCertWarnings) }}
+        - name: AMQP_ADDRESS
+          value: amqp://{{ include "brigade.artemis.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5672
+        - name: AMQP_USERNAME
+          value: {{ .Values.artemis.username }}
+        - name: AMQP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "brigade.artemis.fullname" . }}
+              key: password
+      {{- with .Values.scheduler.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/brigade/templates/scheduler/service-account.yaml
+++ b/charts/brigade/templates/scheduler/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "brigade.scheduler.fullname" . }}
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.scheduler.labels" . | nindent 4 }}

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -125,6 +125,35 @@ apiserver:
     type: NodePort
     # nodePort: 31600
 
+scheduler:
+
+  image:
+    repository: krancour/brigade-scheduler
+    ## tag should only be specified if you want to override Chart.appVersion
+    ## The default tag is the value of .Chart.AppVersion
+    # tag:
+    pullPolicy: IfNotPresent
+
+  tls:
+    ignoreCertWarnings: true
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as
+    # a conscious choice for the user. This also increases chances charts run on
+    # environments with little resources, such as Minikube. If you do want to
+    # specify resources, uncomment the following lines, adjust them as
+    # necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
 worker:
 
   image:

--- a/v2/scheduler/Dockerfile
+++ b/v2/scheduler/Dockerfile
@@ -1,0 +1,20 @@
+FROM krancour/go-tools:v0.4.0
+ARG VERSION
+ARG COMMIT
+ENV CGO_ENABLED=0
+WORKDIR /src
+COPY sdk/ sdk/
+WORKDIR /src/v2
+COPY v2/scheduler/ scheduler/
+COPY v2/internal/ internal/
+COPY v2/go.mod go.mod
+COPY v2/go.sum go.sum
+RUN go build \
+  -o ../bin/scheduler \
+  -ldflags "-w -X github.com/brigadecore/brigade/v2/internal/version.version=$VERSION -X github.com/brigadecore/brigade/v2/internal/version.commit=$COMMIT" \
+  ./scheduler
+
+FROM scratch
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=0 /src/bin/ /brigade/bin/
+ENTRYPOINT ["/brigade/bin/scheduler"]

--- a/v2/scheduler/config.go
+++ b/v2/scheduler/config.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
+	"github.com/brigadecore/brigade/v2/internal/os"
+	"github.com/brigadecore/brigade/v2/scheduler/internal/lib/queue/amqp"
+)
+
+func apiClientConfig() (string, string, restmachinery.APIClientOptions, error) {
+	opts := restmachinery.APIClientOptions{}
+	address, err := os.GetRequiredEnvVar("API_ADDRESS")
+	if err != nil {
+		return address, "", opts, err
+	}
+	token, err := os.GetRequiredEnvVar("API_TOKEN")
+	if err != nil {
+		return address, token, opts, err
+	}
+	opts.AllowInsecureConnections, err =
+		os.GetBoolFromEnvVar("API_IGNORE_CERT_WARNINGS", false)
+	return address, token, opts, err
+}
+
+// readerFactoryConfig returns an amqp.ReaderFactoryConfig based on
+// configuration obtained from environment variables.
+func readerFactoryConfig() (amqp.ReaderFactoryConfig, error) {
+	config := amqp.ReaderFactoryConfig{}
+	var err error
+	config.Address, err = os.GetRequiredEnvVar("AMQP_ADDRESS")
+	if err != nil {
+		return config, err
+	}
+	config.Username, err = os.GetRequiredEnvVar("AMQP_USERNAME")
+	if err != nil {
+		return config, err
+	}
+	config.Password, err = os.GetRequiredEnvVar("AMQP_PASSWORD")
+	return config, err
+}

--- a/v2/scheduler/config_test.go
+++ b/v2/scheduler/config_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
+	"github.com/brigadecore/brigade/v2/scheduler/internal/lib/queue/amqp"
+	"github.com/stretchr/testify/require"
+)
+
+// Note that unit testing in Go does NOT clear environment variables between
+// tests, which can sometimes be a pain, but it's fine here-- so each of these
+// test functions uses a series of test cases that cumulatively build upon one
+// another.
+
+func TestAPIClientConfig(t *testing.T) {
+	testCases := []struct {
+		name       string
+		setup      func()
+		assertions func(
+			address string,
+			token string,
+			opts restmachinery.APIClientOptions,
+			err error,
+		)
+	}{
+		{
+			name:  "API_ADDRESS not set",
+			setup: func() {},
+			assertions: func(
+				_ string,
+				_ string,
+				_ restmachinery.APIClientOptions,
+				err error,
+			) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "API_ADDRESS")
+			},
+		},
+		{
+			name: "API_TOKEN not set",
+			setup: func() {
+				os.Setenv("API_ADDRESS", "foo")
+			},
+			assertions: func(
+				_ string,
+				_ string,
+				_ restmachinery.APIClientOptions,
+				err error,
+			) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "API_TOKEN")
+			},
+		},
+		{
+			name: "SUCCESS not set",
+			setup: func() {
+				os.Setenv("API_TOKEN", "bar")
+				os.Setenv("API_IGNORE_CERT_WARNINGS", "true")
+			},
+			assertions: func(
+				address string,
+				token string,
+				opts restmachinery.APIClientOptions,
+				err error,
+			) {
+				require.NoError(t, err)
+				require.Equal(t, "foo", address)
+				require.Equal(t, "bar", token)
+				require.True(t, opts.AllowInsecureConnections)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.setup()
+			address, token, opts, err := apiClientConfig()
+			testCase.assertions(address, token, opts, err)
+		})
+	}
+}
+
+func TestReaderFactoryConfig(t *testing.T) {
+	testCases := []struct {
+		name       string
+		setup      func()
+		assertions func(amqp.ReaderFactoryConfig, error)
+	}{
+		{
+			name:  "AMQP_ADDRESS not set",
+			setup: func() {},
+			assertions: func(_ amqp.ReaderFactoryConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "AMQP_ADDRESS")
+			},
+		},
+		{
+			name: "AMQP_USERNAME not set",
+			setup: func() {
+				os.Setenv("AMQP_ADDRESS", "foo")
+			},
+			assertions: func(_ amqp.ReaderFactoryConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "AMQP_USERNAME")
+			},
+		},
+		{
+			name: "AMQP_PASSWORD not set",
+			setup: func() {
+				os.Setenv("AMQP_USERNAME", "bar")
+			},
+			assertions: func(_ amqp.ReaderFactoryConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "AMQP_PASSWORD")
+			},
+		},
+		{
+			name: "success",
+			setup: func() {
+				os.Setenv("AMQP_PASSWORD", "bat")
+			},
+			assertions: func(config amqp.ReaderFactoryConfig, err error) {
+				require.NoError(t, err)
+				require.Equal(
+					t,
+					amqp.ReaderFactoryConfig{
+						Address:  "foo",
+						Username: "bar",
+						Password: "bat",
+					},
+					config,
+				)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.setup()
+			config, err := readerFactoryConfig()
+			testCase.assertions(config, err)
+		})
+	}
+}

--- a/v2/scheduler/jobs.go
+++ b/v2/scheduler/jobs.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/v2/internal/retries"
+	"github.com/brigadecore/brigade/v2/scheduler/internal/lib/queue"
+	"github.com/pkg/errors"
+)
+
+// manageJobCapacity periodically checks how many Jobs are currently running on
+// the substrate and sends a signal on an availability channel when there is
+// available capacity.
+func (s *scheduler) manageJobCapacity(ctx context.Context) {
+	for {
+		// Look for capacity until we find some. Use a progressive backoff, capped
+		// at 10 seconds between retries.
+		if err := retries.ManageRetries(
+			ctx,
+			"find job capacity",
+			0,              // Infinite retries
+			10*time.Second, // Max backoff
+			func() (bool, error) {
+				select {
+				case <-ctx.Done():
+					return false, nil // Stop looking
+				default:
+				}
+				substrateJobCount, err := s.countRunningJobsFn(ctx)
+				if err != nil {
+					return false, err // Real error; stop retrying
+				}
+				if substrateJobCount.Count < s.config.maxConcurrentJobs {
+					return false, nil // Found capacity; stop looking
+				}
+				return true, nil // Keep looking
+			},
+		); err != nil {
+			// Report error
+			select {
+			case s.errCh <- err:
+			case <-ctx.Done():
+			}
+			return
+		}
+
+		// Offer capacity to anyone who's ready for it
+		select {
+		case s.jobAvailabilityCh <- struct{}{}:
+		case <-ctx.Done():
+			return
+		}
+
+		// Wait to hear that whoever received the capacity has done whatever they
+		// were going to do. This helps prevent a race where we loop around and
+		// start looking for capacity and maybe find some that someone else is about
+		// to claim.
+		select {
+		case <-s.jobAvailabilityCh:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// nolint: gocyclo
+func (s *scheduler) runJobLoop(ctx context.Context, projectID string) {
+
+	var jobsReader queue.Reader
+
+outerLoop:
+	for {
+
+		if jobsReader != nil {
+			func() {
+				closeCtx, cancelCloseCtx :=
+					context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancelCloseCtx()
+				jobsReader.Close(closeCtx)
+			}()
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		var err error
+		jobsReader, err = s.queueReaderFactory.NewReader(
+			fmt.Sprintf("jobs.%s", projectID),
+		)
+		if err != nil { // It's fatal if we can't get a queue reader
+			select {
+			case s.errCh <- err:
+			case <-ctx.Done():
+			}
+			return
+		}
+
+		// This is the main loop for receiving this Project's Events' Workers' Jobs
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			// Get the next message
+			msg, err := jobsReader.Read(ctx)
+			if err != nil {
+				s.jobLoopErrFn(err)
+				continue outerLoop // Try again with a new reader
+			}
+
+			messageTokens := strings.Split(msg.Message, ":")
+			if len(messageTokens) != 2 {
+				s.jobLoopErrFn(
+					errors.Errorf(
+						"received invalid message on project %q job queue",
+						projectID,
+					),
+				)
+				if err = msg.Ack(ctx); err != nil {
+					s.jobLoopErrFn(err)
+				}
+				continue // Next message
+			}
+			eventID := messageTokens[0]
+			jobName := messageTokens[1]
+
+			event, err := s.getEventFn(ctx, eventID)
+			if err != nil {
+				s.jobLoopErrFn(err)
+
+				if err := s.updateJobStatusFn(
+					ctx,
+					eventID,
+					jobName,
+					core.JobStatus{
+						Phase: core.JobPhaseSchedulingFailed,
+					},
+				); err != nil {
+					s.jobLoopErrFn(err)
+				}
+
+				// Ack the message because there's nothing we can do and we don't want
+				// something we can't process to clog the queue.
+				if err := msg.Ack(ctx); err != nil {
+					s.jobLoopErrFn(err)
+				}
+				continue // Next message
+			}
+
+			job, exists := event.Worker.Jobs[jobName]
+			if !exists {
+				s.jobLoopErrFn(
+					errors.Errorf(
+						"no job %q exists for event %q",
+						jobName,
+						eventID,
+					),
+				)
+				if err := msg.Ack(ctx); err != nil {
+					s.jobLoopErrFn(err)
+				}
+				continue // Next Job
+			}
+
+			// If the Job's phase isn't PENDING, then there's nothing to do
+			if job.Status.Phase != core.JobPhasePending {
+				if err := msg.Ack(ctx); err != nil {
+					s.jobLoopErrFn(err)
+				}
+				continue // Next message
+			}
+
+			// Wait for capacity
+			select {
+			case <-s.jobAvailabilityCh:
+			case <-ctx.Done():
+				continue outerLoop // This will do cleanup before returning
+			}
+
+			// TODO: In the future, it would be nice to be able to block on PROJECT
+			// capacity as well. i.e. Max of n concurrent jobs per project. I
+			// (krancour) see this as a post-2.0 enhancement.
+
+			// Now use the API to start the Job...
+
+			if err := s.startJobFn(ctx, event.ID, jobName); err != nil {
+				s.jobLoopErrFn(err)
+			}
+
+			if err := msg.Ack(ctx); err != nil {
+				s.jobLoopErrFn(err)
+			}
+
+			// Tell the capacity manager we used the capacity it gave us
+			select {
+			case s.jobAvailabilityCh <- struct{}{}:
+			case <-ctx.Done():
+				continue outerLoop // This will do cleanup before returning
+			}
+		}
+
+	}
+
+}

--- a/v2/scheduler/jobs_test.go
+++ b/v2/scheduler/jobs_test.go
@@ -1,0 +1,500 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/v2/scheduler/internal/lib/queue"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManageJobsCapacity(t *testing.T) {
+	testCases := []struct {
+		name       string
+		scheduler  *scheduler
+		assertions func(
+			ctx context.Context,
+			jobAvailabilityCh chan struct{},
+			errCh chan error,
+		)
+	}{
+		{
+			name: "error checking capacity",
+			scheduler: &scheduler{
+				config: schedulerConfig{
+					maxConcurrentJobs: 2,
+				},
+				countRunningJobsFn: func(
+					context.Context,
+				) (core.SubstrateJobCount, error) {
+					return core.SubstrateJobCount{}, errors.New("something went wrong")
+				},
+				jobAvailabilityCh: make(chan struct{}),
+				errCh:             make(chan error),
+			},
+			assertions: func(
+				ctx context.Context,
+				jobAvailabilityCh chan struct{},
+				errCh chan error,
+			) {
+				select {
+				case <-jobAvailabilityCh:
+					require.Fail(
+						t,
+						"notified of available capacity when we should have received "+
+							"an error",
+					)
+				case err := <-errCh:
+					require.Error(t, err)
+					require.Contains(t, err.Error(), "something went wrong")
+				case <-ctx.Done():
+					require.Fail(t, "never received expected error")
+				}
+			},
+		},
+		{
+			name: "no capacity available",
+			scheduler: &scheduler{
+				config: schedulerConfig{
+					maxConcurrentJobs: 2,
+				},
+				countRunningJobsFn: func(
+					context.Context,
+				) (core.SubstrateJobCount, error) {
+					return core.SubstrateJobCount{
+						Count: 2,
+					}, nil
+				},
+				jobAvailabilityCh: make(chan struct{}),
+				errCh:             make(chan error),
+			},
+			assertions: func(
+				ctx context.Context,
+				jobAvailabilityCh chan struct{},
+				errCh chan error,
+			) {
+				select {
+				case <-jobAvailabilityCh:
+					require.Fail(t, "notified of available capacity when none existed")
+				case <-errCh:
+					require.Fail(t, "received unexpected error")
+				case <-ctx.Done():
+				}
+			},
+		},
+		{
+			name: "capacity available",
+			scheduler: &scheduler{
+				config: schedulerConfig{
+					maxConcurrentJobs: 2,
+				},
+				countRunningJobsFn: func(
+					context.Context,
+				) (core.SubstrateJobCount, error) {
+					return core.SubstrateJobCount{
+						Count: 1,
+					}, nil
+				},
+				jobAvailabilityCh: make(chan struct{}),
+				errCh:             make(chan error),
+			},
+			assertions: func(
+				ctx context.Context,
+				jobAvailabilityCh chan struct{},
+				errCh chan error,
+			) {
+				select {
+				case <-jobAvailabilityCh:
+					// Signal back to the capacity manager
+					jobAvailabilityCh <- struct{}{}
+				case <-errCh:
+					require.Fail(t, "received unexpected error")
+				case <-ctx.Done():
+					require.Fail(t, "never notified of existing capacity")
+				}
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			go testCase.scheduler.manageJobCapacity(ctx)
+			testCase.assertions(
+				ctx,
+				testCase.scheduler.jobAvailabilityCh,
+				testCase.scheduler.errCh,
+			)
+			cancel()
+		})
+	}
+}
+
+func TestRunJobLoop(t *testing.T) {
+	const testProject = "manhattan"
+	testCases := []struct {
+		name       string
+		setup      func(ctx context.Context, cancelFn func()) *scheduler
+		assertions func(error)
+	}{
+		{
+			name: "error getting queue reader",
+			setup: func(_ context.Context, cancelFn func()) *scheduler {
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return nil, errors.New("something went wrong")
+						},
+					},
+					jobLoopErrFn: func(i ...interface{}) {
+						require.Fail(
+							t,
+							"error logging function should not have been called",
+						)
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.Equal(t, err.Error(), "something went wrong")
+			},
+		},
+
+		{
+			name: "error reading a message",
+			setup: func(_ context.Context, cancelFn func()) *scheduler {
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return &mockQueueReader{
+								ReadFn: func(c context.Context) (*queue.Message, error) {
+									return nil, errors.New("something went wrong")
+								},
+								CloseFn: func(c context.Context) error {
+									return nil
+								},
+							}, nil
+						},
+					},
+					jobLoopErrFn: func(i ...interface{}) {
+						err := i[0].(error)
+						require.Equal(t, err.Error(), "something went wrong")
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+
+		{
+			name: "message is invalid",
+			setup: func(_ context.Context, cancelFn func()) *scheduler {
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return &mockQueueReader{
+								ReadFn: func(c context.Context) (*queue.Message, error) {
+									return &queue.Message{
+										Message: "foo", // Expected format is event:job
+										Ack: func(context.Context) error {
+											return nil
+										},
+									}, nil
+								},
+								CloseFn: func(c context.Context) error {
+									return nil
+								},
+							}, nil
+						},
+					},
+					jobLoopErrFn: func(i ...interface{}) {
+						err := i[0].(error)
+						require.Contains(t, err.Error(), "received invalid message")
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+
+		{
+			name: "error getting the event",
+			setup: func(_ context.Context, cancelFn func()) *scheduler {
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return &mockQueueReader{
+								ReadFn: func(c context.Context) (*queue.Message, error) {
+									return &queue.Message{
+										Message: "foo:bar",
+										Ack: func(context.Context) error {
+											return nil
+										},
+									}, nil
+								},
+								CloseFn: func(c context.Context) error {
+									return nil
+								},
+							}, nil
+						},
+					},
+					getEventFn: func(context.Context, string) (core.Event, error) {
+						return core.Event{}, errors.New("something went wrong")
+					},
+					updateJobStatusFn: func(
+						context.Context,
+						string,
+						string,
+						core.JobStatus,
+					) error {
+						return nil
+					},
+					jobLoopErrFn: func(i ...interface{}) {
+						err := i[0].(error)
+						require.Equal(t, err.Error(), "something went wrong")
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+
+		{
+			name: "job does not exist",
+			setup: func(_ context.Context, cancelFn func()) *scheduler {
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return &mockQueueReader{
+								ReadFn: func(c context.Context) (*queue.Message, error) {
+									return &queue.Message{
+										Message: "foo:bar",
+										Ack: func(context.Context) error {
+											return nil
+										},
+									}, nil
+								},
+								CloseFn: func(c context.Context) error {
+									return nil
+								},
+							}, nil
+						},
+					},
+					getEventFn: func(context.Context, string) (core.Event, error) {
+						return core.Event{
+							Worker: &core.Worker{},
+						}, nil
+					},
+					jobLoopErrFn: func(i ...interface{}) {
+						err := i[0].(error)
+						require.Contains(t, err.Error(), "no job")
+						require.Contains(t, err.Error(), "exists for event")
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+
+		{
+			name: "job phase is not PENDING",
+			setup: func(_ context.Context, cancelFn func()) *scheduler {
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return &mockQueueReader{
+								ReadFn: func(c context.Context) (*queue.Message, error) {
+									return &queue.Message{
+										Message: "foo:bar",
+										Ack: func(context.Context) error {
+											return nil
+										},
+									}, nil
+								},
+								CloseFn: func(c context.Context) error {
+									return nil
+								},
+							}, nil
+						},
+					},
+					getEventFn: func(context.Context, string) (core.Event, error) {
+						cancelFn()
+						return core.Event{
+							Worker: &core.Worker{
+								Jobs: map[string]core.Job{
+									"bar": {
+										Status: &core.JobStatus{
+											Phase: core.JobPhaseRunning,
+										},
+									},
+								},
+							},
+						}, nil
+					},
+					jobLoopErrFn: func(i ...interface{}) {
+						require.Fail(
+							t,
+							"error logging function should not have been called",
+						)
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+
+		{
+			name: "error starting job",
+			setup: func(ctx context.Context, cancelFn func()) *scheduler {
+				jobAvailabilityCh := make(chan struct{})
+				go func() {
+					select {
+					case jobAvailabilityCh <- struct{}{}:
+					case <-ctx.Done():
+					}
+					select {
+					case <-jobAvailabilityCh:
+					case <-ctx.Done():
+					}
+				}()
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return &mockQueueReader{
+								ReadFn: func(c context.Context) (*queue.Message, error) {
+									return &queue.Message{
+										Message: "foo:bar",
+										Ack: func(context.Context) error {
+											return nil
+										},
+									}, nil
+								},
+								CloseFn: func(c context.Context) error {
+									return nil
+								},
+							}, nil
+						},
+					},
+					getEventFn: func(context.Context, string) (core.Event, error) {
+						return core.Event{
+							Worker: &core.Worker{
+								Jobs: map[string]core.Job{
+									"bar": {
+										Status: &core.JobStatus{
+											Phase: core.JobPhasePending,
+										},
+									},
+								},
+							},
+						}, nil
+					},
+					jobAvailabilityCh: jobAvailabilityCh,
+					startJobFn: func(context.Context, string, string) error {
+						return errors.New("something went wrong")
+					},
+					jobLoopErrFn: func(i ...interface{}) {
+						err := i[0].(error)
+						require.Equal(t, err.Error(), "something went wrong")
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+
+		{
+			name: "success",
+			setup: func(ctx context.Context, cancelFn func()) *scheduler {
+				jobAvailabilityCh := make(chan struct{})
+				go func() {
+					select {
+					case jobAvailabilityCh <- struct{}{}:
+					case <-ctx.Done():
+					}
+					select {
+					case <-jobAvailabilityCh:
+					case <-ctx.Done():
+					}
+				}()
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return &mockQueueReader{
+								ReadFn: func(c context.Context) (*queue.Message, error) {
+									return &queue.Message{
+										Message: "foo:bar",
+										Ack: func(context.Context) error {
+											return nil
+										},
+									}, nil
+								},
+								CloseFn: func(c context.Context) error {
+									return nil
+								},
+							}, nil
+						},
+					},
+					getEventFn: func(context.Context, string) (core.Event, error) {
+						return core.Event{
+							Worker: &core.Worker{
+								Jobs: map[string]core.Job{
+									"bar": {
+										Status: &core.JobStatus{
+											Phase: core.JobPhasePending,
+										},
+									},
+								},
+							},
+						}, nil
+					},
+					jobAvailabilityCh: jobAvailabilityCh,
+					startJobFn: func(context.Context, string, string) error {
+						cancelFn()
+						return nil
+					},
+					jobLoopErrFn: func(i ...interface{}) {
+						require.Fail(
+							t,
+							"error logging function should not have been called",
+						)
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			scheduler := testCase.setup(ctx, cancel)
+			scheduler.errCh = make(chan error)
+			go scheduler.runJobLoop(ctx, testProject)
+			// Listen for errors
+			select {
+			case err := <-scheduler.errCh:
+				cancel()
+				testCase.assertions(err)
+			case <-ctx.Done():
+			}
+			cancel()
+		})
+	}
+}

--- a/v2/scheduler/main.go
+++ b/v2/scheduler/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"log"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/v2/internal/signals"
+	"github.com/brigadecore/brigade/v2/internal/version"
+	"github.com/brigadecore/brigade/v2/scheduler/internal/lib/queue"
+	"github.com/brigadecore/brigade/v2/scheduler/internal/lib/queue/amqp"
+)
+
+func main() {
+	log.Printf(
+		"Starting Brigade Scheduler -- version %s -- commit %s",
+		version.Version(),
+		version.Commit(),
+	)
+
+	ctx := signals.Context()
+
+	// Brigade core API client
+	var apiClient core.APIClient
+	{
+		address, token, opts, err := apiClientConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+		apiClient = core.NewAPIClient(address, token, &opts)
+	}
+
+	// Message receiving abstraction
+	var queueReaderFactory queue.ReaderFactory
+	{
+		config, err := readerFactoryConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+		queueReaderFactory = amqp.NewReaderFactory(config)
+	}
+	defer queueReaderFactory.Close(ctx)
+
+	// Scheduler
+	var scheduler *scheduler
+	{
+		config, err := getSchedulerConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+		scheduler = newScheduler(
+			apiClient,
+			queueReaderFactory,
+			config,
+		)
+	}
+
+	// Run it!
+	log.Println(scheduler.run(ctx))
+}

--- a/v2/scheduler/projects.go
+++ b/v2/scheduler/projects.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/pkg/errors"
+)
+
+func (s *scheduler) manageProjects(ctx context.Context) {
+	// Maintain a map of functions for canceling the loops for each known Project
+	loopCancelFns := map[string]func(){}
+
+	ticker := time.NewTicker(s.config.addAndRemoveProjectsInterval)
+	defer ticker.Stop()
+
+	for {
+
+		// Build a set of current projects. This makes it a little faster and easier
+		// to search for projects later in this algorithm.
+		currentProjects := map[string]struct{}{}
+		listOpts := &meta.ListOptions{Limit: 100}
+		for {
+			projects, err := s.listProjectsFn(ctx, nil, listOpts)
+			if err != nil {
+				select {
+				case s.errCh <- errors.Wrap(err, "error listing projects"):
+				case <-ctx.Done():
+				}
+				return
+			}
+			for _, project := range projects.Items {
+				currentProjects[project.ID] = struct{}{}
+			}
+			if projects.RemainingItemCount > 0 {
+				listOpts.Continue = projects.Continue
+			} else {
+				break
+			}
+		}
+
+		// Reconcile differences between projects we knew about already and the
+		// current set of projects...
+
+		// Stop Worker and Job scheduling loops for projects that have been deleted
+		for projectID, cancelFn := range loopCancelFns {
+			if _, stillExists := currentProjects[projectID]; !stillExists {
+				log.Printf(
+					"stopping worker and job scheduling loops for project %q",
+					projectID,
+				)
+				cancelFn()
+				delete(loopCancelFns, projectID)
+			}
+		}
+
+		// Start Worker and Job scheduling loops for any projects that have been
+		// added
+		for projectID := range currentProjects {
+			if _, known := loopCancelFns[projectID]; !known {
+				loopCtx, loopCtxCancelFn := context.WithCancel(ctx)
+				loopCancelFns[projectID] = loopCtxCancelFn
+				log.Printf(
+					"starting worker and job scheduling loops for project %q",
+					projectID,
+				)
+				go s.runWorkerLoopFn(loopCtx, projectID)
+				go s.runJobLoopFn(loopCtx, projectID)
+			}
+		}
+
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return
+		}
+	}
+
+}

--- a/v2/scheduler/projects_test.go
+++ b/v2/scheduler/projects_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManageProjects(t *testing.T) {
+	testCases := []struct {
+		name       string
+		setup      func() *scheduler
+		assertions func(error)
+	}{
+		{
+			name: "error listing projects",
+			setup: func() *scheduler {
+				return &scheduler{
+					config: schedulerConfig{
+						addAndRemoveProjectsInterval: time.Second,
+					},
+					listProjectsFn: func(
+						context.Context,
+						*core.ProjectsSelector,
+						*meta.ListOptions,
+					) (core.ProjectList, error) {
+						return core.ProjectList{}, errors.New("something went wrong")
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error listing projects")
+			},
+		},
+		{
+			name: "success",
+			setup: func() *scheduler {
+				return &scheduler{
+					config: schedulerConfig{
+						addAndRemoveProjectsInterval: time.Second,
+					},
+					listProjectsFn: func(
+						context.Context,
+						*core.ProjectsSelector,
+						*meta.ListOptions,
+					) (core.ProjectList, error) {
+						return core.ProjectList{
+							Items: []core.Project{
+								{
+									ObjectMeta: meta.ObjectMeta{
+										ID: "blue-book",
+									},
+								},
+							},
+						}, nil
+					},
+					runWorkerLoopFn: func(context.Context, string) {},
+					runJobLoopFn:    func(context.Context, string) {},
+				}
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			scheduler := testCase.setup()
+			scheduler.errCh = make(chan error)
+			go scheduler.manageProjects(ctx)
+			// Listen for errors
+			select {
+			case err := <-scheduler.errCh:
+				testCase.assertions(err)
+			case <-ctx.Done():
+				testCase.assertions(nil)
+			}
+			cancel()
+		})
+	}
+}

--- a/v2/scheduler/scheduler.go
+++ b/v2/scheduler/scheduler.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/sdk/v2/meta"
+	"github.com/brigadecore/brigade/v2/internal/os"
+	"github.com/brigadecore/brigade/v2/scheduler/internal/lib/queue"
+)
+
+type schedulerConfig struct {
+	addAndRemoveProjectsInterval time.Duration
+	maxConcurrentWorkers         int
+	maxConcurrentJobs            int
+}
+
+func getSchedulerConfig() (schedulerConfig, error) {
+	config := schedulerConfig{}
+	var err error
+	config.addAndRemoveProjectsInterval, err =
+		os.GetDurationFromEnvVar("ADD_REMOVE_PROJECT_INTERVAL", 30*time.Second)
+	if err != nil {
+		return config, err
+	}
+	config.maxConcurrentWorkers, err =
+		os.GetIntFromEnvVar("MAX_CONCURRENT_WORKERS", 1)
+	if err != nil {
+		return config, err
+	}
+	config.maxConcurrentJobs, err = os.GetIntFromEnvVar("MAX_CONCURRENT_JOBS", 3)
+	return config, err
+}
+
+type scheduler struct {
+	queueReaderFactory   queue.ReaderFactory
+	config               schedulerConfig
+	workerAvailabilityCh chan struct{}
+	jobAvailabilityCh    chan struct{}
+	// All of the scheduler's goroutines will send fatal errors here
+	errCh chan error
+	// All of these internal functions are overridable for testing purposes
+	manageWorkerCapacityFn func(context.Context)
+	workerLoopErrFn        func(...interface{})
+	manageJobCapacityFn    func(context.Context)
+	jobLoopErrFn           func(...interface{})
+	manageProjectsFn       func(context.Context)
+	runWorkerLoopFn        func(ctx context.Context, projectID string)
+	runJobLoopFn           func(ctx context.Context, projectID string)
+	// These normally point to API client functions, but can also be overridden
+	// for test purposes
+	listProjectsFn func(
+		context.Context,
+		*core.ProjectsSelector,
+		*meta.ListOptions,
+	) (core.ProjectList, error)
+	countRunningWorkersFn func(context.Context) (core.SubstrateWorkerCount, error)
+	countRunningJobsFn    func(context.Context) (core.SubstrateJobCount, error)
+	getEventFn            func(context.Context, string) (core.Event, error)
+	updateWorkerStatusFn  func(
+		ctx context.Context,
+		eventID string,
+		status core.WorkerStatus,
+	) error
+	startWorkerFn     func(ctx context.Context, eventID string) error
+	updateJobStatusFn func(
+		ctx context.Context,
+		eventID string,
+		jobName string,
+		status core.JobStatus,
+	) error
+	startJobFn func(ctx context.Context, eventID string, jobName string) error
+}
+
+func newScheduler(
+	coreClient core.APIClient,
+	queueReaderFactory queue.ReaderFactory,
+	config schedulerConfig,
+) *scheduler {
+	s := &scheduler{
+		queueReaderFactory:   queueReaderFactory,
+		config:               config,
+		workerAvailabilityCh: make(chan struct{}),
+		jobAvailabilityCh:    make(chan struct{}),
+		errCh:                make(chan error),
+		// API functions
+		listProjectsFn:        coreClient.Projects().List,
+		countRunningWorkersFn: coreClient.Substrate().CountRunningWorkers,
+		countRunningJobsFn:    coreClient.Substrate().CountRunningJobs,
+		getEventFn:            coreClient.Events().Get,
+		updateWorkerStatusFn:  coreClient.Events().Workers().UpdateStatus,
+		startWorkerFn:         coreClient.Events().Workers().Start,
+		updateJobStatusFn:     coreClient.Events().Workers().Jobs().UpdateStatus,
+		startJobFn:            coreClient.Events().Workers().Jobs().Start,
+	}
+	s.manageWorkerCapacityFn = s.manageWorkerCapacity
+	s.workerLoopErrFn = log.Println
+	s.manageJobCapacityFn = s.manageJobCapacity
+	s.jobLoopErrFn = log.Println
+	s.manageProjectsFn = s.manageProjects
+	s.runWorkerLoopFn = s.runWorkerLoop
+	s.runJobLoopFn = s.runJobLoop
+	return s
+}
+
+// run coordinates the many goroutines involved in different aspects of the
+// scheduler. If any one of these goroutines encounters an unrecoverable error,
+// everything shuts down.
+func (s *scheduler) run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	wg := sync.WaitGroup{}
+
+	// Manage available Worker capacity
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.manageWorkerCapacityFn(ctx)
+	}()
+
+	// Manage available Job capacity
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.manageJobCapacityFn(ctx)
+	}()
+
+	// Monitor for new/deleted projects at a regular interval. Launch new or kill
+	// existing project-specific Worker and Job loops as needed.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.manageProjectsFn(ctx)
+	}()
+
+	// Wait for an error or a completed context
+	var err error
+	select {
+	case err = <-s.errCh:
+		cancel() // Shut it all down
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
+
+	// Adapt wg to a channel that can be used in a select
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		wg.Wait()
+	}()
+
+	select {
+	case <-doneCh:
+	case <-time.After(3 * time.Second):
+		// Probably doesn't matter that this is hardcoded. Relatively speaking, 3
+		// seconds is a lot of time for things to wrap up.
+	}
+
+	return err
+}

--- a/v2/scheduler/scheduler_test.go
+++ b/v2/scheduler/scheduler_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
+	"github.com/brigadecore/brigade/v2/scheduler/internal/lib/queue"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSchedulerConfig(t *testing.T) {
+	// Note that unit testing in Go does NOT clear environment variables between
+	// tests, which can sometimes be a pain, but it's fine here-- so each of these
+	// test cases builds on the previous case.
+	testCases := []struct {
+		name       string
+		setup      func()
+		assertions func(schedulerConfig, error)
+	}{
+		{
+			name:  "success with defaults",
+			setup: func() {},
+			assertions: func(config schedulerConfig, err error) {
+				require.Equal(t, 30*time.Second, config.addAndRemoveProjectsInterval)
+				require.Equal(t, 1, config.maxConcurrentWorkers)
+				require.Equal(t, 3, config.maxConcurrentJobs)
+			},
+		},
+		{
+			name: "ADD_REMOVE_PROJECT_INTERVAL not parsable as duration",
+			setup: func() {
+				os.Setenv("ADD_REMOVE_PROJECT_INTERVAL", "foo")
+			},
+			assertions: func(config schedulerConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "was not parsable as a duration")
+				require.Contains(t, err.Error(), "ADD_REMOVE_PROJECT_INTERVAL")
+			},
+		},
+		{
+			name: "MAX_CONCURRENT_WORKERS not parsable as int",
+			setup: func() {
+				os.Setenv("ADD_REMOVE_PROJECT_INTERVAL", "1m")
+				os.Setenv("MAX_CONCURRENT_WORKERS", "foo")
+			},
+			assertions: func(config schedulerConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "was not parsable as an int")
+				require.Contains(t, err.Error(), "MAX_CONCURRENT_WORKERS")
+			},
+		},
+		{
+			name: "MAX_CONCURRENT_JOBS not parsable as int",
+			setup: func() {
+				os.Setenv("ADD_REMOVE_PROJECT_INTERVAL", "1m")
+				os.Setenv("MAX_CONCURRENT_WORKERS", "5")
+				os.Setenv("MAX_CONCURRENT_JOBS", "foo")
+			},
+			assertions: func(config schedulerConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "was not parsable as an int")
+				require.Contains(t, err.Error(), "MAX_CONCURRENT_JOBS")
+			},
+		},
+		{
+			name: "success with overrides",
+			setup: func() {
+				os.Setenv("ADD_REMOVE_PROJECT_INTERVAL", "1m")
+				os.Setenv("MAX_CONCURRENT_WORKERS", "5")
+				os.Setenv("MAX_CONCURRENT_JOBS", "10")
+			},
+			assertions: func(config schedulerConfig, err error) {
+				require.Equal(t, time.Minute, config.addAndRemoveProjectsInterval)
+				require.Equal(t, 5, config.maxConcurrentWorkers)
+				require.Equal(t, 10, config.maxConcurrentJobs)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.setup()
+			config, err := getSchedulerConfig()
+			testCase.assertions(config, err)
+		})
+	}
+}
+
+func TestNewScheduler(t *testing.T) {
+	coreClient := core.NewAPIClient("", "", &restmachinery.APIClientOptions{})
+	queueReaderFactory := &mockQueueReaderFactory{}
+	config := schedulerConfig{
+		addAndRemoveProjectsInterval: 2 * time.Minute,
+	}
+	scheduler := newScheduler(coreClient, queueReaderFactory, config)
+	require.Same(t, queueReaderFactory, scheduler.queueReaderFactory)
+	require.Equal(t, config, scheduler.config)
+	require.NotNil(t, scheduler.workerAvailabilityCh)
+	require.NotNil(t, scheduler.jobAvailabilityCh)
+	require.NotNil(t, scheduler.errCh)
+}
+
+func TestSchedulerRun(t *testing.T) {
+	testCases := []struct {
+		name       string
+		setup      func() *scheduler
+		assertions func(context.Context, error)
+	}{
+		{
+			name: "worker capacity manager produced error",
+			setup: func() *scheduler {
+				s := &scheduler{
+					manageJobCapacityFn: func(context.Context) {},
+					manageProjectsFn:    func(context.Context) {},
+					errCh:               make(chan error),
+				}
+				s.manageWorkerCapacityFn = func(context.Context) {
+					s.errCh <- errors.New("something went wrong")
+				}
+				return s
+			},
+			assertions: func(_ context.Context, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+			},
+		},
+		{
+			name: "job capacity manager produced error",
+			setup: func() *scheduler {
+				s := &scheduler{
+					manageWorkerCapacityFn: func(context.Context) {},
+					manageProjectsFn:       func(context.Context) {},
+					errCh:                  make(chan error),
+				}
+				s.manageJobCapacityFn = func(context.Context) {
+					s.errCh <- errors.New("something went wrong")
+				}
+				return s
+			},
+			assertions: func(_ context.Context, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+			},
+		},
+		{
+			name: "projects manager produced error",
+			setup: func() *scheduler {
+				s := &scheduler{
+					manageWorkerCapacityFn: func(context.Context) {},
+					manageJobCapacityFn:    func(context.Context) {},
+					errCh:                  make(chan error),
+				}
+				s.manageProjectsFn = func(context.Context) {
+					s.errCh <- errors.New("something went wrong")
+				}
+				return s
+			},
+			assertions: func(_ context.Context, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+			},
+		},
+		{
+			name: "context gets canceled",
+			setup: func() *scheduler {
+				return &scheduler{
+					manageWorkerCapacityFn: func(context.Context) {},
+					manageJobCapacityFn:    func(context.Context) {},
+					manageProjectsFn:       func(context.Context) {},
+					errCh:                  make(chan error),
+				}
+			},
+			assertions: func(ctx context.Context, err error) {
+				require.Error(t, err)
+				require.Equal(t, ctx.Err(), err)
+			},
+		},
+		{
+			name: "timeout during shutdown",
+			setup: func() *scheduler {
+				return &scheduler{
+					manageWorkerCapacityFn: func(context.Context) {},
+					manageJobCapacityFn:    func(context.Context) {},
+					manageProjectsFn: func(context.Context) {
+						// We'll make this function stubbornly never shut down. Everything
+						// should still be ok.
+						select {}
+					},
+					errCh: make(chan error),
+				}
+			},
+			assertions: func(ctx context.Context, err error) {
+				require.Error(t, err)
+				require.Equal(t, ctx.Err(), err)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			err := testCase.setup().run(ctx)
+			testCase.assertions(ctx, err)
+		})
+	}
+}
+
+type mockQueueReaderFactory struct {
+	NewReaderFn func(queueName string) (queue.Reader, error)
+	CloseFn     func(context.Context) error
+}
+
+func (m *mockQueueReaderFactory) NewReader(
+	queueName string) (queue.Reader, error) {
+	return m.NewReaderFn(queueName)
+}
+
+func (m *mockQueueReaderFactory) Close(ctx context.Context) error {
+	return m.CloseFn(ctx)
+}
+
+type mockQueueReader struct {
+	ReadFn  func(context.Context) (*queue.Message, error)
+	CloseFn func(context.Context) error
+}
+
+func (m *mockQueueReader) Read(ctx context.Context) (*queue.Message, error) {
+	return m.ReadFn(ctx)
+}
+
+func (m *mockQueueReader) Close(ctx context.Context) error {
+	return m.CloseFn(ctx)
+}

--- a/v2/scheduler/workers.go
+++ b/v2/scheduler/workers.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/v2/internal/retries"
+	"github.com/brigadecore/brigade/v2/scheduler/internal/lib/queue"
+)
+
+// manageWorkerCapacity periodically checks how many Workers are currently
+// running on the substrate and sends a signal on an availability channel when
+// there is available capacity.
+func (s *scheduler) manageWorkerCapacity(ctx context.Context) {
+	for {
+		// Look for capacity until we find some. Use a progressive backoff, capped
+		// at 10 seconds between retries.
+		if err := retries.ManageRetries(
+			ctx,
+			"find worker capacity",
+			0,              // Infinite retries
+			10*time.Second, // Max backoff
+			func() (bool, error) {
+				select {
+				case <-ctx.Done():
+					return false, nil // Stop looking
+				default:
+				}
+				substrateWorkerCount, err := s.countRunningWorkersFn(ctx)
+				if err != nil {
+					return false, err // Real error; stop retrying
+				}
+				if substrateWorkerCount.Count < s.config.maxConcurrentWorkers {
+					return false, nil // Found capacity; stop looking
+				}
+				return true, nil // Keep looking
+			},
+		); err != nil {
+			// Report error
+			select {
+			case s.errCh <- err:
+			case <-ctx.Done():
+			}
+			return
+		}
+
+		// Offer capacity to anyone who's ready for it
+		select {
+		case s.workerAvailabilityCh <- struct{}{}:
+		case <-ctx.Done():
+			return
+		}
+
+		// Wait to hear that whoever received the capacity has done whatever they
+		// were going to do. This helps prevent a race where we loop around and
+		// start looking for capacity and maybe find some that someone else is about
+		// to claim.
+		select {
+		case <-s.workerAvailabilityCh:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// nolint: gocyclo
+func (s *scheduler) runWorkerLoop(ctx context.Context, projectID string) {
+
+	var workersReader queue.Reader
+
+outerLoop:
+	for {
+
+		if workersReader != nil {
+			func() {
+				closeCtx, cancelCloseCtx :=
+					context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancelCloseCtx()
+				workersReader.Close(closeCtx)
+			}()
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		var err error
+		workersReader, err = s.queueReaderFactory.NewReader(
+			fmt.Sprintf("workers.%s", projectID),
+		)
+		if err != nil { // It's fatal if we can't get a queue reader
+			select {
+			case s.errCh <- err:
+			case <-ctx.Done():
+			}
+			return
+		}
+
+		// This is the main loop for receiving this Project's Events' Workers
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			// Get the next message
+			msg, err := workersReader.Read(ctx)
+			if err != nil {
+				s.workerLoopErrFn(err)
+				continue outerLoop // Try again with a new reader
+			}
+
+			eventID := msg.Message
+
+			event, err := s.getEventFn(ctx, eventID)
+			if err != nil {
+				s.workerLoopErrFn(err)
+
+				if err := s.updateWorkerStatusFn(
+					ctx,
+					eventID,
+					core.WorkerStatus{
+						Phase: core.WorkerPhaseSchedulingFailed,
+					},
+				); err != nil {
+					s.workerLoopErrFn(err)
+				}
+
+				// Ack the message because there's nothing we can do and we don't want
+				// something we can't process to clog the queue.
+				if err := msg.Ack(ctx); err != nil {
+					s.workerLoopErrFn(err)
+				}
+				continue // Next message
+			}
+
+			// If the Worker's phase isn't PENDING, then there's nothing to do
+			if event.Worker.Status.Phase != core.WorkerPhasePending {
+				if err := msg.Ack(ctx); err != nil {
+					s.workerLoopErrFn(err)
+				}
+				continue // Next message
+			}
+
+			// Wait for capacity
+			select {
+			case <-s.workerAvailabilityCh:
+			case <-ctx.Done():
+				continue outerLoop // This will do cleanup before returning
+			}
+
+			// TODO: In the future, it would be nice to be able to block on PROJECT
+			// capacity as well. i.e. Max of n concurrent workers per project. I
+			// (krancour) see this as a post-2.0 enhancement.
+
+			// Now use the API to start the Worker...
+
+			if err := s.startWorkerFn(ctx, event.ID); err != nil {
+				s.workerLoopErrFn(err)
+			}
+
+			if err := msg.Ack(ctx); err != nil {
+				s.workerLoopErrFn(err)
+			}
+
+			// Tell the capacity manager we used the capacity it gave us
+			select {
+			case s.workerAvailabilityCh <- struct{}{}:
+			case <-ctx.Done():
+				continue outerLoop // This will do cleanup before returning
+			}
+		}
+
+	}
+
+}

--- a/v2/scheduler/workers_test.go
+++ b/v2/scheduler/workers_test.go
@@ -1,0 +1,411 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/v2/scheduler/internal/lib/queue"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManageWorkerCapacity(t *testing.T) {
+	testCases := []struct {
+		name       string
+		scheduler  *scheduler
+		assertions func(
+			ctx context.Context,
+			workerAvailabilityCh chan struct{},
+			errCh chan error,
+		)
+	}{
+		{
+			name: "error checking capacity",
+			scheduler: &scheduler{
+				config: schedulerConfig{
+					maxConcurrentWorkers: 2,
+				},
+				countRunningWorkersFn: func(
+					context.Context,
+				) (core.SubstrateWorkerCount, error) {
+					return core.SubstrateWorkerCount{}, errors.New("something went wrong")
+				},
+				workerAvailabilityCh: make(chan struct{}),
+				errCh:                make(chan error),
+			},
+			assertions: func(
+				ctx context.Context,
+				workerAvailabilityCh chan struct{},
+				errCh chan error,
+			) {
+				select {
+				case <-workerAvailabilityCh:
+					require.Fail(
+						t,
+						"notified of available capacity when we should have received "+
+							"an error",
+					)
+				case err := <-errCh:
+					require.Error(t, err)
+					require.Contains(t, err.Error(), "something went wrong")
+				case <-ctx.Done():
+					require.Fail(t, "never received expected error")
+				}
+			},
+		},
+		{
+			name: "no capacity available",
+			scheduler: &scheduler{
+				config: schedulerConfig{
+					maxConcurrentWorkers: 2,
+				},
+				countRunningWorkersFn: func(
+					context.Context,
+				) (core.SubstrateWorkerCount, error) {
+					return core.SubstrateWorkerCount{
+						Count: 2,
+					}, nil
+				},
+				workerAvailabilityCh: make(chan struct{}),
+				errCh:                make(chan error),
+			},
+			assertions: func(
+				ctx context.Context,
+				workerAvailabilityCh chan struct{},
+				errCh chan error,
+			) {
+				select {
+				case <-workerAvailabilityCh:
+					require.Fail(t, "notified of available capacity when none existed")
+				case <-errCh:
+					require.Fail(t, "received unexpected error")
+				case <-ctx.Done():
+				}
+			},
+		},
+		{
+			name: "capacity available",
+			scheduler: &scheduler{
+				config: schedulerConfig{
+					maxConcurrentWorkers: 2,
+				},
+				countRunningWorkersFn: func(
+					context.Context,
+				) (core.SubstrateWorkerCount, error) {
+					return core.SubstrateWorkerCount{
+						Count: 1,
+					}, nil
+				},
+				workerAvailabilityCh: make(chan struct{}),
+				errCh:                make(chan error),
+			},
+			assertions: func(
+				ctx context.Context,
+				workerAvailabilityCh chan struct{},
+				errCh chan error,
+			) {
+				select {
+				case <-workerAvailabilityCh:
+					// Signal back to the capacity manager
+					workerAvailabilityCh <- struct{}{}
+				case <-errCh:
+					require.Fail(t, "received unexpected error")
+				case <-ctx.Done():
+					require.Fail(t, "never notified of existing capacity")
+				}
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			go testCase.scheduler.manageWorkerCapacity(ctx)
+			testCase.assertions(
+				ctx,
+				testCase.scheduler.workerAvailabilityCh,
+				testCase.scheduler.errCh,
+			)
+			cancel()
+		})
+	}
+}
+
+func TestRunWorkerLoop(t *testing.T) {
+	const testProject = "manhattan"
+	testCases := []struct {
+		name       string
+		setup      func(ctx context.Context, cancelFn func()) *scheduler
+		assertions func(error)
+	}{
+		{
+			name: "error getting queue reader",
+			setup: func(_ context.Context, cancelFn func()) *scheduler {
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return nil, errors.New("something went wrong")
+						},
+					},
+					workerLoopErrFn: func(i ...interface{}) {
+						require.Fail(
+							t,
+							"error logging function should not have been called",
+						)
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.Equal(t, err.Error(), "something went wrong")
+			},
+		},
+
+		{
+			name: "error reading a message",
+			setup: func(_ context.Context, cancelFn func()) *scheduler {
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return &mockQueueReader{
+								ReadFn: func(c context.Context) (*queue.Message, error) {
+									return nil, errors.New("something went wrong")
+								},
+								CloseFn: func(c context.Context) error {
+									return nil
+								},
+							}, nil
+						},
+					},
+					workerLoopErrFn: func(i ...interface{}) {
+						err := i[0].(error)
+						require.Equal(t, err.Error(), "something went wrong")
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+
+		{
+			name: "error getting the event",
+			setup: func(_ context.Context, cancelFn func()) *scheduler {
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return &mockQueueReader{
+								ReadFn: func(c context.Context) (*queue.Message, error) {
+									return &queue.Message{
+										Ack: func(context.Context) error {
+											return nil
+										},
+									}, nil
+								},
+								CloseFn: func(c context.Context) error {
+									return nil
+								},
+							}, nil
+						},
+					},
+					getEventFn: func(context.Context, string) (core.Event, error) {
+						return core.Event{}, errors.New("something went wrong")
+					},
+					updateWorkerStatusFn: func(
+						context.Context,
+						string,
+						core.WorkerStatus,
+					) error {
+						return nil
+					},
+					workerLoopErrFn: func(i ...interface{}) {
+						err := i[0].(error)
+						require.Equal(t, err.Error(), "something went wrong")
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+
+		{
+			name: "worker phase is not PENDING",
+			setup: func(_ context.Context, cancelFn func()) *scheduler {
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return &mockQueueReader{
+								ReadFn: func(c context.Context) (*queue.Message, error) {
+									return &queue.Message{
+										Ack: func(context.Context) error {
+											return nil
+										},
+									}, nil
+								},
+								CloseFn: func(c context.Context) error {
+									return nil
+								},
+							}, nil
+						},
+					},
+					getEventFn: func(context.Context, string) (core.Event, error) {
+						cancelFn()
+						return core.Event{
+							Worker: &core.Worker{
+								Status: core.WorkerStatus{
+									Phase: core.WorkerPhaseRunning,
+								},
+							},
+						}, nil
+					},
+					workerLoopErrFn: func(i ...interface{}) {
+						require.Fail(
+							t,
+							"error logging function should not have been called",
+						)
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+
+		{
+			name: "error starting worker",
+			setup: func(ctx context.Context, cancelFn func()) *scheduler {
+				workerAvailabilityCh := make(chan struct{})
+				go func() {
+					select {
+					case workerAvailabilityCh <- struct{}{}:
+					case <-ctx.Done():
+					}
+					select {
+					case <-workerAvailabilityCh:
+					case <-ctx.Done():
+					}
+				}()
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return &mockQueueReader{
+								ReadFn: func(c context.Context) (*queue.Message, error) {
+									return &queue.Message{
+										Ack: func(context.Context) error {
+											return nil
+										},
+									}, nil
+								},
+								CloseFn: func(c context.Context) error {
+									return nil
+								},
+							}, nil
+						},
+					},
+					getEventFn: func(context.Context, string) (core.Event, error) {
+						return core.Event{
+							Worker: &core.Worker{
+								Status: core.WorkerStatus{
+									Phase: core.WorkerPhasePending,
+								},
+							},
+						}, nil
+					},
+					workerAvailabilityCh: workerAvailabilityCh,
+					startWorkerFn: func(context.Context, string) error {
+						return errors.New("something went wrong")
+					},
+					workerLoopErrFn: func(i ...interface{}) {
+						err := i[0].(error)
+						require.Equal(t, err.Error(), "something went wrong")
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+
+		{
+			name: "success",
+			setup: func(ctx context.Context, cancelFn func()) *scheduler {
+				workerAvailabilityCh := make(chan struct{})
+				go func() {
+					select {
+					case workerAvailabilityCh <- struct{}{}:
+					case <-ctx.Done():
+					}
+					select {
+					case <-workerAvailabilityCh:
+					case <-ctx.Done():
+					}
+				}()
+				return &scheduler{
+					queueReaderFactory: &mockQueueReaderFactory{
+						NewReaderFn: func(queueName string) (queue.Reader, error) {
+							return &mockQueueReader{
+								ReadFn: func(c context.Context) (*queue.Message, error) {
+									return &queue.Message{
+										Ack: func(context.Context) error {
+											return nil
+										},
+									}, nil
+								},
+								CloseFn: func(c context.Context) error {
+									return nil
+								},
+							}, nil
+						},
+					},
+					getEventFn: func(context.Context, string) (core.Event, error) {
+						return core.Event{
+							Worker: &core.Worker{
+								Status: core.WorkerStatus{
+									Phase: core.WorkerPhasePending,
+								},
+							},
+						}, nil
+					},
+					workerAvailabilityCh: workerAvailabilityCh,
+					startWorkerFn: func(context.Context, string) error {
+						cancelFn()
+						return nil
+					},
+					workerLoopErrFn: func(i ...interface{}) {
+						require.Fail(
+							t,
+							"error logging function should not have been called",
+						)
+						cancelFn()
+					},
+				}
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			scheduler := testCase.setup(ctx, cancel)
+			scheduler.errCh = make(chan error)
+			go scheduler.runWorkerLoop(ctx, testProject)
+			// Listen for errors
+			select {
+			case err := <-scheduler.errCh:
+				testCase.assertions(err)
+			case <-ctx.Done():
+				testCase.assertions(nil)
+			}
+			cancel()
+		})
+	}
+}


### PR DESCRIPTION
This listens for queued workers and jobs and uses the API to kick them off when available system capacity permits.

But don't get _too_ excited. Any worker that gets kicked off should fail because the new worker image isn't PR'ed yet.