### PR TITLE
Add support for server sent event streams

### DIFF
--- a/v2/apiserver/internal/core/jobs.go
+++ b/v2/apiserver/internal/core/jobs.go
@@ -49,6 +49,25 @@ const (
 	JobPhaseUnknown JobPhase = "UNKNOWN"
 )
 
+// IsTerminal returns a bool indicating whether the JobPhase is terminal.
+func (j JobPhase) IsTerminal() bool {
+	switch j {
+	case JobPhaseAborted:
+		fallthrough
+	case JobPhaseCanceled:
+		fallthrough
+	case JobPhaseFailed:
+		fallthrough
+	case JobPhaseSchedulingFailed:
+		fallthrough
+	case JobPhaseSucceeded:
+		fallthrough
+	case JobPhaseTimedOut:
+		return true
+	}
+	return false
+}
+
 // Job represents a component spawned by a Worker to complete a single task
 // in the course of handling an Event.
 type Job struct {

--- a/v2/apiserver/internal/core/jobs.go
+++ b/v2/apiserver/internal/core/jobs.go
@@ -17,6 +17,9 @@ const (
 	// JobPhaseAborted represents the state wherein a Job was forcefully
 	// stopped during execution.
 	JobPhaseAborted JobPhase = "ABORTED"
+	// JobPhaseCanceled represents the state wherein a pending Job was
+	// canceled prior to execution.
+	JobPhaseCanceled JobPhase = "CANCELED"
 	// JobPhaseFailed represents the state wherein a Job has run to
 	// completion but experienced errors.
 	JobPhaseFailed JobPhase = "FAILED"
@@ -26,10 +29,10 @@ const (
 	// JobPhaseRunning represents the state wherein a Job is currently
 	// being executed.
 	JobPhaseRunning JobPhase = "RUNNING"
-	// JobPhaseSchedulingFailed represents the state wherein a job was not
+	// JobPhaseSchedulingFailed represents the state wherein a Job was not
 	// scheduled due to some unexpected and unrecoverable error encountered by the
 	// scheduler.
-	JobPhaseSchedulingFailed WorkerPhase = "SCHEDULING_FAILED"
+	JobPhaseSchedulingFailed JobPhase = "SCHEDULING_FAILED"
 	// JobPhaseStarting represents the state wherein a Job is starting on the
 	// substrate but isn't running yet.
 	JobPhaseStarting JobPhase = "STARTING"

--- a/v2/apiserver/internal/core/rest/logs_endpoints.go
+++ b/v2/apiserver/internal/core/rest/logs_endpoints.go
@@ -69,7 +69,7 @@ func (l *LogsEndpoints) stream(
 			if err != nil {
 				restmachinery.WriteAPIResponse(
 					w,
-					http.StatusNotFound,
+					http.StatusBadRequest,
 					&meta.ErrBadRequest{
 						Reason: "Value of \"Last-Event-ID\" header was not parseable as " +
 							"an int",

--- a/v2/apiserver/internal/core/rest/logs_endpoints.go
+++ b/v2/apiserver/internal/core/rest/logs_endpoints.go
@@ -39,12 +39,45 @@ func (l *LogsEndpoints) stream(
 	// nolint: errcheck
 	follow, _ := strconv.ParseBool(r.URL.Query().Get("follow"))
 
+	// Clients can request use of the SSE protocol instead of HTTP/2 streaming.
+	// Not every potential client language has equally good support for both of
+	// those, so allowing clients to pick is useful.
+	sse, _ := strconv.ParseBool(r.URL.Query().Get("sse")) // nolint: errcheck
+
 	selector := core.LogsSelector{
 		Job:       r.URL.Query().Get("job"),
 		Container: r.URL.Query().Get("container"),
 	}
 	opts := core.LogStreamOptions{
 		Follow: follow,
+	}
+
+	var lastEventID int64
+	// SSE has support for resuming where you left off after a
+	// disconnect/reconnect. Formally, I (krancour) believe the specification says
+	// clients can echo the ID of the last message received in a Last-Event-ID
+	// header, but I've encountered clients that use a lastEventId query parameter
+	// instead. Invoking Postel's principle, we'll support both.
+	if sse {
+		lastEventIDStr := r.Header.Get("Last-Event-ID")
+		if lastEventIDStr == "" {
+			lastEventIDStr = r.URL.Query().Get("lastEventId")
+		}
+		if lastEventIDStr != "" {
+			var err error
+			lastEventID, err = strconv.ParseInt(lastEventIDStr, 10, 64)
+			if err != nil {
+				restmachinery.WriteAPIResponse(
+					w,
+					http.StatusNotFound,
+					&meta.ErrBadRequest{
+						Reason: "Value of \"Last-Event-ID\" header was not parseable as " +
+							"an int",
+					},
+				)
+				return
+			}
+		}
 	}
 
 	logEntryCh, err := l.Service.Stream(r.Context(), id, selector, opts)
@@ -66,13 +99,37 @@ func (l *LogsEndpoints) stream(
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.(http.Flusher).Flush()
+	var i int64
 	for logEntry := range logEntryCh {
 		logEntryBytes, err := json.Marshal(logEntry)
 		if err != nil {
 			log.Println(errors.Wrapf(err, "error marshaling log entry"))
-			return
+			continue
 		}
-		fmt.Fprint(w, string(logEntryBytes))
+		if sse {
+			i++
+			// SSE has support for resuming where you left off after a
+			// disconnect/reconnect. This check is so we can "fast forward" past
+			// messages the client says it already received.
+			if i > lastEventID {
+				fmt.Fprintf(
+					w,
+					"event: message\ndata: %s\nid: %d\n\n",
+					string(logEntryBytes),
+					i,
+				)
+				w.(http.Flusher).Flush()
+			}
+		} else {
+			fmt.Fprint(w, string(logEntryBytes))
+			w.(http.Flusher).Flush()
+		}
+	}
+	// If we're using SSE, we'll explicitly send an event that denotes the end of
+	// the stream.
+	if sse {
+		i++
+		fmt.Fprintf(w, "event: done\ndata: done\nid: %d\n\n", i)
 		w.(http.Flusher).Flush()
 	}
 }

--- a/v2/apiserver/internal/core/rest/logs_endpoints.go
+++ b/v2/apiserver/internal/core/rest/logs_endpoints.go
@@ -71,8 +71,7 @@ func (l *LogsEndpoints) stream(
 					w,
 					http.StatusBadRequest,
 					&meta.ErrBadRequest{
-						Reason: "Value of \"Last-Event-ID\" header was not parseable as " +
-							"an int",
+						Reason: "Value of last id was not parseable as an int",
 					},
 				)
 				return

--- a/v2/apiserver/internal/core/workers.go
+++ b/v2/apiserver/internal/core/workers.go
@@ -72,6 +72,25 @@ func WorkerPhasesAll() []WorkerPhase {
 	}
 }
 
+// IsTerminal returns a bool indicating whether the WorkerPhase is terminal.
+func (w WorkerPhase) IsTerminal() bool {
+	switch w {
+	case WorkerPhaseAborted:
+		fallthrough
+	case WorkerPhaseCanceled:
+		fallthrough
+	case WorkerPhaseFailed:
+		fallthrough
+	case WorkerPhaseSchedulingFailed:
+		fallthrough
+	case WorkerPhaseSucceeded:
+		fallthrough
+	case WorkerPhaseTimedOut:
+		return true
+	}
+	return false
+}
+
 // Worker represents a component that orchestrates handling of a single Event.
 type Worker struct {
 	// Spec is the technical blueprint for the Worker.

--- a/v2/apiserver/internal/core/workers.go
+++ b/v2/apiserver/internal/core/workers.go
@@ -20,35 +20,35 @@ const LogLevelInfo LogLevel = "INFO"
 type WorkerPhase string
 
 const (
-	// WorkerPhaseAborted represents the state wherein a worker was forcefully
+	// WorkerPhaseAborted represents the state wherein a Worker was forcefully
 	// stopped during execution.
 	WorkerPhaseAborted WorkerPhase = "ABORTED"
-	// WorkerPhaseCanceled represents the state wherein a pending worker was
+	// WorkerPhaseCanceled represents the state wherein a pending Worker was
 	// canceled prior to execution.
 	WorkerPhaseCanceled WorkerPhase = "CANCELED"
-	// WorkerPhaseFailed represents the state wherein a worker has run to
+	// WorkerPhaseFailed represents the state wherein a Worker has run to
 	// completion but experienced errors.
 	WorkerPhaseFailed WorkerPhase = "FAILED"
-	// WorkerPhasePending represents the state wherein a worker is awaiting
+	// WorkerPhasePending represents the state wherein a Worker is awaiting
 	// execution.
 	WorkerPhasePending WorkerPhase = "PENDING"
-	// WorkerPhaseRunning represents the state wherein a worker is currently
+	// WorkerPhaseRunning represents the state wherein a Worker is currently
 	// being executed.
 	WorkerPhaseRunning WorkerPhase = "RUNNING"
-	// WorkerPhaseSchedulingFailed represents the state wherein a worker was not
+	// WorkerPhaseSchedulingFailed represents the state wherein a Worker was not
 	// scheduled due to some unexpected and unrecoverable error encountered by the
 	// scheduler.
 	WorkerPhaseSchedulingFailed WorkerPhase = "SCHEDULING_FAILED"
 	// WorkerPhaseStarting represents the state wherein a Worker is starting on
 	// the substrate but isn't running yet.
 	WorkerPhaseStarting WorkerPhase = "STARTING"
-	// WorkerPhaseSucceeded represents the state where a worker has run to
+	// WorkerPhaseSucceeded represents the state where a Worker has run to
 	// completion without error.
 	WorkerPhaseSucceeded WorkerPhase = "SUCCEEDED"
-	// WorkerPhaseTimedOut represents the state wherein a worker has has not
+	// WorkerPhaseTimedOut represents the state wherein a Worker has has not
 	// completed within a designated timeframe.
 	WorkerPhaseTimedOut WorkerPhase = "TIMED_OUT"
-	// WorkerPhaseUnknown represents the state wherein a worker's state is
+	// WorkerPhaseUnknown represents the state wherein a Worker's state is
 	// unknown. Note that this is possible if and only if the underlying Worker
 	// execution substrate (Kubernetes), for some unanticipated, reason does not
 	// know the Worker's (Pod's) state.

--- a/v2/apiserver/internal/lib/restmachinery/server.go
+++ b/v2/apiserver/internal/lib/restmachinery/server.go
@@ -53,7 +53,10 @@ func NewServer(endpoints []Endpoints, config *ServerConfig) Server {
 		config: *config,
 		handler: cors.New(
 			cors.Options{
-				AllowedMethods: []string{"DELETE", "GET", "POST", "PUT"},
+				AllowCredentials: true,
+				AllowedOrigins:   []string{"*"},
+				AllowedMethods:   []string{"DELETE", "GET", "POST", "PUT"},
+				AllowedHeaders:   []string{"Authorization"},
 			},
 		).Handler(router),
 	}

--- a/v2/worker/package.json
+++ b/v2/worker/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "axios": "^0.21.0",
+    "eventsource": "^1.0.7",
     "module-alias": "^2.2.2",
     "require-from-string": "^2.0.2",
     "winston": "^3.3.3"

--- a/v2/worker/src/jobs.ts
+++ b/v2/worker/src/jobs.ts
@@ -45,13 +45,11 @@ export class Job extends BrigadierJob {
         },
       })
       if (response.status != 201) {
-        console.log(response.data)
-        throw new Error(response.data)
+        throw new Error(`Received ${response.status} from the API server`)
       }
     }
-    catch(err) {
-      // Wrap the original error to give clear context.
-      throw new Error(`job ${this.name}: ${err}`)
+    catch(e) {
+      throw new Error(`Error creating job "${this.name}": ${e.message}`)
     }
     return this.wait()
   }
@@ -76,25 +74,25 @@ export class Job extends BrigadierJob {
           status = JSON.parse(event.data)
         } catch(e) {
           eventSource.close() 
-          reject(new Error("Error parsing job status"))
+          reject(new Error(`Error parsing job "${this.name}" status: ${e.message}`))
         }
         this.logger.debug(`Current job phase is ${status.phase}`)
         switch (status.phase) {
         case "ABORTED":
           eventSource.close()
-          reject(new Error("Job was aborted"))
+          reject(new Error(`Job "${this.name}" was aborted`))
           break
         case "CANCELED":
           eventSource.close()
-          reject(new Error("Job was canceled before starting"))
+          reject(new Error(`Job "${this.name}" was canceled before starting`))
           break
         case "FAILED":
           eventSource.close()
-          reject(new Error("Job failed"))
+          reject(new Error(`Job "${this.name}" failed`))
           break
         case "SCHEDULING_FAILED":
           eventSource.close()
-          reject(new Error("Job scheduling failed"))
+          reject(new Error(`Job "${this.name}" scheduling failed`))
           break
         case "SUCCEEDED":
           eventSource.close()
@@ -102,7 +100,7 @@ export class Job extends BrigadierJob {
           break
         case "TIMED_OUT":
           eventSource.close()
-          reject(new Error("Job timed out"))
+          reject(new Error(`Job "${this.name}" timed out`))
           break
         }
         // For all other phases there's nothing to do. Keep waiting.
@@ -110,14 +108,14 @@ export class Job extends BrigadierJob {
       eventSource.addEventListener("error", (e: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
         if (e.status) { // If the error has an HTTP status code associated with it...
           eventSource.close()
-          reject(new Error(`Received ${e.status} from the API server`))
+          reject(new Error(`Received ${e.status} from the API server when attempting to open job "${this.name}" status stream`))
         } else if (eventSource.readyState == EventSource.CONNECTING) {
           // We lost the connection and we're reconnecting... nbd
           this.logger.debug("Reconnecting to status stream")
         } else if (eventSource.readyState == EventSource.CLOSED) {
           // We disconnected for some unknown reason... and presumably exhausted
           // attempts to reconnect
-          reject(new Error("Encountered unknown error receiving status stream"))
+          reject(new Error(`Error receiving job "${this.name}" status stream: ${e.message}`))
         }
       })
     })
@@ -144,7 +142,7 @@ export class Job extends BrigadierJob {
           logEntry = JSON.parse(event.data)
         } catch(e) {
           eventSource.close() 
-          reject(new Error("Error parsing log entry"))
+          reject(new Error(`Error parsing log entry for job "${this.name}": ${e.message}`))
         }
         if (logs != "") {
           logs += "\n"
@@ -154,14 +152,14 @@ export class Job extends BrigadierJob {
       eventSource.addEventListener("error", (e: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
         if (e.status) { // If the error has an HTTP status code associated with it...
           eventSource.close()
-          reject(new Error(`Received ${e.status} from the API server`))
+          reject(new Error(`Received ${e.status} from the API server when attempting to open job "${this.name}" log stream`))
         } else if (eventSource.readyState == EventSource.CONNECTING) {
           // We lost the connection and we're reconnecting... nbd
           this.logger.debug("Reconnecting to log stream")
         } else if (eventSource.readyState == EventSource.CLOSED) {
           // We disconnected for some unknown reason... and presumably exhausted
           // attempts to reconnect
-          reject(new Error("Encountered unknown error receiving log stream"))
+          reject(new Error(`Encountered unknown error receiving job "${this.name}" log stream`))
         }
       })
       eventSource.addEventListener("done", () => {

--- a/v2/worker/yarn.lock
+++ b/v2/worker/yarn.lock
@@ -652,6 +652,13 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eventsource@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.0.7.tgz#8fbc72c93fcd34088090bc0a4e64f4b5cee6d8d0"
+  integrity sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==
+  dependencies:
+    original "^1.0.0"
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
@@ -1129,6 +1136,13 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
+original@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/original/-/original-1.0.2.tgz#e442a61cffe1c5fd20a65f3261c26663b303f25f"
+  integrity sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==
+  dependencies:
+    url-parse "^1.4.3"
+
 p-limit@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz"
@@ -1224,6 +1238,11 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -1279,6 +1298,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -1540,6 +1564,14 @@ uri-js@^4.2.2:
   integrity sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==
   dependencies:
     punycode "^2.1.0"
+
+url-parse@^1.4.3:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
+  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
I was recently tooling around with creating a TS/JS Brigade 2 API client that works in both Node and any modern browser. In doing so, I stumbled across the fact that no analog to Node's `http2` library exists in the browser world. (There is no polyfill for it either.) This is not to say that browsers can't do http/2-- that would be absurd. But they _don't_ (yet?) expose any http/2 client that can be used to _programmatically_ consume a stream. This means any hypothetical TS/JS Brigade 2 API client used _within a browser_ cannot consume our log streams and status streams as they were currently implemented on the backend.

However, I learned that there's an entire [specification](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events) for _server sent events_. Modern browsers have decent support for it. Node does not, but the capability can be polyfilled into Node. Server sent events are a quick and easy way to implement a _one way_ stream (not full duplex like http/2) from server to client. _They are ideal for our purposes._ (And of course, they do still work over http/2 if that's how the client and server happen to communicate under the hood, but they don't _require_ it.)

Initially, I tried to transition our status and log streams to using SSE _exclusively_, but found that there were only a couple Go clients available that I could use in the Go SDK for Brigade 2. One was riddled with bugs. The other did not faithfully implement the specification. It seemed best for Go-based clients to stick to the original approach...

In the end, this PR preserves existing ability to do http/2 streams, but adds the _option_ for clients (like a hypothetical TS/JS client) to _request_ a stream of SSEs.

One nice consequence to this is that worker code can be dramatically simplified (also included in this PR) by using SSE instead of the `http2` library, since the `EventSource` API (a polyfill) automatically handles reconnects and stuff-- because that's actually part of the SSE spec.

Out of necessity, also fixes #1212

Unit tests for the new SSE stream options are lacking, because as noted, there isn't a good way to consume those streams using Go. All of this works, e2e. Since workers depend on this, when we get around to creating an e2e test suite, it will implicitly cover this new functionality.