### PR TITLE
add log agent

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,30 @@
+# A Note on Our Use of GitHub Actions
+
+Nearly all of Brigade's own pipelines are implemented using Brigade. (i.e. We
+eat our own dog food.)
+
+Brigade Workers and Jobs are implemented as Kubernetes pods comprised of one or
+more OCI containers. Building any of Brigade's many Linux-based OCI images is a
+task that can be accomplished by a Brigade Job as the process of building a new
+Linux-based OCI image _inside_ a Linux-based OCI container is a well-understood
+and well-documented pattern colloquially called "Docker in Docker" or simply
+"DinD."
+
+Building a Windows-based OCI image inside a Windows-based OCI container is
+_not_, as of this writing, a common, well-understood, or well-documented
+pattern. Building Brigade's one Windows-based OCI image, therefore, requires the
+use of a physical Windows machine or virtual machine having an appropriate
+kernel. This requirement, unfortunately, eliminates the possibility of building
+such an image using Brigade itself.
+
+For this reason, and this reason only, the maintainers have opted (for now) to
+utilize GitHub Actions _only_ for building this one Windows-based OCI image. It
+is expected that this decision may be revisited as the state of the art in
+building Windows-based OCI images advances.
+
+Further, building Windows-based OCI images is time consuming in comparison to
+building Linux-based OCI images. In light of this, the maintainers have elected
+_not_ to unconditionally require the build of Brigade's one Windows-based OCI
+image to complete as a prerequisite for merging a PR. Maintainers _will_ require
+that build to pass in the event that the PR in question modifies the
+corresponding Dockerfile.

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -1,0 +1,17 @@
+name: Brigade v2 Merge
+
+on:
+  push:
+    branches:
+      - v2
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Windows logger agent
+        run: |
+          docker build -f v2/logger/Dockerfile.winserv-2019 v2/logger

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # TODO: We should also publish the image
       - name: Build Windows logger agent
         run: |
           docker build -f v2/logger/Dockerfile.winserv-2019 v2/logger

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,17 @@
+name: Brigade v2 PR
+
+on:
+  pull_request:
+    branches:
+      - v2
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Windows logger agent
+        run: |
+          docker build -f v2/logger/Dockerfile.winserv-2019 v2/logger

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,13 @@ build: build-images xbuild-cli
 .PHONY: build-images
 build-images: build-apiserver build-scheduler build-observer
 
+.PHONY: build-logger-linux
+build-logger-linux:
+	docker build \
+		-t $(DOCKER_IMAGE_PREFIX)brigade-logger-linux:$(IMMUTABLE_DOCKER_TAG) \
+		- < v2/logger/Dockerfile.linux
+	docker tag $(DOCKER_IMAGE_PREFIX)brigade-logger-linux:$(IMMUTABLE_DOCKER_TAG) $(DOCKER_IMAGE_PREFIX)brigade-logger-linux:$(MUTABLE_DOCKER_TAG)
+
 .PHONY: build-%
 build-%:
 	docker build \
@@ -132,6 +139,7 @@ xbuild-cli:
 	'
 
 .PHONY: push-images
+push-images: push-apiserver push-scheduler push-observer push-logger-linux
 push-images: push-apiserver push-scheduler push-observer
 
 .PHONY: push-%
@@ -161,3 +169,7 @@ hack: push-images build-cli
 		--set observer.image.repository=$(DOCKER_IMAGE_PREFIX)brigade-observer \
 		--set observer.image.tag=$(IMMUTABLE_DOCKER_TAG) \
 		--set observer.image.pullPolicy=Always
+		--set observer.image.pullPolicy=Always \
+		--set logger.linux.image.repository=$(DOCKER_IMAGE_PREFIX)brigade-logger-linux \
+		--set logger.linux.image.tag=$(IMMUTABLE_DOCKER_TAG) \
+		--set logger.linux.image.pullPolicy=Always

--- a/brigade.js
+++ b/brigade.js
@@ -52,7 +52,11 @@ function buildObserver() {
   return buildImage("observer");
 }
 
