### PR TITLE
prerequisite api changes for the forthcoming observer component

### DIFF
--- a/sdk/v2/core/jobs.go
+++ b/sdk/v2/core/jobs.go
@@ -217,6 +217,7 @@ type JobsClient interface {
 		jobName string,
 		status JobStatus,
 	) error
+	Cleanup(ctx context.Context, eventID, jobName string) error
 }
 
 type jobsClient struct {
@@ -344,6 +345,26 @@ func (j *jobsClient) UpdateStatus(
 			),
 			AuthHeaders: j.BearerTokenAuthHeaders(),
 			ReqBodyObj:  status,
+			SuccessCode: http.StatusOK,
+		},
+	)
+}
+
+func (j *jobsClient) Cleanup(
+	ctx context.Context,
+	eventID,
+	jobName string,
+) error {
+	return j.ExecuteRequest(
+		ctx,
+		rm.OutboundRequest{
+			Method: http.MethodPut,
+			Path: fmt.Sprintf(
+				"v2/events/%s/worker/jobs/%s/cleanup",
+				eventID,
+				jobName,
+			),
+			AuthHeaders: j.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 		},
 	)

--- a/sdk/v2/core/jobs_test.go
+++ b/sdk/v2/core/jobs_test.go
@@ -218,3 +218,35 @@ func TestJobClientUpdateStatus(t *testing.T) {
 	)
 	require.NoError(t, err)
 }
+
+func TestJobClientCleanup(t *testing.T) {
+	const testEventID = "12345"
+	const testJobName = "Italian"
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				defer r.Body.Close()
+				require.Equal(t, http.MethodPut, r.Method)
+				require.Equal(
+					t,
+					fmt.Sprintf(
+						"/v2/events/%s/worker/jobs/%s/cleanup",
+						testEventID,
+						testJobName,
+					),
+					r.URL.Path,
+				)
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintln(w, "{}")
+			},
+		),
+	)
+	defer server.Close()
+	client := NewJobsClient(server.URL, testAPIToken, nil)
+	err := client.Cleanup(
+		context.Background(),
+		testEventID,
+		testJobName,
+	)
+	require.NoError(t, err)
+}

--- a/sdk/v2/core/workers.go
+++ b/sdk/v2/core/workers.go
@@ -239,6 +239,7 @@ type WorkersClient interface {
 		eventID string,
 		status WorkerStatus,
 	) error
+	Cleanup(ctx context.Context, eventID string) error
 
 	Jobs() JobsClient
 }
@@ -329,6 +330,18 @@ func (w *workersClient) UpdateStatus(
 			Path:        fmt.Sprintf("v2/events/%s/worker/status", eventID),
 			AuthHeaders: w.BearerTokenAuthHeaders(),
 			ReqBodyObj:  status,
+			SuccessCode: http.StatusOK,
+		},
+	)
+}
+
+func (w *workersClient) Cleanup(ctx context.Context, eventID string) error {
+	return w.ExecuteRequest(
+		ctx,
+		rm.OutboundRequest{
+			Method:      http.MethodPut,
+			Path:        fmt.Sprintf("v2/events/%s/worker/cleanup", eventID),
+			AuthHeaders: w.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 		},
 	)

--- a/sdk/v2/core/workers_test.go
+++ b/sdk/v2/core/workers_test.go
@@ -149,3 +149,26 @@ func TestWorkersClientUpdateStatus(t *testing.T) {
 	)
 	require.NoError(t, err)
 }
+
+func TestWorkersClientCleanup(t *testing.T) {
+	const testEventID = "12345"
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				defer r.Body.Close()
+				require.Equal(t, http.MethodPut, r.Method)
+				require.Equal(
+					t,
+					fmt.Sprintf("/v2/events/%s/worker/cleanup", testEventID),
+					r.URL.Path,
+				)
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintln(w, "{}")
+			},
+		),
+	)
+	defer server.Close()
+	client := NewWorkersClient(server.URL, testAPIToken, nil)
+	err := client.Cleanup(context.Background(), testEventID)
+	require.NoError(t, err)
+}

--- a/v2/apiserver/internal/core/common_test.go
+++ b/v2/apiserver/internal/core/common_test.go
@@ -141,6 +141,12 @@ type mockSubstrate struct {
 		event Event,
 		jobName string,
 	) error
+	DeleteJobFn func(
+		ctx context.Context,
+		project Project,
+		event Event,
+		jobName string,
+	) error
 	DeleteWorkerAndJobsFn func(context.Context, Project, Event) error
 }
 
@@ -193,6 +199,15 @@ func (m *mockSubstrate) StartJob(
 	jobName string,
 ) error {
 	return m.StartJobFn(ctx, project, event, jobName)
+}
+
+func (m *mockSubstrate) DeleteJob(
+	ctx context.Context,
+	project Project,
+	event Event,
+	jobName string,
+) error {
+	return m.DeleteJobFn(ctx, project, event, jobName)
 }
 
 func (m *mockSubstrate) DeleteWorkerAndJobs(

--- a/v2/apiserver/internal/core/jobs_test.go
+++ b/v2/apiserver/internal/core/jobs_test.go
@@ -250,6 +250,113 @@ func TestJobsServiceUpdateStatus(t *testing.T) {
 	}
 }
 
