### PR TITLE
Add experimental support for brigade.ts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .git
 .gocache
+v2/brigadier/node_modules
+v2/worker/node_modules

--- a/examples/git/github-demo.yaml
+++ b/examples/git/github-demo.yaml
@@ -1,0 +1,19 @@
+apiVersion: brigade.sh/v2
+kind: Project
+metadata:
+  id: github-demo
+description: A project that demonstrates integration with GitHub
+spec:
+  eventSubscriptions:
+  - source: github.com/brigadecore/brigade-github-gateway/v2
+    types:
+    - pull_request:opened
+    - pull_request:synchronize
+    - pull_request:reopened
+    - push
+    labels:
+      repo: krancour/brigade2-pipeline-demo
+  workerTemplate:
+    logLevel: DEBUG
+    git:
+      cloneURL: https://github.com/krancour/brigade2-pipeline-demo.git

--- a/examples/javascript/dependencies-demo.yaml
+++ b/examples/javascript/dependencies-demo.yaml
@@ -1,0 +1,23 @@
+apiVersion: brigade.sh/v2
+kind: Project
+metadata:
+  id: dependencies-demo
+description: A project that defines dependencies in package.json
+spec:
+  workerTemplate:
+    logLevel: DEBUG
+    defaultConfigFiles:
+      package.json: |-
+        {
+          "private": true,
+          "dependencies": {
+            "colors": "1.4.0"
+          }
+        }
+      brigade.js: |-
+        const { events } = require("@brigadecore/brigadier");
+        const colors = require("colors/safe");
+
+        events.on("github.com/brigadecore/brigade/cli", "exec", () => {
+          console.log(colors.green("It's not easy being green."));
+        });

--- a/examples/javascript/hello-world.yaml
+++ b/examples/javascript/hello-world.yaml
@@ -1,0 +1,15 @@
+apiVersion: brigade.sh/v2
+kind: Project
+metadata:
+  id: hello-world
+description: The simplest possible demonstration
+spec:
+  workerTemplate:
+    logLevel: DEBUG
+    defaultConfigFiles:
+      brigade.js: |-
+        const { events } = require("@brigadecore/brigadier");
+
+        events.on("github.com/brigadecore/brigade/cli", "exec", () => {
+          console.log("Hello, World!");
+        });

--- a/examples/javascript/pipeline-demo.yaml
+++ b/examples/javascript/pipeline-demo.yaml
@@ -5,9 +5,10 @@ metadata:
 description: A project that demonstrates a simple pipeline
 spec:
   workerTemplate:
+    logLevel: DEBUG
     defaultConfigFiles:
       brigade.js: |-
-        const { events, Job } = require("brigadier");
+        const { events, Job } = require("@brigadecore/brigadier");
 
         events.on("github.com/brigadecore/brigade/cli", "exec", async event => {
           let fooJob = new Job("foo", "debian:latest", event);

--- a/examples/typescript/dependencies-demo.yaml
+++ b/examples/typescript/dependencies-demo.yaml
@@ -1,0 +1,23 @@
+apiVersion: brigade.sh/v2
+kind: Project
+metadata:
+  id: dependencies-demo
+description: A project that defines dependencies in package.json
+spec:
+  workerTemplate:
+    logLevel: DEBUG
+    defaultConfigFiles:
+      package.json: |-
+        {
+          "private": true,
+          "dependencies": {
+            "colors": "1.4.0"
+          }
+        }
+      brigade.ts: |-
+        import { events } from "@brigadecore/brigadier"
+        import * as colors from "colors/safe"
+
+        events.on("github.com/brigadecore/brigade/cli", "exec", () => {
+          console.log(colors.green("It's not easy being green."))
+        })

--- a/examples/typescript/hello-world.yaml
+++ b/examples/typescript/hello-world.yaml
@@ -5,10 +5,11 @@ metadata:
 description: The simplest possible demonstration
 spec:
   workerTemplate:
+    logLevel: DEBUG
     defaultConfigFiles:
-      brigade.js: |-
-        const { events } = require("brigadier");
+      brigade.ts: |-
+        import { events } from "@brigadecore/brigadier"
 
         events.on("github.com/brigadecore/brigade/cli", "exec", () => {
-          console.log("Hello, World!");
-        });
+          console.log("Hello, World!")
+        })

