### PR TITLE
always preserve order of sort criteria

### DIFF
--- a/v2/apiserver/internal/authx/mongodb/service_accounts_store.go
+++ b/v2/apiserver/internal/authx/mongodb/service_accounts_store.go
@@ -97,7 +97,14 @@ func (s *serviceAccountsStore) List(
 	}
 
 	findOptions := options.Find()
-	findOptions.SetSort(bson.M{"id": 1})
+	findOptions.SetSort(
+		// bson.D preserves order so we use this wherever we sort so that if
+		// additional sort criteria are added in the future, they will be applied
+		// in the specified order.
+		bson.D{
+			{Key: "id", Value: 1},
+		},
+	)
 	findOptions.SetLimit(opts.Limit)
 	cur, err := s.collection.Find(ctx, criteria, findOptions)
 	if err != nil {

--- a/v2/apiserver/internal/authx/mongodb/users_store.go
+++ b/v2/apiserver/internal/authx/mongodb/users_store.go
@@ -78,7 +78,14 @@ func (u *usersStore) List(
 	}
 
 	findOptions := options.Find()
-	findOptions.SetSort(bson.M{"id": 1})
+	findOptions.SetSort(
+		// bson.D preserves order so we use this wherever we sort so that if
+		// additional sort criteria are added in the future, they will be applied
+		// in the specified order.
+		bson.D{
+			{Key: "id", Value: 1},
+		},
+	)
 	findOptions.SetLimit(opts.Limit)
 	cur, err := u.collection.Find(ctx, criteria, findOptions)
 	if err != nil {

--- a/v2/apiserver/internal/core/mongodb/events_store.go
+++ b/v2/apiserver/internal/core/mongodb/events_store.go
@@ -93,7 +93,14 @@ func (e *eventsStore) List(
 	}
 
 	findOptions := options.Find()
-	findOptions.SetSort(bson.M{"created": -1, "id": 1})
+	findOptions.SetSort(
+		// bson.D preserves order, and we want to sort by created date/time FIRST
+		// and id SECOND
+		bson.D{
+			{Key: "created", Value: -1},
+			{Key: "id", Value: 1},
+		},
+	)
 	findOptions.SetLimit(opts.Limit)
 	cur, err := e.collection.Find(ctx, criteria, findOptions)
 	if err != nil {
@@ -320,7 +327,14 @@ func (e *eventsStore) CancelMany(
 	delete(criteria, "worker.status.phase")
 	criteria["canceled"] = cancellationTime
 	findOptions := options.Find()
-	findOptions.SetSort(bson.M{"created": -1})
+	findOptions.SetSort(
+		// bson.D preserves order so we use this wherever we sort so that if
+		// additional sort criteria are added in the future, they will be applied
+		// in the specified order.
+		bson.D{
+			{Key: "created", Value: -1},
+		},
+	)
 	cur, err := e.collection.Find(ctx, criteria, findOptions)
 	if err != nil {
 		return events, errors.Wrapf(err, "error finding canceled events")
@@ -389,7 +403,14 @@ func (e *eventsStore) DeleteMany(
 	// Select the logically deleted documents...
 	criteria["deleted"] = deletedTime
 	findOptions := options.Find()
-	findOptions.SetSort(bson.M{"created": -1})
+	findOptions.SetSort(
+		// bson.D preserves order so we use this wherever we sort so that if
+		// additional sort criteria are added in the future, they will be applied
+		// in the specified order.
+		bson.D{
+			{Key: "created", Value: -1},
+		},
+	)
 	cur, err := e.collection.Find(ctx, criteria, findOptions)
 	if err != nil {
 		return events, errors.Wrapf(

--- a/v2/apiserver/internal/core/mongodb/projects_store.go
+++ b/v2/apiserver/internal/core/mongodb/projects_store.go
@@ -82,7 +82,14 @@ func (p *projectsStore) List(
 	}
 
 	findOptions := options.Find()
-	findOptions.SetSort(bson.M{"id": 1})
+	findOptions.SetSort(
+		// bson.D preserves order so we use this wherever we sort so that if
+		// additional sort criteria are added in the future, they will be applied
+		// in the specified order.
+		bson.D{
+			{Key: "id", Value: 1},
+		},
+	)
 	findOptions.SetLimit(opts.Limit)
 	cur, err := p.collection.Find(ctx, criteria, findOptions)
 	if err != nil {
@@ -125,7 +132,14 @@ func (p *projectsStore) ListSubscribers(
 		}
 	}
 	findOptions := options.Find()
-	findOptions.SetSort(bson.M{"id": 1})
+	findOptions.SetSort(
+		// bson.D preserves order so we use this wherever we sort so that if
+		// additional sort criteria are added in the future, they will be applied
+		// in the specified order.
+		bson.D{
+			{Key: "id", Value: 1},
+		},
+	)
 	cur, err := p.collection.Find(
 		ctx,
 		bson.M{


### PR DESCRIPTION
Fixes #1171 

When listing events, they are ordered newest first. There's a possibility of multiple events being created at the exact same time, so to ensure consistent sort order, event id is used as secondary sort criteria.

#1171 occurs because we incorrectly used `bson.M` to specify sort criteria when querying MongoDB. This type does _not_ preserve the order of the criteria themselves. So, we were sometimes, by luck of the draw, sorting by creation time and _then_ id, and other times, sorting by id and _then_ creation time. This could lead to confusing, inconsistent results.... and broken pagination.

This PR redefines event sort criteria using `bson.D`, which preserves the order of our criteria, so that we always sort by creation time first, and id second.

This was the only case with multiple sort criteria, but for the sake of consistency, this PR also transitions to using `bson.D` even for queries with a single sort criterion. This way it's harder to make the mistake of using `bson.M` if the sort criteria for any given query expand in the future.

