### PR TITLE
fix(project.json): add commit and ref fields to gitConfig

### DIFF
--- a/v2/apiserver/schemas/event.json
+++ b/v2/apiserver/schemas/event.json
@@ -62,6 +62,9 @@
 				},
 				"commit": {
 					"type": "string",
+					"pattern": "^[a-f0-9]*$",
+					"minLength": 8,
+					"maxLength": 40,
 					"description": "A git commit sha"
 				},
 				"ref": {

--- a/v2/apiserver/schemas/event.json
+++ b/v2/apiserver/schemas/event.json
@@ -62,7 +62,7 @@
 				},
 				"commit": {
 					"type": "string",
-					"pattern": "^[a-f0-9]*$",
+					"pattern": "^[a-fA-F0-9]*$",
 					"minLength": 8,
 					"maxLength": 40,
 					"description": "A git commit sha"

--- a/v2/apiserver/schemas/project.json
+++ b/v2/apiserver/schemas/project.json
@@ -226,7 +226,7 @@
         },
 				"commit": {
 					"type": "string",
-					"pattern": "^[a-f0-9]*$",
+					"pattern": "^[a-fA-F0-9]*$",
 					"minLength": 8,
 					"maxLength": 40,
 					"description": "A git commit sha"

--- a/v2/apiserver/schemas/project.json
+++ b/v2/apiserver/schemas/project.json
@@ -223,6 +223,14 @@
 						}
 					],
 					"description": "The URL for cloning a git project"
+        },
+				"commit": {
+					"type": "string",
+					"description": "A git commit sha"
+				},
+				"ref": {
+					"type": "string",
+					"description": "A reference to a git branch or tag"
 				},
 				"initSubmodules": {
 					"type": "boolean",

--- a/v2/apiserver/schemas/project.json
+++ b/v2/apiserver/schemas/project.json
@@ -226,6 +226,9 @@
         },
 				"commit": {
 					"type": "string",
+					"pattern": "^[a-f0-9]*$",
+					"minLength": 8,
+					"maxLength": 40,
 					"description": "A git commit sha"
 				},
 				"ref": {


### PR DESCRIPTION
Adds missing `commit` and `ref` fields to the `workerSpec`'s `git` section of the project config, to match the similar config on an event.

Actually, since the two `gitConfig` definitions are now equivalent between the project and event schema, we could entertain housing common schema definitions in a sibling file that both could then pull from... thoughts?