### PR TITLE
remove duplicate line from make hack target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,6 @@ hack: push-images build-cli
 		--set observer.image.repository=$(DOCKER_IMAGE_PREFIX)brigade-observer \
 		--set observer.image.tag=$(IMMUTABLE_DOCKER_TAG) \
 		--set observer.image.pullPolicy=Always \
-		--set observer.image.pullPolicy=Always \
 		--set logger.linux.image.repository=$(DOCKER_IMAGE_PREFIX)brigade-logger-linux \
 		--set logger.linux.image.tag=$(IMMUTABLE_DOCKER_TAG) \
 		--set logger.linux.image.pullPolicy=Always


### PR DESCRIPTION
This corrects what appears to be the result of a botched rebase somewhere along the line.