--- a/examples/typescript/pipeline-demo.yaml
+++ b/examples/typescript/pipeline-demo.yaml
@@ -1,0 +1,23 @@
+apiVersion: brigade.sh/v2
+kind: Project
+metadata:
+  id: pipeline-demo
+description: A project that demonstrates a simple pipeline
+spec:
+  workerTemplate:
+    logLevel: DEBUG
+    defaultConfigFiles:
+      brigade.ts: |-
+        import { events, Job } from "@brigadecore/brigadier"
+
+        events.on("github.com/brigadecore/brigade/cli", "exec", async event => {
+          let fooJob = new Job("foo", "debian:latest", event)
+          fooJob.primaryContainer.command = ["echo"]
+          fooJob.primaryContainer.arguments = ["foo"]
+          await fooJob.run()
+
+          let barJob = new Job("bar", "debian:latest", event)
+          barJob.primaryContainer.command = ["echo"]
+          barJob.primaryContainer.arguments = ["bar"]
+          await barJob.run()
+        })

--- a/v2/apiserver/internal/core/events.go
+++ b/v2/apiserver/internal/core/events.go
@@ -342,7 +342,7 @@ func (e *eventsService) createSingleEvent(
 	}
 
 	if workerSpec.ConfigFilesDirectory == "" {
-		workerSpec.ConfigFilesDirectory = "."
+		workerSpec.ConfigFilesDirectory = ".brigade"
 	}
 
 	// This is a token unique to the Event so that the Event's Worker can use when

--- a/v2/apiserver/schemas/project.json
+++ b/v2/apiserver/schemas/project.json
@@ -57,12 +57,11 @@
 			"additionalProperties": false,
 			"properties": {
 				"id": {
-					"allOf": [
-						{
-							"$ref": "#/definitions/identifier"
-						}
-					],
-					"description": "A meaningful identifier for the project"
+					"type": "string",
+					"description": "A meaningful identifier for the project",
+					"pattern": "^[a-z][a-z\\d-]*[a-z\\d]$",
+					"minLength": 3,
+					"maxLength": 18
 				}
 			}
 		},

--- a/v2/worker/Dockerfile
+++ b/v2/worker/Dockerfile
@@ -1,12 +1,23 @@
 FROM node:12.16.2-alpine3.11
 ARG VERSION
 ENV WORKER_VERSION=${VERSION}
-WORKDIR /src
-COPY v2/brigadier/ brigadier/
-COPY v2/worker/ worker/
-WORKDIR /src/brigadier
-RUN yarn install
-WORKDIR /src/worker
+
+RUN apk add bash && npm install -g typescript
+
+WORKDIR /var/brigade-worker/src/brigadier
+COPY v2/brigadier/ .
+
+# Can't figure out how to do this in POSIX, so bash it is...
+RUN bash -c 'if [[ $WORKER_VERSION =~ ^v[0-9]+(\.[0-9]+)*(\-.+)?$ ]]; then \
+    V=$(echo $WORKER_VERSION | cut -c 2-); \
+  else \
+    V=0.0.1 ; \
+  fi ; \
+  sed -i s/placeholder/$V/ package.json && yarn install && yarn build \
+  '
+
+WORKDIR /var/brigade-worker/src/worker
+COPY v2/worker/ .
 RUN yarn install && yarn build
 
 CMD yarn -s start

