### PR TITLE
transition from more complex docker-in-docker to less complex kaniko

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -5,7 +5,7 @@ const { events, Job } = require("brigadier");
 const { Check } = require("@brigadecore/brigade-utils");
 
 const goImg = "krancour/go-tools:v0.4.0";
-const dockerImg = "docker:stable-dind";
+const kanikoImg = "krancour/kaniko:v0.2.0";
 const localPath = "/workspaces/brigade";
 
 // Run Go unit tests
@@ -58,13 +58,12 @@ function buildLoggerLinux() {
 }
 
 function buildImage(imageName) {
-  var job = new Job(`build-${imageName}`, dockerImg);
+  var job = new Job(`build-${imageName}`, kanikoImg);
   job.mountPath = localPath;
-  job.privileged = true;
+  job.env = {
+    "SKIP_DOCKER": "true"
+  };
   job.tasks = [
-    "apk add --update --no-cache make git",
-    "dockerd-entrypoint.sh &",
-    "sleep 20",
     `cd ${localPath}`,
     `make build-${imageName}`
   ];
@@ -80,7 +79,7 @@ function buildCLI() {
   };
   job.tasks = [
     `cd ${localPath}`,
-    "make xbuild-cli"
+    "make build-cli"
   ];
   return job;
 }


### PR DESCRIPTION
This PR transitions the official builds (those used in CI and, eventually, the release pipeline) to Kaniko. The main benefit to this is it ends our dependency on the comparatively complex and less secure "Docker in Docker" pattern (less secure because DinD requires a privileged container).

A secondary benefit is we get experience with a different build pattern that I think we might want to add to our playbook. (i.e. We should probably present this as an alternative to DinD in Brigade's own documentation whenever we get around to writing 2.0 docs.)

The custom Kaniko image this uses is in my own Docker Hub repository for now, with source in my own GitHub repository, but as with other "utility" images we use, we can more that over to the `brigadecore` organization in the near future.

Builds and release of my custom Kaniko image _are_ automated.

Note also that the `Makefile` got a bit of a makeover (pun intended). All "hack"-oriented targets (see bottom of the Makefile) shun Kaniko and use Docker to build images. Why? On a developer's device wherein Docker runs locally or in a VM (like Docker Desktop), DinD doesn't come into play, so using Docker instead of Kaniko speeds up development since it will allow developers to take advantage of the local image cache.