### PR TITLE
fix fluentd connection to mongodb

### DIFF
--- a/charts/brigade/templates/logger/secret.yaml
+++ b/charts/brigade/templates/logger/secret.yaml
@@ -76,11 +76,16 @@ stringData:
       @type mongo
 
       {{- if .Values.mongodb.enabled }}
-      host {{ include "call-nested" (list . "mongodb" "mongodb.fullname") }}.{{ .Release.Namespace }}.svc.cluster.local
+      {{- $replicaCount := int .Values.mongodb.replicaCount }}
+      {{- $fullname := include "call-nested" (list . "mongodb" "mongodb.fullname") }}
+      {{- $releaseNamespace := .Release.Namespace }}
+      {{- range $e, $i := until $replicaCount }}
+      host {{ $fullname }}-{{ $i }}.{{ $fullname }}-headless.{{ $releaseNamespace }}.svc.cluster.local
+      {{- end }}
       port 27017
-      database {{ .Values.mongodb.mongodbDatabase }}
-      user {{ .Values.mongodb.mongodbUsername }}
-      password {{ .Values.mongodb.mongodbPassword }}
+      database {{ .Values.mongodb.auth.database }}
+      user {{ .Values.mongodb.auth.username }}
+      password {{ .Values.mongodb.auth.password }}
       {{- else }}
       connection_string {{ .Values.externalMongodb.connectionString }}
       {{- end }}


### PR DESCRIPTION
#1223 overlooked the fact that fluentd configuration had to be updated to account for the new mongodb chart.

This PR fixes that.