### PR TITLE
shorten k8s resource names

### DIFF
--- a/v2/internal/kubernetes/common.go
+++ b/v2/internal/kubernetes/common.go
@@ -18,15 +18,15 @@ const (
 )
 
 func EventSecretName(eventID string) string {
-	return fmt.Sprintf("event-%s", eventID)
+	return eventID
 }
 
 func WorkspacePVCName(eventID string) string {
-	return fmt.Sprintf("workspace-%s", eventID)
+	return eventID
 }
 
 func WorkerPodName(eventID string) string {
-	return fmt.Sprintf("worker-%s", eventID)
+	return eventID
 }
 
 func WorkerPodsSelector() string {
@@ -38,11 +38,11 @@ func WorkerPodsSelector() string {
 }
 
 func JobSecretName(eventID, jobName string) string {
-	return fmt.Sprintf("job-%s-%s", eventID, jobName)
+	return fmt.Sprintf("%s-%s", eventID, jobName)
 }
 
 func JobPodName(eventID, jobName string) string {
-	return fmt.Sprintf("job-%s-%s", eventID, jobName)
+	return fmt.Sprintf("%s-%s", eventID, jobName)
 }
 
 func JobPodsSelector() string {


### PR DESCRIPTION
As we continue to abstract brigade users farther from the underlying k8s details, the names of resources become less relevant-- especially since everything is labeled very well.

This PR shortens event secret names, job secret names, worker pod names, job pod names, and workspace PVC names.

They remain easily recognizable despite being shorter.

This doesn't solve #1195, but it's related to it.