### PR TITLE
add api endpoints and client for getting insight into the substrate

### DIFF
--- a/sdk/v2/core/api_client.go
+++ b/sdk/v2/core/api_client.go
@@ -9,6 +9,9 @@ type APIClient interface {
 	Events() EventsClient
 	// Projects returns a specialized client for Project management.
 	Projects() ProjectsClient
+	// Substrate returns a specialized client for monitoring the state of the
+	// substrate.
+	Substrate() SubstrateClient
 }
 
 type apiClient struct {
@@ -16,6 +19,8 @@ type apiClient struct {
 	eventsClient EventsClient
 	// projectsClient is a specialized client for Project management.
 	projectsClient ProjectsClient
+	// substrateClient is a specialized client for substrate monitoring.
+	substrateClient SubstrateClient
 }
 
 // NewAPIClient returns an APIClient, which is the root of a tree of more
@@ -27,8 +32,9 @@ func NewAPIClient(
 	opts *restmachinery.APIClientOptions,
 ) APIClient {
 	return &apiClient{
-		eventsClient:   NewEventsClient(apiAddress, apiToken, opts),
-		projectsClient: NewProjectsClient(apiAddress, apiToken, opts),
+		eventsClient:    NewEventsClient(apiAddress, apiToken, opts),
+		projectsClient:  NewProjectsClient(apiAddress, apiToken, opts),
+		substrateClient: NewSubstrateClient(apiAddress, apiToken, opts),
 	}
 }
 
@@ -38,4 +44,8 @@ func (a *apiClient) Events() EventsClient {
 
 func (a *apiClient) Projects() ProjectsClient {
 	return a.projectsClient
+}
+
+func (a *apiClient) Substrate() SubstrateClient {
+	return a.substrateClient
 }

--- a/sdk/v2/core/api_client_test.go
+++ b/sdk/v2/core/api_client_test.go
@@ -13,4 +13,6 @@ func TestNewAPIClient(t *testing.T) {
 	require.Equal(t, client.(*apiClient).projectsClient, client.Projects())
 	require.NotNil(t, client.(*apiClient).eventsClient)
 	require.Equal(t, client.(*apiClient).eventsClient, client.Events())
+	require.NotNil(t, client.(*apiClient).substrateClient)
+	require.Equal(t, client.(*apiClient).substrateClient, client.Substrate())
 }

--- a/sdk/v2/core/substrate.go
+++ b/sdk/v2/core/substrate.go
@@ -1,0 +1,80 @@
+package core
+
+import (
+	"context"
+	"net/http"
+
+	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
+)
+
+// SubstrateWorkerCount represents a count of Workers currently executing on
+// the substrate.
+type SubstrateWorkerCount struct {
+	// Count is the cardinality of Workers currently executing on the substrate.
+	Count int `json:"count"`
+}
+
+// SubstrateJobCount represents a count of Workers currently executing on
+// the substrate.
+type SubstrateJobCount struct {
+	// Count is the cardinality of Jobs currently executing on the substrate.
+	Count int `json:"count"`
+}
+
+// SubstrateClient is the specialized client for monitoring the substrate.
+type SubstrateClient interface {
+	// CountRunningWorkers returns a count of Workers currently executing on the
+	// substrate.
+	CountRunningWorkers(context.Context) (SubstrateWorkerCount, error)
+	// CountRunningJobs returns a count of Jobs currently executing on the
+	// substrate.
+	CountRunningJobs(context.Context) (SubstrateJobCount, error)
+}
+
+type substrateClient struct {
+	*rm.BaseClient
+}
+
+// NewSubstrateClient returns a specialized client for monitoring the substrate.
+func NewSubstrateClient(
+	apiAddress string,
+	apiToken string,
+	opts *restmachinery.APIClientOptions,
+) SubstrateClient {
+	return &substrateClient{
+		BaseClient: rm.NewBaseClient(apiAddress, apiToken, opts),
+	}
+}
+
+func (s *substrateClient) CountRunningWorkers(
+	ctx context.Context,
+) (SubstrateWorkerCount, error) {
+	count := SubstrateWorkerCount{}
+	return count, s.ExecuteRequest(
+		ctx,
+		rm.OutboundRequest{
+			Method:      http.MethodGet,
+			Path:        "v2/substrate/running-workers",
+			AuthHeaders: s.BearerTokenAuthHeaders(),
+			SuccessCode: http.StatusOK,
+			RespObj:     &count,
+		},
+	)
+}
+
+func (s *substrateClient) CountRunningJobs(
+	ctx context.Context,
+) (SubstrateJobCount, error) {
+	count := SubstrateJobCount{}
+	return count, s.ExecuteRequest(
+		ctx,
+		rm.OutboundRequest{
+			Method:      http.MethodGet,
+			Path:        "v2/substrate/running-jobs",
+			AuthHeaders: s.BearerTokenAuthHeaders(),
+			SuccessCode: http.StatusOK,
+			RespObj:     &count,
+		},
+	)
+}

--- a/sdk/v2/core/substrate_test.go
+++ b/sdk/v2/core/substrate_test.go
@@ -1,0 +1,64 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSubstrateClient(t *testing.T) {
+	client := NewSubstrateClient(testAPIAddress, testAPIToken, nil)
+	require.IsType(t, &substrateClient{}, client)
+	requireBaseClient(t, client.(*substrateClient).BaseClient)
+}
+
+func TestSubstrateClientCountRunningWorkers(t *testing.T) {
+	testCount := SubstrateWorkerCount{
+		Count: 5,
+	}
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodGet, r.Method)
+				require.Equal(t, "/v2/substrate/running-workers", r.URL.Path)
+				bodyBytes, err := json.Marshal(testCount)
+				require.NoError(t, err)
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintln(w, string(bodyBytes))
+			},
+		),
+	)
+	defer server.Close()
+	client := NewSubstrateClient(server.URL, testAPIToken, nil)
+	count, err := client.CountRunningWorkers(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, testCount, count)
+}
+
+func TestSubstrateClientCountRunningJobs(t *testing.T) {
+	testCount := SubstrateJobCount{
+		Count: 5,
+	}
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodGet, r.Method)
+				require.Equal(t, "/v2/substrate/running-jobs", r.URL.Path)
+				bodyBytes, err := json.Marshal(testCount)
+				require.NoError(t, err)
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintln(w, string(bodyBytes))
+			},
+		),
+	)
+	defer server.Close()
+	client := NewSubstrateClient(server.URL, testAPIToken, nil)
+	count, err := client.CountRunningJobs(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, testCount, count)
+}