-// Build the API server
+// Build the Linux logging agent
+function buildLoggerLinux() {
+  return buildImage("logger-linux");
+}
+
 function buildImage(imageName) {
   var job = new Job(`build-${imageName}`, dockerImg);
   job.mountPath = localPath;
@@ -94,6 +98,7 @@ function runSuite(e, p) {
     run(e, p, buildAPIServer).catch((err) => { return err }),
     run(e, p, buildScheduler).catch((err) => { return err }),
     run(e, p, buildObserver).catch((err) => { return err }),
+    run(e, p, buildLoggerLinux).catch((err) => { return err }),
     run(e, p, buildCLI).catch((err) => { return err })
   ]).then((values) => {
     values.forEach((value) => {
@@ -117,6 +122,8 @@ function runCheck(e, p) {
       return run(e, p, buildScheduler);
     case "build-observer":
       return run(e, p, buildObserver);
+    case "build-logger-linux":
+      return run(e, p, buildLoggerLinux);
     case "build-cli":
       return run(e, p, buildCLI);
     default:

--- a/charts/brigade/templates/_helpers.tpl
+++ b/charts/brigade/templates/_helpers.tpl
@@ -36,6 +36,18 @@ If release name contains chart name it will be used as a full name.
 {{ include "brigade.fullname" . | printf "%s-artemis" }}
 {{- end -}}
 
+{{- define "brigade.logger.fullname" -}}
+{{ include "brigade.fullname" . | printf "%s-logger" }}
+{{- end -}}
+
+{{- define "brigade.logger.linux.fullname" -}}
+{{ include "brigade.logger.fullname" . | printf "%s-linux" }}
+{{- end -}}
+
+{{- define "brigade.logger.windows.fullname" -}}
+{{ include "brigade.logger.fullname" . | printf "%s-windows" }}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}
@@ -87,6 +99,20 @@ app.kubernetes.io/role: primary
 {{- define "brigade.artemis.secondary.labels" -}}
 {{ include "brigade.artemis.labels" . }}
 app.kubernetes.io/role: secondary
+{{- end -}}
+
+{{- define "brigade.logger.labels" -}}
+app.kubernetes.io/component: logger
+{{- end -}}
+
+{{- define "brigade.logger.linux.labels" -}}
+{{ include "brigade.logger.labels" . }}
+app.kubernetes.io/os: linux
+{{- end -}}
+
+{{- define "brigade.logger.windows.labels" -}}
+{{ include "brigade.logger.labels" . }}
+app.kubernetes.io/os: windows
 {{- end -}}
 
 {{- define "call-nested" }}

--- a/charts/brigade/templates/logger/cluster-role-binding.yaml
+++ b/charts/brigade/templates/logger/cluster-role-binding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "brigade.logger.fullname" . }}
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.logger.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "brigade.logger.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "brigade.logger.fullname" . }}
+{{- end }}

--- a/charts/brigade/templates/logger/cluster-role.yaml
+++ b/charts/brigade/templates/logger/cluster-role.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "brigade.logger.fullname" . }}
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.logger.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}

