### PR TITLE
define roles

### DIFF
--- a/v2/apiserver/internal/authx/named_principals.go
+++ b/v2/apiserver/internal/authx/named_principals.go
@@ -1,0 +1,67 @@
+package authx
+
+var (
+	// Root is a singleton that represents Brigade's "root" user.
+	Root = &root{}
+	// Scheduler is a singleton that represents Brigade's scheduler component.
+	Scheduler = &scheduler{}
+	// Observer is a singleton that represents Brigade's observer component.
+	Observer = &observer{}
+)
+
+// root is an implementation of the Principal interface for the "root" user.
+type root struct{}
+
+func (r *root) Roles() []Role {
+	return []Role{
+		RoleAdmin(),
+		RoleEventCreator(RoleScopeGlobal),
+		RoleProjectAdmin(RoleScopeGlobal),
+		RoleProjectCreator(),
+		RoleProjectDeveloper(RoleScopeGlobal),
+		RoleProjectUser(RoleScopeGlobal),
+		RoleReader(),
+	}
+}
+
+// scheduler is an implementation of the Principal interface that represents the
+// scheduler component, which is a special class of user because, although it
+// cannot do much, it has the UNIQUE ability to launch Workers and Jobs.
+type scheduler struct{}
+
+func (s *scheduler) Roles() []Role {
+	return []Role{
+		RoleScheduler(),
+	}
+}
+
+// observer is an implementation of the Principal interface that represents the
+// observer component, which is a special class of user because, although it
+// cannot do much, it has the UNIQUE ability to update Worker and Job statuses.
+type observer struct{}
+
+func (o *observer) Roles() []Role {
+	return []Role{
+		RoleObserver(),
+	}
+}
+
+// worker is an implementation of the Principal interface that represents an
+// Event's Worker, which is a special class of user because, although it cannot
+// do much, it has the UNIQUE ability to create new Jobs.
+type worker struct {
+	eventID string
+}
+
+// Worker returns a Principal that represents the specified Event's Worker.
+func Worker(eventID string) Principal {
+	return &worker{
+		eventID: eventID,
+	}
+}
+
+func (w *worker) Roles() []Role {
+	return []Role{
+		RoleWorker(w.eventID),
+	}
+}