--- a/v2/apiserver/internal/core/common_test.go
+++ b/v2/apiserver/internal/core/common_test.go
@@ -126,13 +126,27 @@ func (m *mockEventsStore) DeleteMany(
 }
 
 type mockSubstrate struct {
-	CreateProjectFn func(
+	CountRunningWorkersFn func(context.Context) (SubstrateWorkerCount, error)
+	CountRunningJobsFn    func(context.Context) (SubstrateJobCount, error)
+	CreateProjectFn       func(
 		ctx context.Context,
 		project Project,
 	) (Project, error)
 	DeleteProjectFn       func(context.Context, Project) error
 	ScheduleWorkerFn      func(context.Context, Project, Event) error
 	DeleteWorkerAndJobsFn func(context.Context, Project, Event) error
+}
+
+func (m *mockSubstrate) CountRunningWorkers(
+	ctx context.Context,
+) (SubstrateWorkerCount, error) {
+	return m.CountRunningWorkersFn(ctx)
+}
+
+func (m *mockSubstrate) CountRunningJobs(
+	ctx context.Context,
+) (SubstrateJobCount, error) {
+	return m.CountRunningJobsFn(ctx)
 }
 
 func (m *mockSubstrate) CreateProject(

--- a/v2/apiserver/internal/core/rest/substrate_endpoints.go
+++ b/v2/apiserver/internal/core/rest/substrate_endpoints.go
@@ -1,0 +1,64 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/brigadecore/brigade/v2/apiserver/internal/core"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/restmachinery"
+	"github.com/gorilla/mux"
+)
+
+// SubstrateEndpoints implements restmachinery.Endpoints to provide
+// Substrate-related URL --> action mappings to a restmachinery.Server.
+type SubstrateEndpoints struct {
+	AuthFilter restmachinery.Filter
+	Service    core.SubstrateService
+}
+
+// Register is invoked by restmachinery.Server to register Project-related
+// URL --> action mappings to a restmachinery.Server.
+func (s *SubstrateEndpoints) Register(router *mux.Router) {
+	// Count running Workers
+	router.HandleFunc(
+		"/v2/substrate/running-workers",
+		s.AuthFilter.Decorate(s.countRunningWorkers),
+	).Methods(http.MethodGet)
+
+	// Count running Jobs
+	router.HandleFunc(
+		"/v2/substrate/running-jobs",
+		s.AuthFilter.Decorate(s.countRunningJobs),
+	).Methods(http.MethodGet)
+}
+
+func (s *SubstrateEndpoints) countRunningWorkers(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	restmachinery.ServeRequest(
+		restmachinery.InboundRequest{
+			W: w,
+			R: r,
+			EndpointLogic: func() (interface{}, error) {
+				return s.Service.CountRunningWorkers(r.Context())
+			},
+			SuccessCode: http.StatusOK,
+		},
+	)
+}
+
+func (s *SubstrateEndpoints) countRunningJobs(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	restmachinery.ServeRequest(
+		restmachinery.InboundRequest{
+			W: w,
+			R: r,
+			EndpointLogic: func() (interface{}, error) {
+				return s.Service.CountRunningJobs(r.Context())
+			},
+			SuccessCode: http.StatusOK,
+		},
+	)
+}

--- a/v2/apiserver/internal/core/substrate.go
+++ b/v2/apiserver/internal/core/substrate.go
@@ -1,10 +1,116 @@
 package core
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
+	"github.com/pkg/errors"
+)
+
+// SubstrateWorkerCount represents a count of Workers currently executing on
+// the substrate.
+type SubstrateWorkerCount struct {
+	// Count is the cardinality of Workers currently executing on the substrate.
+	Count int `json:"count"`
+}
+
+// MarshalJSON amends SubstrateWorkerCount instances with type metadata.
+func (s SubstrateWorkerCount) MarshalJSON() ([]byte, error) {
+	type Alias SubstrateWorkerCount
+	return json.Marshal(
+		struct {
+			meta.TypeMeta `json:",inline"`
+			Alias         `json:",inline"`
+		}{
+			TypeMeta: meta.TypeMeta{
+				APIVersion: meta.APIVersion,
+				Kind:       "SubstrateWorkerCount",
+			},
+			Alias: (Alias)(s),
+		},
+	)
+}
+
+// SubstrateJobCount represents a count of Workers currently executing on
+// the substrate.
+type SubstrateJobCount struct {
+	// Count is the cardinality of Jobs currently executing on the substrate.
+	Count int `json:"count"`
+}
+
+// MarshalJSON amends SubstrateJobCount instances with type metadata.
+func (s SubstrateJobCount) MarshalJSON() ([]byte, error) {
+	type Alias SubstrateJobCount
+	return json.Marshal(
+		struct {
+			meta.TypeMeta `json:",inline"`
+			Alias         `json:",inline"`
+		}{
+			TypeMeta: meta.TypeMeta{
+				APIVersion: meta.APIVersion,
+				Kind:       "SubstrateJobCount",
+			},
+			Alias: (Alias)(s),
+		},
+	)
+}
+
+// SubstrateService is the specialized interface for monitoring the state of the
+// substrate.
+type SubstrateService interface {
+	// CountRunningWorkers returns a count of Workers currently executing on the
+	// substrate.
+	CountRunningWorkers(context.Context) (SubstrateWorkerCount, error)
+	// CountRunningJobs returns a count of Jobs currently executing on the
+	// substrate.
+	CountRunningJobs(context.Context) (SubstrateJobCount, error)
+}
+
+type substrateService struct {
+	substrate Substrate
+}
+
+// NewSubstrateService returns a specialized interface for managing Projects.
+func NewSubstrateService(substrate Substrate) SubstrateService {
+	return &substrateService{
+		substrate: substrate,
+	}
+}
+
+func (s *substrateService) CountRunningWorkers(
+	ctx context.Context,
+) (SubstrateWorkerCount, error) {
+	count, err := s.substrate.CountRunningWorkers(ctx)
+	if err != nil {
+		return count, errors.Wrapf(
+			err,
+			"error counting running workers on substrate",
+		)
+	}
+	return count, nil
+}
+
+func (s *substrateService) CountRunningJobs(
+	ctx context.Context,
+) (SubstrateJobCount, error) {
+	count, err := s.substrate.CountRunningJobs(ctx)
+	if err != nil {
+		return count, errors.Wrapf(err, "error counting running jobs on substrate")
+	}
+	return count, nil
+}
 
 // Substrate is an interface for components that permit services to coordinate
 // with Brigade's underlying workload execution substrate, i.e. Kubernetes.
 type Substrate interface {
+	// CountRunningWorkers returns a count of Workers currently executing on the
+	// substrate.
+	CountRunningWorkers(context.Context) (SubstrateWorkerCount, error)
+	// CountRunningJobs returns a count of Jobs currently executing on the
+	// substrate.
+	CountRunningJobs(context.Context) (SubstrateJobCount, error)
+
 	// CreateProject prepares the substrate to host Project workloads. The
 	// provided Project argument may be amended with substrate-specific details
 	// and returned, so this function should be called prior to a Project being

--- a/v2/apiserver/internal/core/substrate_test.go
+++ b/v2/apiserver/internal/core/substrate_test.go
@@ -1,0 +1,133 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubstrateWorkerCountMarshalJSON(t *testing.T) {
+	requireAPIVersionAndType(t, &SubstrateWorkerCount{}, "SubstrateWorkerCount")
+}
+
+func TestSubstrateJobCountMarshalJSON(t *testing.T) {
+	requireAPIVersionAndType(t, &SubstrateJobCount{}, "SubstrateJobCount")
+}
+
+func TestNewSubstrateService(t *testing.T) {
+	substrate := &mockSubstrate{}
+	svc := NewSubstrateService(substrate)
+	require.Same(t, substrate, svc.(*substrateService).substrate)
+}
+
+func TestSubstrateServiceCountRunningWorkers(t *testing.T) {
+	const testCount = 5
+	testCases := []struct {
+		name       string
+		service    SubstrateService
+		assertions func(SubstrateWorkerCount, error)
+	}{
+		{
+			name: "error counting workers in substrate",
+			service: &substrateService{
+				substrate: &mockSubstrate{
+					CountRunningWorkersFn: func(
+						context.Context,
+					) (SubstrateWorkerCount, error) {
+						return SubstrateWorkerCount{}, errors.New("something went wrong")
+					},
+				},
+			},
+			assertions: func(_ SubstrateWorkerCount, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(
+					t,
+					err.Error(),
+					"error counting running workers on substrate",
+				)
+			},
+		},
+		{
+			name: "success",
+			service: &substrateService{
+				substrate: &mockSubstrate{
+					CountRunningWorkersFn: func(
+						context.Context,
+					) (SubstrateWorkerCount, error) {
+						return SubstrateWorkerCount{
+							Count: testCount,
+						}, nil
+					},
+				},
+			},
+			assertions: func(count SubstrateWorkerCount, err error) {
+				require.NoError(t, err)
+				require.Equal(t, testCount, count.Count)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			count, err := testCase.service.CountRunningWorkers(context.Background())
+			testCase.assertions(count, err)
+		})
+	}
+}
+
+func TestSubstrateServiceCountRunningJobs(t *testing.T) {
+	const testCount = 5
+	testCases := []struct {
+		name       string
+		service    SubstrateService
+		assertions func(SubstrateJobCount, error)
+	}{
+		{
+			name: "error counting jobs in substrate",
+			service: &substrateService{
+				substrate: &mockSubstrate{
+					CountRunningJobsFn: func(
+						context.Context,
+					) (SubstrateJobCount, error) {
+						return SubstrateJobCount{}, errors.New("something went wrong")
+					},
+				},
+			},
+			assertions: func(_ SubstrateJobCount, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(
+					t,
+					err.Error(),
+					"error counting running jobs on substrate",
+				)
+			},
+		},
+		{
+			name: "success",
+			service: &substrateService{
+				substrate: &mockSubstrate{
+					CountRunningJobsFn: func(
+						context.Context,
+					) (SubstrateJobCount, error) {
+						return SubstrateJobCount{
+							Count: testCount,
+						}, nil
+					},
+				},
+			},
+			assertions: func(count SubstrateJobCount, err error) {
+				require.NoError(t, err)
+				require.Equal(t, testCount, count.Count)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			count, err := testCase.service.CountRunningJobs(context.Background())
+			testCase.assertions(count, err)
+		})
+	}
+}

--- a/v2/apiserver/main.go
+++ b/v2/apiserver/main.go
@@ -123,6 +123,9 @@ func main() {
 		)
 	}
 
+	// Substrate service
+	substrateService := core.NewSubstrateService(substrate)
+
 	// Users service
 	usersService := authx.NewUsersService(usersStore, sessionsStore)
 
@@ -175,6 +178,10 @@ func main() {
 				&authxREST.SessionsEndpoints{
 					AuthFilter: authFilter,
 					Service:    sessionsService,
+				},
+				&coreREST.SubstrateEndpoints{
+					AuthFilter: authFilter,
+					Service:    substrateService,
 				},
 				&authxREST.UsersEndpoints{
 					AuthFilter: authFilter,


### PR DESCRIPTION
This is another PR aimed at reducing the size of my forthcoming scheduler PR.

While hacking on the scheduler, I realized there was a good opportunity to abstract the scheduler away from the underlying substrate by adding API endpoints that can give the scheduler the insight it needs into how many workers and jobs are currently running on the substrate.

i.e. This will stop the forthcoming scheduler component from having to be Kubernetes-specific in any way.