### PR TITLE
give api server permission to create pods and pvcs

### DIFF
--- a/charts/brigade/templates/apiserver/cluster-role.yaml
+++ b/charts/brigade/templates/apiserver/cluster-role.yaml
@@ -35,6 +35,7 @@ rules:
   - pods
   - persistentvolumeclaims
   verbs:
+  - create
   - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io


### PR DESCRIPTION
An oversight in #1165 is that the api server is missing permissions to create PVCs and Pods. This PR corrects that.