--- a/v2/worker/src/prestart.ts
+++ b/v2/worker/src/prestart.ts
@@ -8,28 +8,74 @@ const event = require("/var/event/event.json") // eslint-disable-line @typescrip
 
 logger.level = (event.worker.logLevel || "info").toLowerCase()
 
-const configFilePath = path.join("/var/vcs", event.worker.configFilesDirectory, "brigade.json")
+const configFilesPath = path.join("/var/vcs", event.worker.configFilesDirectory)
 
-let dependencies
-if (fs.existsSync(configFilePath)) {
-  dependencies = require(configFilePath).dependencies // eslint-disable-line @typescript-eslint/no-var-requires
-} else if (event.worker.defaultConfigFiles) {
-  const configFileContents = event.worker.defaultConfigFiles["brigade.json"]
-  if (configFileContents) {
-    dependencies = JSON.parse(configFileContents).dependencies
-  } else {
-    logger.debug("prestart: no dependencies file found")
-    process.exit(0)
+// Create the configFilesPath if it doesn't already exist
+if (!fs.existsSync(configFilesPath)) {
+  fs.mkdirSync(configFilesPath, { recursive: true })
+}
+
+// If applicable, write defaultConfigFiles into configFilesPath
+if (event.worker.defaultConfigFiles) {
+  for (const filename in event.worker.defaultConfigFiles) {
+    const fullFilePath = path.join(configFilesPath, filename)
+    if (fs.existsSync(fullFilePath)) {
+      logger.warn(`${fullFilePath} already exists; refusing to overwrite it with default ${filename}`)
+    } else {
+      logger.debug(`writing default ${filename} to ${fullFilePath}`)
+      fs.writeFileSync(fullFilePath, event.worker.defaultConfigFiles[filename])
+    }
   }
 }
 
-if (!dependencies || Object.keys(dependencies).length == 0) {
-  console.debug("prestart: no dependencies to install")
-  process.exit(0)
+const brigadierPackageName = "@brigadecore/brigadier"
+const brigadierSrcPath = "/var/brigade-worker/src/brigadier"
+const packageJSONPath = path.join(configFilesPath, "package.json")
+let pkg
+if (fs.existsSync(packageJSONPath)) {
+  logger.debug(`found an existing package.json at ${packageJSONPath}`)
+  pkg = require(packageJSONPath)
+  logger.debug(`patching package.json to use ${brigadierPackageName} included in worker image`)
+  if (pkg.devDependencies) {
+    delete pkg.devDependencies[brigadierPackageName]
+  }
+  if (pkg.peerDependencies) {
+    delete pkg.peerDependencies[brigadierPackageName]
+  }
+  if (pkg.optionalDependencies) {
+    delete pkg.optionalDependencies[brigadierPackageName]
+  }
+  if (pkg.dependencies) {
+    delete pkg.dependencies[brigadierPackageName]
+  } else {
+    pkg.dependencies = {}
+  }
+} else {
+  logger.debug(`no existing package.json found at ${packageJSONPath}`)
+  logger.debug("creating a minimal package.json")
+  pkg = {
+    private: true,
+    dependencies: {}
+  }
+}
+pkg.dependencies[brigadierPackageName] = brigadierSrcPath
+logger.debug(`writing package.json to ${packageJSONPath}`)
+fs.writeFileSync(packageJSONPath, JSON.stringify(pkg))
+
+// Install dependencies
+logger.debug("installing dependencies")
+try {
+  execFileSync("yarn", ["install"], { cwd: configFilesPath })
+} catch(e) {
+  throw new Error(`error executing yarn install:\n\n${e.output}`)
 }
 
-if (require.main === module) { // This helps us NOT actually install packages while testing
-  const packages = Object.entries(dependencies).map(([dep, version]) => dep + "@" + version)
-  console.info(`installing ${packages.join(", ")}`)
-  execFileSync("yarn", ["add", ...packages])
+// Experimental TypeScript support...
+if (fs.existsSync(path.join(configFilesPath, "brigade.ts"))) {
+  logger.debug("compiling brigade.ts")
+  try {
+    execFileSync("tsc", ["--target", "ES6", "--module", "commonjs", "brigade.ts"], { cwd: configFilesPath })
+  } catch(e) {
+    throw new Error(`error compiling brigade.ts:\n\n${e.output}`)
+  }
 }


### PR DESCRIPTION
Fixes #527

Details on each commit:

### limit project names to 18 characters

In the course of tinkering with the rest of this PR, I created a project with a name longer than 18 characters. The length of the "brigade-" prefix combined with the project name and a UUID (v4) suffix created a namespace name that exceeded the maximum length of 63 characters.

See #1195. I do not believe such stingy limits are broadly applicable.

This could have been its own PR, but it's a small change.

### add node_modules to .dockerignore

It never hurts to slim down the Docker build context.

### add experimental typescript support

This works by enhancing the pre-processing done in the prestart script. The goal is to take a `brigade.ts` and compile it down to a `brigade.js` that the rest of the Worker can then deal with as per usual. Resolving dependencies is, of course, a prerequisite for compiling a TS script. At a minimum, a `brigade.ts` script is going to have a dependency on the `@brigadecore/brigadier` package. Getting dependency resolution to work more smoothly is actually the bulk of the code in this commit.

Previously, dependencies (if any) were enumerated in `brigade.json`. The prestart script would spawn a `yarn add` child process to install those packages by name.  This can be done more idiomatically by providing a `package.json` as input to a `yarn install` child process instead. So, out with the optional `brigade.json` and in with an optional `package.json`. This hopefully feels more familiar to developers.

The first thing the prestart script actually does is take any and all files that have been embedded in the project definition (which is common for a project with no VCS) and write them out to the file system as actual files. This is primarily because our `yarn install` child process requires an actual `package.json` file on the file system-- a "package.json" that's only a string in memory isn't of any use. A desirable side effect of writing all of the files embedded in the project out to the file system is that embedded scripts can seamlessly reference other embedded scripts and resources, just as if they were actual files (because they eventually will be). This makes it possible, for the first time, for developers of _non-VCS_ projects to break up an unwieldy `brigade.js` (or `brigade.ts`) into smaller, more organized scripts. Previously, this could only have been done in a VCS project.

Next, if no `package.json` exists on disk at this point, the prestart script creates a minimal one, so in the basic case of a project whose `brigade.js` (or `brigade.ts`) doesn't have any dependencies apart from `@brigadecore/brigadier`, providing a `package.json` is completely optional.

Next, the script _patches_ the `package.json` to amend it with (or override) _local_ (i.e. baked into the Worker image) coordinates for the `@brigadecore/brigadier` package. This ensures any `brigade.ts` is compiled against the _same_ version of `@brigadecore/brigadier` on which the Worker itself is based. This seems more sensible than to potentially compile against any random, possibly very old version of `@brigadecore/brigadier` that the project's _original_ `project.json` (if it had one) might have referenced. Note that any other dependencies enumerated in `package.json` remain unaltered.

Next, the script creates the `yarn install` child process and lets it do all of the real work.

Last, but only if applicable, the script spawns a `tsc` process to compile `brigade.ts` to `brigade.js`.

### change default config directory to .brigade instead of project root

This is partly inspired by innumerable other tools that keep their configuration in a dot-folder, but much more importantly, not expecting `package.json` to live in the project root means:

1. Your brigade script can have a _different_ `package.json`, and therefore different set of dependencies, from the rest of the project. This is of particular importance to JavaScript or TypeScript projects that are likely to have a `project.json` already.

1. When the prestart script runs `yarn install` inside the `.brigade` directory, it will not pollute the rest of the project. Again, this is of particular importance to JavaScript or TypeScript projects.

### major reworking of examples

The examples are updated to exercise various scenarios using  both JavaScript and TypeScript.