### PR TITLE
allow apiserver to list pods

### DIFF
--- a/charts/brigade/templates/apiserver/cluster-role.yaml
+++ b/charts/brigade/templates/apiserver/cluster-role.yaml
@@ -17,6 +17,21 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - deletecollection
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - deletecollection
+  - list
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
@@ -29,14 +44,6 @@ rules:
   - serviceaccounts
   verbs:
   - create
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - persistentvolumeclaims
-  verbs:
-  - create
-  - deletecollection
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:


### PR DESCRIPTION
This is a follow-up to #1162

This permission for the apiserver to list k8s pods. It breaks apart the the permissions for pods and PVCs since listing pods is necessary and listing PVCs is not. Since this grows the number of sections in this file, I also reordered them alphabetically by resource type so that it doesn't become unwieldy.

A side-by-side comparison of changes might be more helpful than a line-by-line comparison.