--- a/charts/brigade/templates/logger/linux-daemonset.yaml
+++ b/charts/brigade/templates/logger/linux-daemonset.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "brigade.logger.linux.fullname" . }}
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.logger.linux.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "brigade.selectorLabels" . | nindent 6 }}
+      {{- include "brigade.logger.linux.labels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "brigade.selectorLabels" . | nindent 8 }}
+        {{- include "brigade.logger.linux.labels" . | nindent 8 }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/logger/secret.yaml") . | sha256sum }}
+    spec:
+      serviceAccount: {{ include "brigade.logger.fullname" . }}
+      containers:
+      - name: logger
+        image: {{ .Values.logger.linux.image.repository }}:{{ default .Chart.AppVersion .Values.logger.linux.image.tag }}
+        imagePullPolicy: {{ .Values.logger.linux.image.pullPolicy }}
+        volumeMounts:
+        - name: var-log
+          mountPath: /var/log
+        - name: docker-containers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: logger-config
+          mountPath: /fluentd/etc
+      volumes:
+      - name: var-log
+        hostPath:
+          path: /var/log
+      - name: docker-containers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: logger-config
+        secret:
+          secretName: {{ include "brigade.logger.fullname" . }}
+      {{- with .Values.logger.linux.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.logger.linux.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/brigade/templates/logger/secret.yaml
+++ b/charts/brigade/templates/logger/secret.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "brigade.logger.fullname" . }}
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.logger.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  fluent.conf: |
+    <source>
+      @type tail
+      path /var/log/containers/*.log
+      pos_file /var/log/brigade-fluentd-containers.log.pos
+      tag kube.*
+      read_from_head true
+      refresh_interval 15
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+          time_key time
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+          time_format %Y-%m-%dT%H:%M:%S.%N%:z
+        </pattern>
+      </parse>
+    </source>
+
+    <filter kube.var.log.containers.**.log>
+      @type kubernetes_metadata
+    </filter>
+
+    <match kube.var.log.containers.**.log>
+      @type rewrite_tag_filter
+      <rule>
+        key     $.kubernetes.labels.brigade_sh/component
+        pattern /^worker$/
+        tag     worker
+      </rule>
+      <rule>
+        key     $.kubernetes.labels.brigade_sh/component
+        pattern /^job$/
+        tag     job
+      </rule>
+    </match>
+
+    <filter worker>
+      @type record_transformer
+      enable_ruby
+      renew_record true
+      <record>
+        component ${record.dig("kubernetes", "labels", "brigade_sh/component")}
+        event     ${record.dig("kubernetes", "labels", "brigade_sh/event")}
+        container ${record.dig("kubernetes", "container_name")}
+      </record>
+      keep_keys component,event,worker,container,time,log
+    </filter>
+
+    <filter job>
+      @type record_transformer
+      enable_ruby
+      renew_record true
+      <record>
+        component ${record.dig("kubernetes", "labels", "brigade_sh/component")}
+        event     ${record.dig("kubernetes", "labels", "brigade_sh/event")}
+        job       ${record.dig("kubernetes", "labels", "brigade_sh/job")}
+        container ${record.dig("kubernetes", "container_name")}
+      </record>
+      keep_keys component,event,worker,job,container,time,log
+    </filter>
+
+    <match worker job>
+      @type mongo
+
+      {{- if .Values.mongodb.enabled }}
+      host {{ include "call-nested" (list . "mongodb" "mongodb.fullname") }}.{{ .Release.Namespace }}.svc.cluster.local
+      port 27017
+      database {{ .Values.mongodb.mongodbDatabase }}
+      user {{ .Values.mongodb.mongodbUsername }}
+      password {{ .Values.mongodb.mongodbPassword }}
+      {{- else }}
+      connection_string {{ .Values.externalMongodb.connectionString }}
+      {{- end }}
+
+      collection logs
+
+      {{- if or .Values.mongodb.enabled (not .Values.externalMongodb.isCosmosdb) }}
+      capped
+      capped_size 1024m
+      {{- end }}
+
+      time_key time
+
+      <buffer>
+        @type file
+        path /fluentd/log/buffer
+        flush_interval 5s
+      </buffer>
+    </match>

--- a/charts/brigade/templates/logger/service-account.yaml
+++ b/charts/brigade/templates/logger/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "brigade.logger.fullname" . }}
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.logger.labels" . | nindent 4 }}

--- a/charts/brigade/templates/logger/windows-daemonset.yaml
+++ b/charts/brigade/templates/logger/windows-daemonset.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "brigade.logger.windows.fullname" . }}
+  labels:
+    {{- include "brigade.labels" . | nindent 4 }}
+    {{- include "brigade.logger.windows.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "brigade.selectorLabels" . | nindent 6 }}
+      {{- include "brigade.logger.windows.labels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "brigade.selectorLabels" . | nindent 8 }}
+        {{- include "brigade.logger.windows.labels" . | nindent 8 }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/logger/secret.yaml") . | sha256sum }}
+    spec:
+      serviceAccount: {{ include "brigade.logger.fullname" . }}
+      containers:
+      - name: logger
+        image: {{ .Values.logger.windows.image.repository }}:{{ default .Chart.AppVersion .Values.logger.windows.image.tag }}
+        imagePullPolicy: {{ .Values.logger.windows.image.pullPolicy }}
+        volumeMounts:
+        - name: var-log
+          mountPath: /var/log
+        - name: docker-containers
+          mountPath: /ProgramData/docker/containers
+          readOnly: true
+        - name: logger-config
+          mountPath: /fluentd/etc
+      volumes:
+      - name: var-log
+        hostPath:
+          path: /var/log
+      - name: docker-containers
+        hostPath:
+          path: /ProgramData/docker/containers
+      - name: logger-config
+        secret:
+          secretName: {{ include "brigade.logger.fullname" . }}
+      {{- with .Values.logger.windows.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.logger.windows.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -182,7 +182,7 @@ logger:
   linux:
 
     image:
-      repository: krancour/brigade-logger-linux
+      repository: brigadecore/brigade-logger-linux
       ## tag should only be specified if you want to override Chart.appVersion
       ## The default tag is the value of .Chart.AppVersion
       # tag:
@@ -209,7 +209,7 @@ logger:
   windows:
 
     image:
-      repository: krancour/brigade-logger-windows
+      repository: brigadecore/brigade-logger-windows
       ## tag should only be specified if you want to override Chart.appVersion
       ## The default tag is the value of .Chart.AppVersion
       # tag:

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -177,6 +177,66 @@ worker:
 
   workspaceStorageClass: nfs
 
+logger:
+
+  linux:
+
+    image:
+      repository: krancour/brigade-logger-linux
+      ## tag should only be specified if you want to override Chart.appVersion
+      ## The default tag is the value of .Chart.AppVersion
+      # tag:
+      pullPolicy: IfNotPresent
+
+    resources: {}
+      # We usually recommend not to specify default resources and to leave this
+      # as a conscious choice for the user. This also increases chances charts
+      # run on environments with little resources, such as Minikube. If you do
+      # want to specify resources, uncomment the following lines, adjust them as
+      # necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #   cpu: 100m
+      #   memory: 128Mi
+      # requests:
+      #   cpu: 100m
+      #   memory: 128Mi
+
+    nodeSelector:
+      beta.kubernetes.io/os: linux
+
+    tolerations: []
+
+  windows:
+
+    image:
+      repository: krancour/brigade-logger-windows
+      ## tag should only be specified if you want to override Chart.appVersion
+      ## The default tag is the value of .Chart.AppVersion
+      # tag:
+      pullPolicy: IfNotPresent
+
+    resources: {}
+      # We usually recommend not to specify default resources and to leave this
+      # as a conscious choice for the user. This also increases chances charts
+      # run on environments with little resources, such as Minikube. If you do
+      # want to specify resources, uncomment the following lines, adjust them as
+      # necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #   cpu: 100m
+      #   memory: 128Mi
+      # requests:
+      #   cpu: 100m
+      #   memory: 128Mi
+
+    nodeSelector:
+      beta.kubernetes.io/os: windows
+
+    tolerations:
+    - effect: NoSchedule
+      key: os
+      operator: Equal
+      value: windows
+
 externalMongodb:
 
   isCosmosdb: false

--- a/v2/logger/Dockerfile.linux
+++ b/v2/logger/Dockerfile.linux
@@ -1,0 +1,21 @@
+FROM fluent/fluentd:v1.11.5-debian-1.0
+
+USER root
+
+RUN buildDeps="make gcc g++ libc-dev libffi-dev" \
+  && apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends \
+    $buildDeps \
+    net-tools \
+  && gem install \
+    bson:4.11.1 \
+    fluent-plugin-rewrite-tag-filter:2.3.0 \
+    fluent-plugin-mongo:1.4.1 \
+    fluent-plugin-kubernetes_metadata_filter:2.5.2 \
+    fluent-plugin-multi-format-parser:1.0.0 \
+  && apt-get purge -y --auto-remove \
+    $buildDeps \
+  && rm -rf /var/lib/apt/lists/* \
+  && gem sources --clear-all \
+  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem

--- a/v2/logger/Dockerfile.linux
+++ b/v2/logger/Dockerfile.linux
@@ -1,3 +1,6 @@
+# This Dockerfile builds a custom Fluentd image that layers in the Fluentd
+# plugins we rely upon on top of a standard Fluentd image.
+
 FROM fluent/fluentd:v1.11.5-debian-1.0
 
 USER root

--- a/v2/logger/Dockerfile.winserv-2019
+++ b/v2/logger/Dockerfile.winserv-2019
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
+
+RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'"
+RUN choco install -y msys2 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
+
+RUN ridk install 2 3 \
+  && echo gem: --no-document >> C:\ProgramData\gemrc \
+  && gem install cool.io -v 1.5.4 --platform ruby \
+  && gem install oj -v 3.3.10 \
+  && gem install json -v 2.2.0 \
+  && gem install fluentd -v 1.7.4 \
+  && gem install win32-service -v 1.0.1 \
+  && gem install win32-ipc -v 0.7.0 \
+  && gem install win32-event -v 0.6.3 \
+  && gem install windows-pr -v 1.2.6 \
+  && gem install bson -v 4.5.0 \
+  && gem install fluent-plugin-rewrite-tag-filter -v 2.3.0 \
+  && gem install fluent-plugin-mongo -v 1.4.1 \
+  && gem install fluent-plugin-kubernetes_metadata_filter -v 2.5.2 \
+  && gem install fluent-plugin-multi-format-parser -v 1.0.0 \
+  && gem sources --clear-all
+
+RUN powershell -Command "mkdir -p C:\fluentd\etc ; mkdir C:\fluentd\log ; rm -fo C:\ruby26\lib\ruby\gems\2.6.0\cache\*.gem; Remove-Item -Recurse -Force 'C:\ProgramData\chocolatey'"
+
+ENTRYPOINT ["cmd", "/k", "fluentd", "-c", "C:\\fluentd\\etc\\fluent.conf"]

--- a/v2/logger/Dockerfile.winserv-2019
+++ b/v2/logger/Dockerfile.winserv-2019
@@ -1,3 +1,17 @@
+# This Dockerfile builds a custom Fluentd image for Windows. It is significantly
+# derived from a Dockerfile maintained by the Fluentd project:
+#
+# https://github.com/fluent/fluentd-docker-image/blob/master/v1.11/windows/Dockerfile
+#
+# That upstream Dockerfile, however, builds an image derived from the
+# mcr.microsoft.com/windows/servercore:1903 base image. The resulting image is
+# incompatible with the kernel on AKS Windows nodes. Ours builds on top of
+# mcr.microsoft.com/windows/servercore:ltsc2019 instead to ensure AKS
+# compatibility.
+#
+# Additionally, this Dockerfile layers in all the Fluentd plugins upon which we
+# depend.
+
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"


### PR DESCRIPTION
This PR builds adds Docker builds of custom fluentd-based log agents for both Linux and Windows.

Why custom? In the case of Linux it's only because we bake in the necessary fluentd plugins-- which is a common thing to do. In the case of Windows, it's that _plus_ the necessity of producing an image that's compatible with Windows Server 2019. (Weirdly, fluentd's Windows image seems to be incompatible with that.)

The build of the Linux-based log agent is not much different from any of the other Docker image builds in this project.

For Windows, however, we have to resort to some shenanigans to get the image built-- we have to fall back on GitHub Actions  to accomplish it (instead of dogfooding Brigade) because "Docker-in-Docker" is not well documented for Windows and my efforts to make it work have been fruitless.

The Windows container build also take a _very long time_. And since most PRs won't touch it, I propose we _not_ configure the v2 branch protections in GitHub to require that particular check pass, and that we not allow pending or in-progress Windows log agent builds to block PRs that don't touch the logger.