--- a/v2/apiserver/internal/authx/named_roles.go
+++ b/v2/apiserver/internal/authx/named_roles.go
@@ -1,0 +1,161 @@
+package authx
+
+const (
+	// RoleNameAdmin is the name of a system-level Role that enables principals to
+	// manage Users, ServiceAccounts, and system-level permissions for Users and
+	// ServiceAccounts.
+	RoleNameAdmin RoleName = "ADMIN"
+	// RoleNameEventCreator is the name of a system-level Role that enables
+	// principals to create Events for all Projects. This is useful for Event
+	// gateways.
+	RoleNameEventCreator RoleName = "EVENT_CREATOR"
+	// RoleNameProjectAdmin is the name of a project-level Role that enables
+	// principals to manage all aspects of a given Project, including the
+	// Project's secrets, and project-level permissions for Users and
+	// ServiceAccounts.
+	RoleNameProjectAdmin RoleName = "PROJECT_ADMIN"
+	// RoleNameProjectCreator is the name of a system-level Role that enables
+	// principals to create new Projects.
+	RoleNameProjectCreator RoleName = "PROJECT_CREATOR"
+	// RoleNameProjectDeveloper is the name of a project-level Role that enables
+	// principals to update Projects. This Role does NOT enable event creation,
+	// secret management, or management of project-level permissions for Users and
+	// ServiceAccounts.
+	RoleNameProjectDeveloper RoleName = "PROJECT_DEVELOPER"
+	// RoleNameProjectUser is the name of a project-level Role that enables
+	// principals to create and manage Events for a Project.
+	RoleNameProjectUser RoleName = "PROJECT_USER"
+	// RoleNameReader is the name of a system-level Role that enables global read
+	// access.
+	RoleNameReader RoleName = "READER"
+
+	// Special roles
+	//
+	// These are reserved for use by system components and are NOT assignable to
+	// Users and ServiceAccounts.
+
+	// RoleNameObserver is the name of a system-level Role that enables principals
+	// to updates Worker and Job status based on observation of the underlying
+	// workload execution substrate. This Role exists exclusively for use by
+	// Brigade's Observer component.
+	RoleNameObserver RoleName = "OBSERVER"
+	// RoleNameScheduler is the name of a system-level Role that enables
+	// principals to initiate execution of a Worker or Job on the underlying
+	// workload execution substrate. This Role exists exclusively for use by
+	// Brigade's Scheduler component.
+	RoleNameScheduler RoleName = "SCHEDULER"
+	// RoleNameWorker is the name of an event-level Role that enables principals
+	// to create new Jobs , monitor the status of those Jobs, and access their
+	// logs. This Role is exclusively for the use of Brigade Workers.
+	RoleNameWorker RoleName = "WORKER"
+)
+
+// RoleAdmin returns a system-level Role that enables principals to manage
+// Users, ServiceAccounts, and system-level permissions for Users and
+// ServiceAccounts.
+func RoleAdmin() Role {
+	return Role{
+		Type: RoleTypeSystem,
+		Name: RoleNameAdmin,
+	}
+}
+
+// RoleEventCreator returns a system-level Role that enables principals to
+// create Events for all Projects-- provided the Events have the specified
+// source. This is useful for Event gateways, which should be able to create
+// Events for all Projects, but should NOT be able to impersonate other
+// gateways.
+func RoleEventCreator(eventSource string) Role {
+	return Role{
+		Type:  RoleTypeSystem,
+		Name:  RoleNameEventCreator,
+		Scope: eventSource,
+	}
+}
+
+// RoleProjectAdmin returns a project-level Role that enables principals to
+// manage all aspects of a given Project, including the Project's secrets, and
+// project-level permissions for Users and ServiceAccounts.
+func RoleProjectAdmin(projectID string) Role {
+	return Role{
+		Type:  RoleTypeProject,
+		Name:  RoleNameProjectAdmin,
+		Scope: projectID,
+	}
+}
+
+// RoleProjectCreator returns a system-level Role that enables principals to
+// create new Projects.
+func RoleProjectCreator() Role {
+	return Role{
+		Type: RoleTypeSystem,
+		Name: RoleNameProjectCreator,
+	}
+}
+
+// RoleProjectDeveloper returns a project-level Role that enables principals to
+// update the given Project. This Role does NOT enable event creation, secret
+// management, or management of project-level permissions for Users and
+// ServiceAccounts.
+func RoleProjectDeveloper(projectID string) Role {
+	return Role{
+		Type:  RoleTypeProject,
+		Name:  RoleNameProjectDeveloper,
+		Scope: projectID,
+	}
+}
+
+// RoleProjectUser is the name of a project-level Role that enables principals
+// to create and manage Events for the specified Project.
+func RoleProjectUser(projectID string) Role {
+	return Role{
+		Type:  RoleTypeProject,
+		Name:  RoleNameProjectUser,
+		Scope: projectID,
+	}
+}
+
+// RoleReader returns a system-level Role that enables global read access.
+func RoleReader() Role {
+	return Role{
+		Type: RoleTypeSystem,
+		Name: RoleNameReader,
+	}
+}
+
+// Special roles
+//
+// These are reserved for use by system components and are NOT assignable to
+// Users and ServiceAccounts.
+
+// RoleObserver returns a system-level Role that enables principals to updates
+// Worker and Job status based on observation of the underlying workload
+// execution substrate. This Role exists exclusively for use by Brigade's
+// Observer component.
+func RoleObserver() Role {
+	return Role{
+		Type: RoleTypeSystem,
+		Name: RoleNameObserver,
+	}
+}
+
+// RoleScheduler returns a system-level Role that enables principals to initiate
+// execution of a Worker or Job on the underlying workload execution substrate.
+// This Role exists exclusively for use by Brigade's Scheduler component.
+func RoleScheduler() Role {
+	return Role{
+		Type: RoleTypeSystem,
+		Name: RoleNameScheduler,
+	}
+}
+
+// RoleWorker returns an event-level Role that enables principals to create new
+// Jobs, monitor the status of those Jobs, and access their logs. This Role is
+// exclusively for the use of Brigade Workers.
+func RoleWorker(eventID string) Role {
+	return Role{
+		Type:  RoleTypeEvent,
+		Name:  RoleNameWorker,
+		Scope: eventID,
+	}
+}

--- a/v2/apiserver/internal/authx/principals.go
+++ b/v2/apiserver/internal/authx/principals.go
@@ -16,34 +16,10 @@ const (
 	PrincipalTypeUser PrincipalType = "USER"
 )
 
-var (
-	// Root is a singleton that represents Brigade's "root" user.
-	Root = &root{}
-	// Scheduler is a singleton that represents Brigade's scheduler component.
-	Scheduler = &scheduler{}
-	// Observer is a singleton that represents Brigade's observer component.
-	Observer = &observer{}
-)
-
 // Principal is an interface for any sort of security principal (human user,
 // service account, etc.)
-type Principal interface{}
-
-// root is an implementation of the Principal interface for the "root" user.
-type root struct{}
-
-type scheduler struct{}
-
-type observer struct{}
-
-type worker struct {
-	eventID string
-}
-
-func Worker(eventID string) Principal {
-	return &worker{
-		eventID: eventID,
-	}
+type Principal interface {
+	Roles() []Role
 }
 
 type principalContextKey struct{}

--- a/v2/apiserver/internal/authx/principals_test.go
+++ b/v2/apiserver/internal/authx/principals_test.go
@@ -14,9 +14,9 @@ func TestContextWithPrincipal(t *testing.T) {
 			ID: "tony@starkindustries.com",
 		},
 	}
