### PR TITLE
set and fine tune context timeout on api calls from observer

### DIFF
--- a/v2/observer/common.go
+++ b/v2/observer/common.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 )
+
+const apiRequestTimeout = 30 * time.Second
 
 // syncDeletedPod only fires when a pod deletion is COMPLETE. i.e. The pod is
 // completely gone.

--- a/v2/observer/jobs.go
+++ b/v2/observer/jobs.go
@@ -117,7 +117,7 @@ func (o *observer) syncJobPod(obj interface{}) {
 	// Use the API to update Job status
 	eventID := pod.Labels[myk8s.LabelEvent]
 	jobName := pod.Labels[myk8s.LabelJob]
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), apiRequestTimeout)
 	defer cancel()
 	if err := o.updateJobStatusFn(
 		ctx,
@@ -163,7 +163,9 @@ func (o *observer) deleteJobResources(
 
 	<-time.After(o.config.delayBeforeCleanup)
 
-	if err := o.cleanupJobFn(context.Background(), eventID, jobName); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), apiRequestTimeout)
+	defer cancel()
+	if err := o.cleanupJobFn(ctx, eventID, jobName); err != nil {
 		o.errFn(
 			fmt.Sprintf(
 				"error cleaning up after event %q job %q: %s",

--- a/v2/observer/workers.go
+++ b/v2/observer/workers.go
@@ -96,7 +96,7 @@ func (o *observer) syncWorkerPod(obj interface{}) {
 
 	// Use the API to update Worker status
 	eventID := pod.Labels[myk8s.LabelEvent]
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), apiRequestTimeout)
 	defer cancel()
 	if err := o.updateWorkerStatusFn(
 		ctx,
@@ -135,7 +135,9 @@ func (o *observer) deleteWorkerResources(namespace, podName, eventID string) {
 
 	<-time.After(o.config.delayBeforeCleanup)
 
-	if err := o.cleanupWorkerFn(context.Background(), eventID); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), apiRequestTimeout)
+	defer cancel()
+	if err := o.cleanupWorkerFn(ctx, eventID); err != nil {
 		o.errFn(
 			fmt.Sprintf(
 				"error cleaning up after worker for event %q: %s",


### PR DESCRIPTION
In two cases, calls from the observer to the API server weren't setting a timeout on the context.

In two other cases where a timeout _was_ set, I've observed the timeout is too aggressive if there's a single instance of the apiserver running and its handling a lot of concurrent requests.

I don't foresee any reason to make this time out configurable-- rather it should simply be "generous." These are calls that we want to succeed even if they take a long time for whatever reason.