### PR TITLE
fix(project.json): allow for 'git@github.com:...' clone urls

### DIFF
--- a/v2/apiserver/schemas/project.json
+++ b/v2/apiserver/schemas/project.json
@@ -26,7 +26,7 @@
 
 		"url": {
 			"type": "string",
-			"pattern": "^[\\w:/\\-\\.\\?=]*$",
+			"pattern": "^[\\w:/\\-\\.\\?=@]*$",
 			"minLength": 5,
 			"maxLength": 250
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the `url` definition in the project schema to allow for `@` characters, as needed to support ssh git URLs (e.g. `git@github.com:myorg/myrepo.git`

**Special notes for your reviewer**:

Do we have tests against our JSON schemas yet?  If so, I can add/update.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