-	ctx := ContextWithPrincipal(context.Background(), testUser)
+	ctx := ContextWithPrincipal(context.Background(), &testUser)
 	val := ctx.Value(principalContextKey{})
-	require.Equal(t, testUser, val)
+	require.Equal(t, &testUser, val)
 }
 
 func TestPrincipalFromContext(t *testing.T) {
@@ -26,7 +26,7 @@ func TestPrincipalFromContext(t *testing.T) {
 		},
 	}
 	ctx :=
-		context.WithValue(context.Background(), principalContextKey{}, testUser)
+		context.WithValue(context.Background(), principalContextKey{}, &testUser)
 	principal := PrincipalFromContext(ctx)
-	require.Equal(t, testUser, principal)
+	require.Equal(t, &testUser, principal)
 }

--- a/v2/apiserver/internal/authx/roles.go
+++ b/v2/apiserver/internal/authx/roles.go
@@ -2,13 +2,24 @@ package authx
 
 import "context"
 
-// RoleName is a type whose value maps to a well-defined Brigade Role.
-type RoleName string
-
 // RoleType is a type whose values can be used to disambiguate one type of Role
 // from another. This allows, for instance, system-level Roles to be
 // differentiated from project-level Roles.
 type RoleType string
+
+const (
+	// RoleTypeEvent represents an event-level Role. In practice, these are only
+	// used by Workers who have no business reading or writing anything related to
+	// any Event other than the one they were spawned to handle.
+	RoleTypeEvent RoleType = "EVENT"
+	// RoleTypeProject represents a project-level Role.
+	RoleTypeProject RoleType = "PROJECT"
+	// RoleTypeSystem represents a system-level Role.
+	RoleTypeSystem RoleType = "SYSTEM"
+)
+
+// RoleName is a type whose value maps to a well-defined Brigade Role.
+type RoleName string
 
 // RoleScopeGlobal represents an unbounded scope.
 const RoleScopeGlobal = "*"
@@ -29,6 +40,10 @@ type Role struct {
 // RoleAssignment represents the assignment of a Role to a principal such as a
 // User or ServiceAccount.
 type RoleAssignment struct {
+	// Note the explicit lack of RoleType field. Project-level RoleAssignments
+	// and system-level RoleAssignment are handled by different endpoints. The
+	// endpoints provide that context.
+
 	// Role specifies a Role.
 	Role RoleName `json:"role"`
 	// Scope qualifies the scope of the Role. The value is opaque and has meaning
@@ -42,6 +57,8 @@ type RoleAssignment struct {
 	PrincipalID string `json:"principalID"`
 }
 
+// RolesStore is an interface for components that implement Role persistence
+// concerns.
 type RolesStore interface {
 	Grant(
 		ctx context.Context,

--- a/v2/apiserver/internal/authx/service_accounts.go
+++ b/v2/apiserver/internal/authx/service_accounts.go
@@ -24,6 +24,15 @@ type ServiceAccount struct {
 	// by an administrator. If this field's value is nil, the ServiceAccount is
 	// not locked.
 	Locked *time.Time `json:"locked,omitempty" bson:"locked"`
+	// ServiceAccountRoles is a slice of Roles (both system-level and
+	// project-level) assigned to this ServiceAccount.
+	ServiceAccountRoles []Role `json:"roles,omitempty" bson:"roles,omitempty"`
+}
+
+// Roles returns a slice of Roles (both system-level and project-level) assigned
+// to this ServiceAccount.
+func (s *ServiceAccount) Roles() []Role {
+	return s.ServiceAccountRoles
 }
 
 // MarshalJSON amends ServiceAccount instances with type metadata.

--- a/v2/apiserver/internal/authx/users.go
+++ b/v2/apiserver/internal/authx/users.go
@@ -18,6 +18,15 @@ type User struct {
 	// Locked indicates when the User has been locked out of the system by an
 	// administrator. If this field's value is nil, the User is not locked.
 	Locked *time.Time `json:"locked" bson:"locked"`
+	// UserRoles is a slice of Roles (both system-level and project-level)
+	// assigned to this User.
+	UserRoles []Role `json:"roles,omitempty" bson:"roles,omitempty"`
+}
+
+// Roles returns a slice of Roles (both system-level and project-level) assigned
+// to this User.
+func (u *User) Roles() []Role {
+	return u.UserRoles
 }
 
 // MarshalJSON amends User instances with type metadata.


### PR DESCRIPTION
This PR is the first of several aimed at defining, managing, and enforcing permissions.

Emphasis in this one is on _defining_, as it introduces several well-defined system-level, project-level (and in one case, event-level) roles-- each with documented domain-specific meaning.

For context, in a subsequent PR, you can expect _use_ of these roles to look something like this:

```
// Principal is retrieved from the context and an error is returned if the principal lacks the specified role.
if err := p.authorize(ctx, authx.RoleProjectCreator()); err != nil {
  return project, err
}
```