### PR TITLE
work with different mongodb deployment topologies

### DIFF
--- a/charts/brigade/templates/apiserver/deployment.yaml
+++ b/charts/brigade/templates/apiserver/deployment.yaml
@@ -84,21 +84,25 @@ spec:
         {{- end }}
         
         {{- if .Values.mongodb.enabled }}
+        {{- if eq .Values.mongodb.architecture "replicaset" }}
         {{- $replicaCount := int .Values.mongodb.replicaCount }}
         {{- $fullname := include "call-nested" (list . "mongodb" "mongodb.fullname") }}
         {{- $releaseNamespace := .Release.Namespace }}
-        {{- $mongoList := list }}
+        {{- $port := .Values.mongodb.service.port }}
+        {{- $hostList := list }}
         {{- range $e, $i := until $replicaCount }}
-        {{- $mongoList = append $mongoList (printf "%s-%d.%s-headless.%s.svc.cluster.local" $fullname $i $fullname $releaseNamespace) }}
+        {{- $hostList = append $hostList (printf "%s-%d.%s-headless.%s.svc.cluster.local:%g" $fullname $i $fullname $releaseNamespace $port) }}
         {{- end }}
-        - name: DATABASE_HOST
-          value: {{ join "," $mongoList }}
-        - name: DATABASE_PORT
-          value: {{ quote .Values.mongodb.service.port }}
-        - name: DATABASE_NAME
-          value: {{ .Values.mongodb.auth.database }}
+        - name: DATABASE_HOSTS
+          value: {{ join "," $hostList }}
         - name: DATABASE_REPLICA_SET
           value: {{ .Values.mongodb.replicaSetName }}
+        {{- else }}
+        - name: DATABASE_HOSTS
+          value: {{ include "call-nested" (list . "mongodb" "mongodb.fullname") }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.mongodb.service.port }}
+        {{- end }}
+        - name: DATABASE_NAME
+          value: {{ .Values.mongodb.auth.database }}
         - name: DATABASE_USERNAME
           value: {{ .Values.mongodb.auth.username }}
         - name: DATABASE_PASSWORD

--- a/charts/brigade/templates/logger/secret.yaml
+++ b/charts/brigade/templates/logger/secret.yaml
@@ -76,11 +76,15 @@ stringData:
       @type mongo
 
       {{- if .Values.mongodb.enabled }}
+      {{- if eq .Values.mongodb.architecture "replicaset" }}
       {{- $replicaCount := int .Values.mongodb.replicaCount }}
       {{- $fullname := include "call-nested" (list . "mongodb" "mongodb.fullname") }}
       {{- $releaseNamespace := .Release.Namespace }}
       {{- range $e, $i := until $replicaCount }}
       host {{ $fullname }}-{{ $i }}.{{ $fullname }}-headless.{{ $releaseNamespace }}.svc.cluster.local
+      {{- end }}
+      {{- else }}
+      host {{ include "call-nested" (list . "mongodb" "mongodb.fullname") }}.{{ .Release.Namespace }}.svc.cluster.local
       {{- end }}
       port 27017
       database {{ .Values.mongodb.auth.database }}

--- a/v2/apiserver/config_test.go
+++ b/v2/apiserver/config_test.go
@@ -27,8 +27,19 @@ func TestDatabase(t *testing.T) {
 		assertions func(*mongo.Database, error)
 	}{
 		{
-			name:  "DATABASE_USERNAME not set",
+			name:  "DATABASE_HOSTS not set",
 			setup: func() {},
+			assertions: func(_ *mongo.Database, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "DATABASE_HOSTS")
+			},
+		},
+		{
+			name: "DATABASE_USERNAME not set",
+			setup: func() {
+				os.Setenv("DATABASE_HOSTS", "localhost")
+			},
 			assertions: func(_ *mongo.Database, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "value not found for")
@@ -47,32 +58,9 @@ func TestDatabase(t *testing.T) {
 			},
 		},
 		{
-			name: "DATABASE_HOST not set",
-			setup: func() {
-				os.Setenv("DATABASE_PASSWORD", "yourenotironmaniam")
-			},
-			assertions: func(_ *mongo.Database, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "value not found for")
-				require.Contains(t, err.Error(), "DATABASE_HOST")
-			},
-		},
-		{
-			name: "DATABASE_PORT not an int",
-			setup: func() {
-				os.Setenv("DATABASE_HOST", "http://localhost")
-				os.Setenv("DATABASE_PORT", "foo")
-			},
-			assertions: func(_ *mongo.Database, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "was not parsable as an int")
-				require.Contains(t, err.Error(), "DATABASE_PORT")
-			},
-		},
-		{
 			name: "DATABASE_NAME not set",
 			setup: func() {
-				os.Setenv("DATABASE_PORT", "27017")
+				os.Setenv("DATABASE_PASSWORD", "yourenotironmaniam")
 			},
 			assertions: func(_ *mongo.Database, err error) {
 				require.Error(t, err)
@@ -81,19 +69,9 @@ func TestDatabase(t *testing.T) {
 			},
 		},
 		{
-			name: "DATABASE_REPLICA_SET not set",
-			setup: func() {
-				os.Setenv("DATABASE_NAME", "brigade")
-			},
-			assertions: func(_ *mongo.Database, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "value not found for")
-				require.Contains(t, err.Error(), "DATABASE_REPLICA_SET")
-			},
-		},
-		{
 			name: "success",
 			setup: func() {
+				os.Setenv("DATABASE_NAME", "brigade")
 				os.Setenv("DATABASE_REPLICA_SET", "rs0")
 			},
 			assertions: func(database *mongo.Database, err error) {


### PR DESCRIPTION
We were previously making an assumption that mongo was deployed in a replicated topology (even if the number of replicas was one).

This change makes the API server and the log agent (the only two components that talk to mongodb) tolerant of _either_ a standalone or replicated topology.