### PR TITLE
allow scheduler to authenticate to api server

### DIFF
--- a/v2/apiserver/config.go
+++ b/v2/apiserver/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brigadecore/brigade/v2/apiserver/internal/authx"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/core/kubernetes"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/crypto"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/queue/amqp"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/restmachinery"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/restmachinery/authn"
@@ -172,7 +173,15 @@ func tokenAuthFilterConfig(
 	}
 	config.OpenIDConnectEnabled, err =
 		os.GetBoolFromEnvVar("OIDC_ENABLED", false)
-	return config, err
+	if err != nil {
+		return config, err
+	}
+	schedulerToken, err := os.GetRequiredEnvVar("SCHEDULER_TOKEN")
+	if err != nil {
+		return config, err
+	}
+	config.HashedSchedulerToken = crypto.Hash("", schedulerToken)
+	return config, nil
 }
 
 // serverConfig returns a restmachinery.ServerConfig based on configuration

--- a/v2/apiserver/config_test.go
+++ b/v2/apiserver/config_test.go
@@ -353,9 +353,20 @@ func TestTokenAuthFilterConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "success",
+			name: "SCHEDULER_TOKEN not set",
 			setup: func() {
 				os.Setenv("OIDC_ENABLED", "true")
+			},
+			assertions: func(_ authn.TokenAuthFilterConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "SCHEDULER_TOKEN")
+			},
+		},
+		{
+			name: "success",
+			setup: func() {
+				os.Setenv("SCHEDULER_TOKEN", "foo")
 			},
 			assertions: func(config authn.TokenAuthFilterConfig, err error) {
 				require.NoError(t, err)

--- a/v2/apiserver/internal/authx/principals.go
+++ b/v2/apiserver/internal/authx/principals.go
@@ -2,8 +2,12 @@ package authx
 
 import "context"
 
-// Root is a singleton that represents Brigade's "root" user.
-var Root = &root{}
+var (
+	// Root is a singleton that represents Brigade's "root" user.
+	Root = &root{}
+	// Scheduler is a singleton that represents Brigade's scheduler component.
+	Scheduler = &scheduler{}
+)
 
 // Principal is an interface for any sort of security principal (human user,
 // service account, etc.)
@@ -11,6 +15,8 @@ type Principal interface{}
 
 // root is an implementation of the Principal interface for the "root" user.
 type root struct{}
+
+type scheduler struct{}
 
 type principalContextKey struct{}
 

--- a/v2/apiserver/internal/lib/restmachinery/authn/token_auth_test.go
+++ b/v2/apiserver/internal/lib/restmachinery/authn/token_auth_test.go
@@ -3,13 +3,13 @@ package authn
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/brigadecore/brigade/v2/apiserver/internal/authx"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/crypto"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,6 +55,30 @@ func TestFilter(t *testing.T) {
 		},
 
 		{
+			name: "token belongs to scheduler",
+			filter: &tokenAuthFilter{
+				config: TokenAuthFilterConfig{
+					HashedSchedulerToken: crypto.Hash("", "foo"),
+				},
+			},
+			setup: func() *http.Request {
+				req, err := http.NewRequest(http.MethodGet, "/", nil)
+				require.NoError(t, err)
+				req.Header.Add("Authorization", "Bearer foo")
+				return req
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				principal := authx.PrincipalFromContext(r.Context())
+				require.NotNil(t, principal)
+				require.Same(t, authx.Scheduler, principal)
+			},
+			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, rr.Code)
+				assert.True(t, handlerCalled)
+			},
+		},
+
+		{
 			name: "error finding service account",
 			filter: &tokenAuthFilter{
 				findServiceAccountByTokenFn: func(
@@ -67,10 +91,7 @@ func TestFilter(t *testing.T) {
 			setup: func() *http.Request {
 				req, err := http.NewRequest(http.MethodGet, "/", nil)
 				require.NoError(t, err)
-				req.Header.Add(
-					"Authorization",
-					fmt.Sprintf("Bearer %s", "foo"),
-				)
+				req.Header.Add("Authorization", "Bearer foo")
 				return req
 			},
 			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
@@ -95,10 +116,7 @@ func TestFilter(t *testing.T) {
 			setup: func() *http.Request {
 				req, err := http.NewRequest(http.MethodGet, "/", nil)
 				require.NoError(t, err)
-				req.Header.Add(
-					"Authorization",
-					fmt.Sprintf("Bearer %s", "foo"),
-				)
+				req.Header.Add("Authorization", "Bearer foo")
 				return req
 			},
 			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
@@ -125,10 +143,7 @@ func TestFilter(t *testing.T) {
 			setup: func() *http.Request {
 				req, err := http.NewRequest(http.MethodGet, "/", nil)
 				require.NoError(t, err)
-				req.Header.Add(
-					"Authorization",
-					fmt.Sprintf("Bearer %s", "foo"),
-				)
+				req.Header.Add("Authorization", "Bearer foo")
 				return req
 			},
 			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
@@ -156,10 +171,7 @@ func TestFilter(t *testing.T) {
 			setup: func() *http.Request {
 				req, err := http.NewRequest(http.MethodGet, "/", nil)
 				require.NoError(t, err)
-				req.Header.Add(
-					"Authorization",
-					fmt.Sprintf("Bearer %s", "foo"),
-				)
+				req.Header.Add("Authorization", "Bearer foo")
 				return req
 			},
 			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
@@ -187,10 +199,7 @@ func TestFilter(t *testing.T) {
 			setup: func() *http.Request {
 				req, err := http.NewRequest(http.MethodGet, "/", nil)
 				require.NoError(t, err)
-				req.Header.Add(
-					"Authorization",
-					fmt.Sprintf("Bearer %s", "foo"),
-				)
+				req.Header.Add("Authorization", "Bearer foo")
 				return req
 			},
 			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
@@ -220,10 +229,7 @@ func TestFilter(t *testing.T) {
 			setup: func() *http.Request {
 				req, err := http.NewRequest(http.MethodGet, "/", nil)
 				require.NoError(t, err)
-				req.Header.Add(
-					"Authorization",
-					fmt.Sprintf("Bearer %s", "foo"),
-				)
+				req.Header.Add("Authorization", "Bearer foo")
 				return req
 			},
 			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
@@ -265,10 +271,7 @@ func TestFilter(t *testing.T) {
 			setup: func() *http.Request {
 				req, err := http.NewRequest(http.MethodGet, "/", nil)
 				require.NoError(t, err)
-				req.Header.Add(
-					"Authorization",
-					fmt.Sprintf("Bearer %s", "foo"),
-				)
+				req.Header.Add("Authorization", "Bearer foo")
 				return req
 			},
 			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
@@ -296,10 +299,7 @@ func TestFilter(t *testing.T) {
 			setup: func() *http.Request {
 				req, err := http.NewRequest(http.MethodGet, "/", nil)
 				require.NoError(t, err)
-				req.Header.Add(
-					"Authorization",
-					fmt.Sprintf("Bearer %s", "foo"),
-				)
+				req.Header.Add("Authorization", "Bearer foo")
 				return req
 			},
 			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
@@ -330,10 +330,7 @@ func TestFilter(t *testing.T) {
 			setup: func() *http.Request {
 				req, err := http.NewRequest(http.MethodGet, "/", nil)
 				require.NoError(t, err)
-				req.Header.Add(
-					"Authorization",
-					fmt.Sprintf("Bearer %s", "foo"),
-				)
+				req.Header.Add("Authorization", "Bearer foo")
 				return req
 			},
 			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
@@ -369,10 +366,7 @@ func TestFilter(t *testing.T) {
 			setup: func() *http.Request {
 				req, err := http.NewRequest(http.MethodGet, "/", nil)
 				require.NoError(t, err)
-				req.Header.Add(
-					"Authorization",
-					fmt.Sprintf("Bearer %s", "foo"),
-				)
+				req.Header.Add("Authorization", "Bearer foo")
 				return req
 			},
 			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
@@ -411,10 +405,7 @@ func TestFilter(t *testing.T) {
 			setup: func() *http.Request {
 				req, err := http.NewRequest(http.MethodGet, "/", nil)
 				require.NoError(t, err)
-				req.Header.Add(
-					"Authorization",
-					fmt.Sprintf("Bearer %s", "foo"),
-				)
+				req.Header.Add("Authorization", "Bearer foo")
 				return req
 			},
 			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
@@ -456,10 +447,7 @@ func TestFilter(t *testing.T) {
 			setup: func() *http.Request {
 				req, err := http.NewRequest(http.MethodGet, "/", nil)
 				require.NoError(t, err)
-				req.Header.Add(
-					"Authorization",
-					fmt.Sprintf("Bearer %s", "foo"),
-				)
+				req.Header.Add("Authorization", "Bearer foo")
 				return req
 			},
 			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
@@ -508,10 +496,7 @@ func TestFilter(t *testing.T) {
 			setup: func() *http.Request {
 				req, err := http.NewRequest(http.MethodGet, "/", nil)
 				require.NoError(t, err)
-				req.Header.Add(
-					"Authorization",
-					fmt.Sprintf("Bearer %s", "foo"),
-				)
+				req.Header.Add("Authorization", "Bearer foo")
 				return req
 			},
 			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {


### PR DESCRIPTION
The scheduler is a special class of user that (once authz is implemented) can do things that other users (humans or service accounts) cannot do.

This PR adds special support for authn by the scheduler in the API server's authentication filter.