### PR TITLE
make chart set SCHEDULER_TOKEN env var on api server

### DIFF
--- a/charts/brigade/templates/_helpers.tpl
+++ b/charts/brigade/templates/_helpers.tpl
@@ -24,6 +24,10 @@ If release name contains chart name it will be used as a full name.
 {{ include "brigade.fullname" . | printf "%s-apiserver" }}
 {{- end -}}
 
+{{- define "brigade.scheduler.fullname" -}}
+{{ include "brigade.fullname" . | printf "%s-scheduler" }}
+{{- end -}}
+
 {{- define "brigade.artemis.fullname" -}}
 {{ include "brigade.fullname" . | printf "%s-artemis" }}
 {{- end -}}
@@ -57,6 +61,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "brigade.apiserver.labels" -}}
 app.kubernetes.io/component: apiserver
+{{- end -}}
+
+{{- define "brigade.scheduler.labels" -}}
+app.kubernetes.io/component: scheduler
 {{- end -}}
 
 {{- define "brigade.artemis.labels" -}}

--- a/charts/brigade/templates/apiserver/deployment.yaml
+++ b/charts/brigade/templates/apiserver/deployment.yaml
@@ -64,6 +64,11 @@ spec:
           value: http://{{ .Values.apiserver.host }}
           {{- end }}
         {{- end }}
+        - name: SCHEDULER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "brigade.scheduler.fullname" . }}
+              key: api-token
         - name: TLS_ENABLED
           value: {{ quote .Values.apiserver.tls.enabled }}
         {{- if .Values.apiserver.tls.enabled }}

--- a/charts/brigade/templates/scheduler/secret.yaml
+++ b/charts/brigade/templates/scheduler/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "brigade.scheduler.fullname" . }}
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.scheduler.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  api-token: {{ randAlphaNum 30 }}


### PR DESCRIPTION
This is a follow up to #1163, which introduced a required env var for the API server. The chart was accidentally not updated to provide a value for that environment variable. This PR remedies that.