### PR TITLE
feat(secrets_commands.go): add secret command alias

### DIFF
--- a/v2/cli/secrets_commands.go
+++ b/v2/cli/secrets_commands.go
@@ -16,8 +16,9 @@ import (
 )
 
 var secretsCommand = &cli.Command{
-	Name:  "secrets",
-	Usage: "Manage project secrets",
+	Name:    "secrets",
+	Aliases: []string{"secret"},
+	Usage:   "Manage project secrets",
 	Subcommands: []*cli.Command{
 		{
 			Name:    "list",


### PR DESCRIPTION
I found myself typing `brig project secret set ...` often, especially as the current mode of this command is to set one secret at a time.  Therefore, I thought this might be an appropriate alias to add.
