### PR TITLE
laying groundwork for authz

### DIFF
--- a/v2/apiserver/internal/authx/principals.go
+++ b/v2/apiserver/internal/authx/principals.go
@@ -2,6 +2,20 @@ package authx
 
 import "context"
 
+// PrincipalType is a type whose values can be used to disambiguate one type of
+// principal from another. For instance, when assigning a Role to a principal
+// via a RoleAssignment, a PrincipalType field is used to indicate whether the
+// value of the PrincipalID field reflects a User ID or a ServiceAccount ID.
+type PrincipalType string
+
+const (
+	// PrincipalTypeServiceAccount represents a principal that is a
+	// ServiceAccount.
+	PrincipalTypeServiceAccount PrincipalType = "SERVICE_ACCOUNT"
+	// PrincipalTypeUser represents a principal that is a User.
+	PrincipalTypeUser PrincipalType = "USER"
+)
+
 var (
 	// Root is a singleton that represents Brigade's "root" user.
 	Root = &root{}

--- a/v2/apiserver/internal/authx/roles.go
+++ b/v2/apiserver/internal/authx/roles.go
@@ -1,0 +1,58 @@
+package authx
+
+import "context"
+
+// RoleName is a type whose value maps to a well-defined Brigade Role.
+type RoleName string
+
+// RoleType is a type whose values can be used to disambiguate one type of Role
+// from another. This allows, for instance, system-level Roles to be
+// differentiated from project-level Roles.
+type RoleType string
+
+// RoleScopeGlobal represents an unbounded scope.
+const RoleScopeGlobal = "*"
+
+// Role represents a set of permissions, with domain-specific meaning, held by a
+// principal, such as a User or ServiceAccount via a RoleAssignment.
+type Role struct {
+	// Type indicates the Role's type, for instance, system-level or
+	// project-level.
+	Type RoleType `json:"type" bson:"type"`
+	// Name is the name of a Role and has domain-specific meaning.
+	Name RoleName `json:"name" bson:"name"`
+	// Scope qualifies the scope of the Role. The value is opaque and has meaning
+	// only in relation to a specific RoleName.
+	Scope string `json:"scope" bson:"scope"`
+}
+
+// RoleAssignment represents the assignment of a Role to a principal such as a
+// User or ServiceAccount.
+type RoleAssignment struct {
+	// Role specifies a Role.
+	Role RoleName `json:"role"`
+	// Scope qualifies the scope of the Role. The value is opaque and has meaning
+	// only in relation to a specific RoleName.
+	Scope string `json:"scope"`
+	// PrincipalType qualifies what kind of principal is referenced by the
+	// PrincipalID field-- for instance, a User or a ServiceAccount.
+	PrincipalType PrincipalType `json:"principalType"`
+	// PrincipalID references a principal. The PrincipalType qualifies what type
+	// of principal that is-- for instance, a User or a ServiceAccount.
+	PrincipalID string `json:"principalID"`
+}
+
+type RolesStore interface {
+	Grant(
+		ctx context.Context,
+		principalType PrincipalType,
+		principalID string,
+		roles ...Role,
+	) error
+	Revoke(
+		ctx context.Context,
+		principalType PrincipalType,
+		principalID string,
+		roles ...Role,
+	) error
+}

--- a/v2/apiserver/internal/core/roles.go
+++ b/v2/apiserver/internal/core/roles.go
@@ -1,0 +1,57 @@
+package core
+
+import "github.com/brigadecore/brigade/v2/apiserver/internal/authx"
+
+// RoleTypeProject represents a project-level Role.
+const RoleTypeProject authx.RoleType = "PROJECT"
+
+const (
+	// RoleNameProjectAdmin is the name of a project-level Role that enables
+	// principals to manage all aspects of a given Project, including the
+	// Project's secrets.
+	RoleNameProjectAdmin authx.RoleName = "PROJECT_ADMIN"
+	// RoleNameProjectDeveloper is the name of a project-level Role that enables
+	// principals to update Projects. This Role does NOT enable event creation
+	// or secret management.
+	RoleNameProjectDeveloper authx.RoleName = "PROJECT_DEVELOPER"
+	// RoleNameProjectUser is the name of a project-level Role that enables
+	// principals to create and manage Events for a Project.
+	RoleNameProjectUser authx.RoleName = "PROJECT_USER"
+)
+
+// RoleProjectAdmin returns a Role that enables a principal to manage a Project
+// having an ID field whose value matches that of the Scope field. If the value
+// of the Scope field is RoleScopeGlobal ("*"), then the Role is unbounded and
+// enables a principal to manage all Projects.
+func RoleProjectAdmin(projectID string) authx.Role {
+	return authx.Role{
+		Type:  RoleTypeProject,
+		Name:  RoleNameProjectAdmin,
+		Scope: projectID,
+	}
+}
+
+// RoleProjectDeveloper returns a Role that enables a principal to read and
+// update a Project having an ID field whose value matches that of the Scope
+// field. If the value of the Scope field is RoleScopeGlobal ("*"), then the
+// Role is unbounded and enables a principal to read and update all Projects.
+func RoleProjectDeveloper(projectID string) authx.Role {
+	return authx.Role{
+		Type:  RoleTypeProject,
+		Name:  RoleNameProjectDeveloper,
+		Scope: projectID,
+	}
+}
+
+// RoleProjectUser returns a Role that enables a principal read, create, and
+// manage Events for a Project having an ID field whose value matches the Scope
+// field. If the value of the Scope field is RoleScopeGlobal ("*"), then the
+// Role is unbounded and enables a principal to read, create, and manage Events
+// for all Projects.
+func RoleProjectUser(projectID string) authx.Role {
+	return authx.Role{
+		Type:  RoleTypeProject,
+		Name:  RoleNameProjectUser,
+		Scope: projectID,
+	}
+}

--- a/v2/apiserver/internal/system/roles.go
+++ b/v2/apiserver/internal/system/roles.go
@@ -1,0 +1,118 @@
+package system
+
+import "github.com/brigadecore/brigade/v2/apiserver/internal/authx"
+
+// RoleTypeSystem represents a system-level Role.
+const RoleTypeSystem authx.RoleType = "SYSTEM"
+
+const (
+	// RoleNameAdmin is the name of a system-level Role that enables principals to
+	// manage Users, ServiceAccounts, and system-level permissions for Users and
+	// ServiceAccounts.
+	RoleNameAdmin authx.RoleName = "ADMIN"
+	// RoleNameEventCreator is the name of a system-level Role that enables
+	// principals to create Events for all Projects. This Role is useful for
+	// ServiceAccounts used for gateways.
+	RoleNameEventCreator authx.RoleName = "EVENT_CREATOR"
+	// RoleNameProjectCreator is the name of a system-level Role that enables
+	// principals to create new Projects.
+	RoleNameProjectCreator authx.RoleName = "PROJECT_CREATOR"
+	// RoleNameReader is the name of a system-level Role that enables global read
+	// access.
+	RoleNameReader authx.RoleName = "READER"
+
+	// Special roles
+	//
+	// These are reserved for use by system components and are NOT assignable to
+	// Users and ServiceAccounts.
+
+	// RoleNameObserver is the name of a system-level Role that enables principals
+	// to updates Worker and Job status based on observation of the underlying
+	// workload execution substrate. This Role exists exclusively for use by
+	// Brigade's Observer component.
+	RoleNameObserver authx.RoleName = "OBSERVER"
+	// RoleNameScheduler is the name of a system-level Role that enables
+	// principals to initiate execution of a Worker or Job on the underlying
+	// workload execution substrate. This Role exists exclusively for use by
+	// Brigade's Scheduler component.
+	RoleNameScheduler authx.RoleName = "SCHEDULER"
+	// RoleNameWorker is the name of an event-level Role that enables principals
+	// to create new Jobs. This Role is exclusively for the use of Brigade
+	// Workers.
+	RoleNameWorker authx.RoleName = "WORKER"
+)
+
+// RoleAdmin returns a Role that enables a principal to manage Users,
+// ServiceAccounts, and globally scoped permissions for Users and
+// ServiceAccounts.
+func RoleAdmin() authx.Role {
+	return authx.Role{
+		Type: RoleTypeSystem,
+		Name: RoleNameAdmin,
+	}
+}
+
+// RoleEventCreator returns a Role that enables a principal to create new Events
+// having a Source field whose value matches that of the Scope field. This Role
+// is useful for ServiceAccounts used for gateways.
+func RoleEventCreator(eventSource string) authx.Role {
+	return authx.Role{
+		Type:  RoleTypeSystem,
+		Name:  RoleNameEventCreator,
+		Scope: eventSource,
+	}
+}
+
+// RoleProjectCreator returns a Role that enables a principal to create new
+// Projects.
+func RoleProjectCreator() authx.Role {
+	return authx.Role{
+		Type: RoleTypeSystem,
+		Name: RoleNameProjectCreator,
+	}
+}
+
+// RoleReader returns a Role that enables a principal to list and read Projects,
+// Events, Users, and Service Accounts.
+func RoleReader() authx.Role {
+	return authx.Role{
+		Type: RoleTypeSystem,
+		Name: RoleNameReader,
+	}
+}
+
+// Special roles
+//
+// These are reserved for use by system components and are NOT assignable to
+// Users and ServiceAccounts.
+
+// RoleObserver returns a Role that enables a principal to update Worker and Job
+// statuses based on observations of the underlying workload execution
+// substrate. This Role is exclusively for the use of the Observer component.
+func RoleObserver() authx.Role {
+	return authx.Role{
+		Type: RoleTypeSystem,
+		Name: RoleNameObserver,
+	}
+}
+
+// RoleScheduler returns a Role that enables a principal to initiate execution
+// of Workers and Jobs on the underlying workload execution substrate. This Role
+// is exclusively for the use of the Scheduler component.
+func RoleScheduler() authx.Role {
+	return authx.Role{
+		Type: RoleTypeSystem,
+		Name: RoleNameScheduler,
+	}
+}
+
+// RoleWorker returns a Role that enables a principal to create Jobs for the
+// Event whose ID matches the Scope. This Role is exclusively for the use of
+// Workers.
+func RoleWorker(eventID string) authx.Role {
+	return authx.Role{
+		Type:  RoleTypeSystem,
+		Name:  RoleNameWorker,
+		Scope: eventID,
+	}
+}


### PR DESCRIPTION
This PR introduces a variety of prerequisite types and constants that will be leveraged by several forthcoming PRs that will:

1. Define the roles belonging to "special" principals such as the root user and the scheduler and observer components.

1. Enable granting/revoking both project-level and system-level roles to/from principals such as users and service accounts.

1. Enforce authorization on all API calls.

I'm submitting these individually in an effort to keep PRs smaller and more reviewable given maintainers' limited holiday season bandwidth.