### PR TITLE
misc cli improvements

### DIFF
--- a/v2/cli/event_commands.go
+++ b/v2/cli/event_commands.go
@@ -31,7 +31,7 @@ var eventCommand = &cli.Command{
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:    flagID,
-					Aliases: []string{"i"},
+					Aliases: []string{"i", flagEvent, "e"},
 					Usage: "Cancel (and abort if applicable) the specified event " +
 						"(required)",
 					Required: true,
@@ -113,7 +113,7 @@ var eventCommand = &cli.Command{
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:    flagID,
-					Aliases: []string{"i"},
+					Aliases: []string{"i", flagEvent, "e"},
 					Usage: "Delete (and abort if applicable) the specified event " +
 						"(required)",
 					Required: true,
@@ -206,7 +206,7 @@ var eventCommand = &cli.Command{
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:     flagID,
-					Aliases:  []string{"i"},
+					Aliases:  []string{"i", flagEvent, "e"},
 					Usage:    "Retrieve the specified event (required)",
 					Required: true,
 				},

--- a/v2/cli/logs_command.go
+++ b/v2/cli/logs_command.go
@@ -18,8 +18,8 @@ var logsCommand = &cli.Command{
 				"logs from the worker or job's \"primary\" container",
 		},
 		&cli.StringFlag{
-			Name:     flagEvent,
-			Aliases:  []string{"e"},
+			Name:     flagID,
+			Aliases:  []string{"i", flagEvent, "e"},
 			Usage:    "View logs from the specified event",
 			Required: true,
 		},
@@ -39,7 +39,7 @@ var logsCommand = &cli.Command{
 }
 
 func logs(c *cli.Context) error {
-	eventID := c.String(flagEvent)
+	eventID := c.String(flagID)
 	follow := c.Bool(flagFollow)
 
 	selector := core.LogsSelector{

--- a/v2/cli/project_commands.go
+++ b/v2/cli/project_commands.go
@@ -43,7 +43,7 @@ var projectCommand = &cli.Command{
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:     flagID,
-					Aliases:  []string{"i"},
+					Aliases:  []string{"i", flagProject, "p"},
 					Usage:    "Delete the specified project (required)",
 					Required: true,
 				},
@@ -61,7 +61,7 @@ var projectCommand = &cli.Command{
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:     flagID,
-					Aliases:  []string{"i"},
+					Aliases:  []string{"i", flagProject, "p"},
 					Usage:    "Retrieve the specified project (required)",
 					Required: true,
 				},

--- a/v2/cli/secrets_commands.go
+++ b/v2/cli/secrets_commands.go
@@ -26,8 +26,8 @@ var secretsCommand = &cli.Command{
 			Flags: []cli.Flag{
 				cliFlagOutput,
 				&cli.StringFlag{
-					Name:     flagProject,
-					Aliases:  []string{"p"},
+					Name:     flagID,
+					Aliases:  []string{"i", flagProject, "p"},
 					Usage:    "Retrieve secrets for the specified project (required)",
 					Required: true,
 				},
@@ -39,8 +39,8 @@ var secretsCommand = &cli.Command{
 			Usage: "Define or redefine the value of one or more secrets",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
-					Name:     flagProject,
-					Aliases:  []string{"p"},
+					Name:     flagID,
+					Aliases:  []string{"i", flagProject, "p"},
 					Usage:    "Set secrets for the specified project (required)",
 					Required: true,
 				},
@@ -59,8 +59,8 @@ var secretsCommand = &cli.Command{
 			Usage: "Clear the value of one or more secrets",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
-					Name:     flagProject,
-					Aliases:  []string{"p"},
+					Name:     flagID,
+					Aliases:  []string{"i", flagProject, "p"},
 					Usage:    "Clear secrets for the specified project",
 					Required: true,
 				},
@@ -78,7 +78,7 @@ var secretsCommand = &cli.Command{
 
 func secretsList(c *cli.Context) error {
 	output := c.String(flagOutput)
-	projectID := c.String(flagProject)
+	projectID := c.String(flagID)
 
 	if err := validateOutputFormat(output); err != nil {
 		return err
@@ -151,7 +151,7 @@ func secretsList(c *cli.Context) error {
 }
 
 func secretsSet(c *cli.Context) error {
-	projectID := c.String(flagProject)
+	projectID := c.String(flagID)
 	kvPairsStr := c.StringSlice(flagSet)
 
 	// We'll make two passes-- we'll parse all the input into a map first,
@@ -196,7 +196,7 @@ func secretsSet(c *cli.Context) error {
 }
 
 func secretsUnset(c *cli.Context) error {
-	projectID := c.String(flagProject)
+	projectID := c.String(flagID)
 	keys := c.StringSlice(flagUnset)
 
 	client, err := getClient(c)


### PR DESCRIPTION
## Background

For background on this PR, it's useful to understand that the new `brig` CLI takes a lot of inspiration from the Azure cli (`az'). All commands and subcommands utilize flags _extensively_-- in fact, no argument is _ever_ accepted from the user without being qualified by some flag. Why? Because, especially for commands that take multiple arguments, it's easier and more intuitive to use flags than to remember (or research) the correct order of positional arguments.

When dealing with any subcommand of `project`, the `--id` (or `-i`) flag qualifies _which_ project.

For instance:

```
$ brig project get -i <project id>
```

Similarly, when dealing with any subcommand of `event`, the `--id` flag qualifies _which_ event.

For instance:

```
$ brig event get -i <project id>
```

## Where this gets confusing

Consider an _event_ subcommand that needs to to be qualified by project-- examples of which would include `event delete-many` or `event-create`.

For instance:

```
$ brig event delete-many --project <project id> --succeeded
```

```
$ brig event create --project <project id>
```

Here, because we're talking about _events_ using the `--id` flag to qualify which project we're working with would be confusing, so we use the `--project` (or `-p`) flag instead. This all reads very intuitively: _"Create an event for this project."_

Taken by itself, this makes sense. But in a broader context, it could confuse users. When using `project` subcommands, you qualify which project with `--id` (or `-i`), but when using `event` subcommands, you qualify which project with `--project` (or `-p`). It makes sense, but it will almost certainly cause confusion anyway.

This PR is aimed at improving the UX _vis a vis_ scenarios such as those outline above.

## The solution

1. Stick with what we've been doing: If you're working with `event` subcommands, `--id` (or `-i`) qualifies which _event_. If you're working with `project` subcommands, `--id` (or `-id`) qualifies which _project_. Anywhere where you're working with, for instance, an `event` subcommand, but need to specify a _project_, the `--project` (or `-p`) flag is used.

2. Invoking Postel's principle, since some might mistakenly try to use the `--project` or `-p` flag to specify a project when using `project` subcommands (where the `--id` or `-i` flag should really be used), we should _add_ `--project` and `-p` aliases for `--id`. Similar logic applies to accepting `--event` or `-e` where `--id` or `-i` are expected for `event` subcommands.

## Also

Also, there were a few existing spots where we weren't already following our own rules. For instance, setting a project secret currently looks like this:

```
$ brig project secret set --project <project id> --set <key>=<value>
```

But because this is a project subcommand, we should use `--id` or `-i` to qualify _which_ project:

```
$ brig project secret set -i <project id> --set <key>=<value>
```

As previously mentioned, invoking Postel's principle, we should keep the `--project` and `-p` flags as aliases here.

Similarly, this needs to be fixed for the `event logs` subcommand where the `--event` (or `-e`) flag has been used to qualify the event, but `--id` (and `-i`) should have been used, with `--event` and `-e` retained as aliases.

## If this is confusing...

Build the CLI from source, use the interactive help, and try some of the commands. They should all be fairly intuitive-- and even more so after this PR is merged.