+func TestJobsServiceCleanup(t *testing.T) {
+	const testEventID = "123456789"
+	const testJobName = "italian"
+	testCases := []struct {
+		name       string
+		service    JobsService
+		assertions func(error)
+	}{
+		{
+			name: "error getting event from store",
+			service: &jobsService{
+				eventsStore: &mockEventsStore{
+					GetFn: func(context.Context, string) (Event, error) {
+						return Event{}, errors.New("something went wrong")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error retrieving event")
+			},
+		},
+		{
+			name: "event has no such job",
+			service: &jobsService{
+				eventsStore: &mockEventsStore{
+					GetFn: func(context.Context, string) (Event, error) {
+						return Event{}, nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrNotFound{}, err)
+			},
+		},
+		{
+			name: "error getting project from store",
+			service: &jobsService{
+				eventsStore: &mockEventsStore{
+					GetFn: func(context.Context, string) (Event, error) {
+						return Event{
+							Worker: Worker{
+								Jobs: map[string]Job{
+									testJobName: {},
+								},
+							},
+						}, nil
+					},
+				},
+				projectsStore: &mockProjectsStore{
+					GetFn: func(context.Context, string) (Project, error) {
+						return Project{}, errors.New("something went wrong")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error retrieving project")
+			},
+		},
+		{
+			name: "error deleting job from substrate",
+			service: &jobsService{
+				eventsStore: &mockEventsStore{
+					GetFn: func(context.Context, string) (Event, error) {
+						return Event{
+							Worker: Worker{
+								Jobs: map[string]Job{
+									testJobName: {},
+								},
+							},
+						}, nil
+					},
+				},
+				projectsStore: &mockProjectsStore{
+					GetFn: func(context.Context, string) (Project, error) {
+						return Project{}, nil
+					},
+				},
+				substrate: &mockSubstrate{
+					DeleteJobFn: func(context.Context, Project, Event, string) error {
+						return errors.New("something went wrong")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error deleting event")
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.service.Cleanup(
+				context.Background(),
+				testEventID,
+				testJobName,
+			)
+			testCase.assertions(err)
+		})
+	}
+}
+
 type mockJobsStore struct {
 	UpdateStatusFn func(
 		ctx context.Context,

--- a/v2/apiserver/internal/core/jobs_test.go
+++ b/v2/apiserver/internal/core/jobs_test.go
@@ -344,6 +344,35 @@ func TestJobsServiceCleanup(t *testing.T) {
 				require.Contains(t, err.Error(), "error deleting event")
 			},
 		},
+		{
+			name: "error deleting job from substrate",
+			service: &jobsService{
+				eventsStore: &mockEventsStore{
+					GetFn: func(context.Context, string) (Event, error) {
+						return Event{
+							Worker: Worker{
+								Jobs: map[string]Job{
+									testJobName: {},
+								},
+							},
+						}, nil
+					},
+				},
+				projectsStore: &mockProjectsStore{
+					GetFn: func(context.Context, string) (Project, error) {
+						return Project{}, nil
+					},
+				},
+				substrate: &mockSubstrate{
+					DeleteJobFn: func(context.Context, Project, Event, string) error {
+						return nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/v2/apiserver/internal/core/kubernetes/substrate_test.go
+++ b/v2/apiserver/internal/core/kubernetes/substrate_test.go
@@ -901,6 +901,41 @@ func TestSubstrateStartJob(t *testing.T) {
 // and asserting we get no error-- so we at least get some test coverage for
 // this function. We'll have to make sure this behavior is well-covered by
 // integration or e2e tests in the future.
+func TestSubstrateDeleteJob(t *testing.T) {
+	const testEventID = "123456789"
+	const testJobName = "italian"
+	s := &substrate{
+		kubeClient: fake.NewSimpleClientset(),
+	}
+	err := s.DeleteJob(
+		context.Background(),
+		core.Project{
+			Kubernetes: &core.KubernetesDetails{
+				Namespace: "foo",
+			},
+		},
+		core.Event{
+			ObjectMeta: meta.ObjectMeta{
+				ID: testEventID,
+			},
+		},
+		testJobName,
+	)
+	require.NoError(t, err)
+}
+
+// TODO: Find a better way to test this. Unfortunately, the DeleteCollection
+// function on a *fake.ClientSet doesn't ACTUALLY delete collections of
+// resources based on the labels provided.
+//
+// Refer to: https://github.com/kubernetes/client-go/issues/609
+//
+// This makes it basically impossible to assert what we'd LIKE to assert here--
+// that resources labeled with the correct Event ID are deleted while other
+// resources are left alone. We'll settle for invoking DeleteWorkerAndJobs(...)
+// and asserting we get no error-- so we at least get some test coverage for
+// this function. We'll have to make sure this behavior is well-covered by
+// integration or e2e tests in the future.
 func TestSubstrateDeleteWorkerAndJobs(t *testing.T) {
 	s := &substrate{
 		kubeClient: fake.NewSimpleClientset(),

--- a/v2/apiserver/internal/core/rest/jobs_endpoints.go
+++ b/v2/apiserver/internal/core/rest/jobs_endpoints.go
@@ -31,6 +31,12 @@ func (j *JobsEndpoints) Register(router *mux.Router) {
 		"/v2/events/{eventID}/worker/jobs/{jobName}/status",
 		j.AuthFilter.Decorate(j.updateStatus),
 	).Methods(http.MethodPut)
+
+	// Clean up a job
+	router.HandleFunc(
+		"/v2/events/{eventID}/worker/jobs/{jobName}/cleanup",
+		j.AuthFilter.Decorate(j.cleanup),
+	).Methods(http.MethodPut)
 }
 
 func (j *JobsEndpoints) start(w http.ResponseWriter, r *http.Request) {
@@ -67,6 +73,26 @@ func (j *JobsEndpoints) updateStatus(
 					mux.Vars(r)["eventID"],
 					mux.Vars(r)["jobName"],
 					status,
+				)
+			},
+			SuccessCode: http.StatusOK,
+		},
+	)
+}
+
+func (j *JobsEndpoints) cleanup(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	restmachinery.ServeRequest(
+		restmachinery.InboundRequest{
+			W: w,
+			R: r,
+			EndpointLogic: func() (interface{}, error) {
+				return nil, j.Service.Cleanup(
+					r.Context(),
+					mux.Vars(r)["eventID"],
+					mux.Vars(r)["jobName"],
 				)
 			},
 			SuccessCode: http.StatusOK,

--- a/v2/apiserver/internal/core/rest/workers_endpoints.go
+++ b/v2/apiserver/internal/core/rest/workers_endpoints.go
@@ -31,6 +31,12 @@ func (w *WorkersEndpoints) Register(router *mux.Router) {
 		"/v2/events/{eventID}/worker/status",
 		w.AuthFilter.Decorate(w.updateStatus),
 	).Methods(http.MethodPut)
+
+	// Clean up a worker
+	router.HandleFunc(
+		"/v2/events/{eventID}/worker/cleanup",
+		w.AuthFilter.Decorate(w.cleanup),
+	).Methods(http.MethodPut)
 }
 
 func (w *WorkersEndpoints) start(wr http.ResponseWriter, r *http.Request) {
@@ -60,6 +66,23 @@ func (w *WorkersEndpoints) updateStatus(
 			EndpointLogic: func() (interface{}, error) {
 				return nil,
 					w.Service.UpdateStatus(r.Context(), mux.Vars(r)["eventID"], status)
+			},
+			SuccessCode: http.StatusOK,
+		},
+	)
+}
+
+func (w *WorkersEndpoints) cleanup(
+	wr http.ResponseWriter,
+	r *http.Request,
+) {
+	restmachinery.ServeRequest(
+		restmachinery.InboundRequest{
+			W: wr,
+			R: r,
+			EndpointLogic: func() (interface{}, error) {
+				return nil,
+					w.Service.Cleanup(r.Context(), mux.Vars(r)["eventID"])
 			},
 			SuccessCode: http.StatusOK,
 		},

--- a/v2/apiserver/internal/core/substrate.go
+++ b/v2/apiserver/internal/core/substrate.go
@@ -133,6 +133,14 @@ type Substrate interface {
 		jobName string,
 	) error
 
+	// DeleteJob deletes all substrate resources pertaining to the specified Job.
+	DeleteJob(
+		ctx context.Context,
+		project Project,
+		event Event,
+		jobName string,
+	) error
+
 	// DeleteWorkerAndJobs deletes all substrate resources pertaining to the
 	// specified Event's Worker and Jobs.
 	DeleteWorkerAndJobs(context.Context, Project, Event) error

--- a/v2/apiserver/internal/core/workers_test.go
+++ b/v2/apiserver/internal/core/workers_test.go
@@ -272,6 +272,29 @@ func TestWorkersServiceCleanup(t *testing.T) {
 				require.Contains(t, err.Error(), "error deleting event")
 			},
 		},
+		{
+			name: "success",
+			service: &workersService{
+				eventsStore: &mockEventsStore{
+					GetFn: func(context.Context, string) (Event, error) {
+						return Event{}, nil
+					},
+				},
+				projectsStore: &mockProjectsStore{
+					GetFn: func(context.Context, string) (Project, error) {
+						return Project{}, nil
+					},
+				},
+				substrate: &mockSubstrate{
+					DeleteWorkerAndJobsFn: func(context.Context, Project, Event) error {
+						return nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
The observer will trigger cleanup of Kubernetes resources related to completed workers and jobs, however, it seems that in keeping with a theme, that work should be delegated to the API server instead of the observer doing it directly.

This PR adds relevant endpoints to both the API server and the SDK.