### PR TITLE
Consolidate shared schema definitions

### DIFF
--- a/v2/apiserver/schemas/common.json
+++ b/v2/apiserver/schemas/common.json
@@ -44,10 +44,6 @@
 				"ref": {
 					"type": "string",
 					"description": "A reference to a git branch or tag"
-				},
-				"initSubmodules": {
-					"type": "boolean",
-					"description": "Whether to initialize git submodules"
 				}
 			}
 		},

--- a/v2/apiserver/schemas/common.json
+++ b/v2/apiserver/schemas/common.json
@@ -25,7 +25,6 @@
 		"gitConfig": {
 			"type": "object",
 			"description": "Worker configuration pertaining specifically to git",
-			"additionalProperties": false,
 			"properties": {
 				"cloneURL": {
 					"oneOf": [

--- a/v2/apiserver/schemas/common.json
+++ b/v2/apiserver/schemas/common.json
@@ -1,0 +1,76 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "github.com/brigadecore/brigade/common.schema.json",
+	"description": "A common set of schema definitions shared by other Brigade schemas",
+
+	"definitions": {
+
+		"apiVersion": {
+			"type": "string",
+			"description": "The major version of the Brigade API with which this object conforms",
+			"enum": ["brigade.sh/v2"]
+		},
+
+		"description": {
+			"type": "string",
+			"minLength": 3,
+			"maxLength": 80
+		},
+
+		"empty": {
+			"type": "string",
+			"enum": [ "" ]
+		},
+
+		"gitConfig": {
+			"type": "object",
+			"description": "Worker configuration pertaining specifically to git",
+			"additionalProperties": false,
+			"properties": {
+				"cloneURL": {
+					"oneOf": [
+						{ "$ref": "#/definitions/empty" },
+						{ "$ref": "#/definitions/url" }
+					],
+					"description": "The URL for cloning a git project"
+				},
+				"commit": {
+					"type": "string",
+					"pattern": "^[a-fA-F0-9]*$",
+					"minLength": 8,
+					"maxLength": 40,
+					"description": "A git commit sha"
+				},
+				"ref": {
+					"type": "string",
+					"description": "A reference to a git branch or tag"
+				},
+				"initSubmodules": {
+					"type": "boolean",
+					"description": "Whether to initialize git submodules"
+				}
+			}
+		},
+
+		"identifier": {
+			"type": "string",
+			"pattern": "^[a-z][a-z\\d-]*[a-z\\d]$",
+			"minLength": 3,
+			"maxLength": 50
+		},
+
+		"label": {
+			"type": "string",
+			"pattern": "^[\\w:/\\-\\.\\?=\\*]*$",
+			"minLength": 1,
+			"maxLength": 250
+		},
+
+		"url": {
+			"type": "string",
+			"pattern": "^[\\w:/\\-\\.\\?=@]*$",
+			"minLength": 5,
+			"maxLength": 250
+		}
+	}
+}

--- a/v2/apiserver/schemas/event.json
+++ b/v2/apiserver/schemas/event.json
@@ -4,38 +4,6 @@
 
 	"definitions": {
 
-		"empty": {
-			"type": "string",
-			"enum": [ "" ]
-		},
-
-		"identifier": {
-			"type": "string",
-			"pattern": "^[a-z][a-z\\d-]*[a-z\\d]$",
-			"minLength": 3,
-			"maxLength": 50
-		},
-
-		"url": {
-			"type": "string",
-			"pattern": "^[\\w:/\\-\\.\\?=]*$",
-			"minLength": 5,
-			"maxLength": 250
-		},
-
-		"label": {
-			"type": "string",
-			"pattern": "^[\\w:/\\-\\.\\?=\\*]*$",
-			"minLength": 1,
-			"maxLength": 250
-		},
-
-		"apiVersion": {
-			"type": "string",
-			"description": "The major version of the Brigade API with which this object conforms",
-			"enum": ["brigade.sh/v2"]
-		},
-
 		"kind": {
 			"type": "string",
 			"description": "The type of object represented by the document",
@@ -46,36 +14,6 @@
 			"type": "object",
 			"description": "Event metadata",
 			"additionalProperties": false
-		},
-
-		"gitConfig": {
-			"type": "object",
-			"description": "Worker configuration pertaining specifically to git",
-			"additionalProperties": false,
-			"properties": {
-				"cloneURL": {
-					"oneOf": [
-						{ "$ref": "#/definitions/empty" },
-						{ "$ref": "#/definitions/url" }
-					],
-					"description": "The URL for cloning a git project"
-				},
-				"commit": {
-					"type": "string",
-					"pattern": "^[a-fA-F0-9]*$",
-					"minLength": 8,
-					"maxLength": 40,
-					"description": "A git commit sha"
-				},
-				"ref": {
-					"type": "string",
-					"description": "A reference to a git branch or tag"
-				},
-				"initSubmodules": {
-					"type": "boolean",
-					"description": "Whether to initialize git submodules"
-				}
-			}
 		}
 
 	},
@@ -86,7 +24,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "#/definitions/apiVersion"
+			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"
@@ -96,17 +34,17 @@
 		},
 		"projectID": {
 			"oneOf": [
-				{ "$ref": "#/definitions/empty" },
-				{ "$ref": "#/definitions/identifier" }
+				{ "$ref": "file:///brigade/schemas/common.json#/definitions/empty" },
+				{ "$ref": "file:///brigade/schemas/common.json#/definitions/identifier" }
 			],
 			"description": "The ID of the project the event is for"
 		},
 		"source": {
-			"allOf": [{ "$ref": "#/definitions/url" }],
+			"allOf": [{ "$ref": "file:///brigade/schemas/common.json#/definitions/url" }],
 			"description": "The name of the source that is sending the event"
 		},
 		"type": {
-			"allOf": [{ "$ref": "#/definitions/label" }],
+			"allOf": [{ "$ref": "file:///brigade/schemas/common.json#/definitions/label" }],
 			"description": "The type of the event"
 		},
 		"labels": {
@@ -117,7 +55,7 @@
 			"additionalProperties": true,
 			"patternProperties": {
 				"^[\\w:/\\-\\.\\?=\\*]*$": {
-					"$ref": "#/definitions/label"
+					"$ref": "file:///brigade/schemas/common.json#/definitions/label"
 				}
 			},
 			"description": "Labels to help Brigade route the event to subscribed projects"
@@ -132,7 +70,9 @@
 			"description": "A detailed description of the event",
 			"maxLength": 100
 		},
-		"git": { "$ref": "#/definitions/gitConfig" },
+		"git": {
+			"$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig"
+		},
 		"payload": {
 			"type": "string",
 			"description": "Event payload"

--- a/v2/apiserver/schemas/event.json
+++ b/v2/apiserver/schemas/event.json
@@ -71,7 +71,8 @@
 			"maxLength": 100
 		},
 		"git": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig"
+			"$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig",
+			"additionalProperties": false
 		},
 		"payload": {
 			"type": "string",

--- a/v2/apiserver/schemas/job-status.json
+++ b/v2/apiserver/schemas/job-status.json
@@ -4,12 +4,6 @@
 
 	"definitions": {
 
-		"apiVersion": {
-			"type": "string",
-			"description": "The major version of the Brigade API with which this object conforms",
-			"enum": ["brigade.sh/v2"]
-		},
-
 		"kind": {
 			"type": "string",
 			"description": "The type of object represented by the document",
@@ -24,7 +18,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "#/definitions/apiVersion"
+			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"

--- a/v2/apiserver/schemas/job.json
+++ b/v2/apiserver/schemas/job.json
@@ -4,12 +4,6 @@
 
 	"definitions": {
 
-		"apiVersion": {
-			"type": "string",
-			"description": "The major version of the Brigade API with which this object conforms",
-			"enum": ["brigade.sh/v2"]
-		},
-
 		"kind": {
 			"type": "string",
 			"description": "The type of object represented by the document",
@@ -144,7 +138,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "#/definitions/apiVersion"
+			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"

--- a/v2/apiserver/schemas/project.json
+++ b/v2/apiserver/schemas/project.json
@@ -207,7 +207,19 @@
 					"description": "The amount of storage to be provisioned for a worker"
 				},
 				"git": {
-					"$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig"
+					"cloneURL": {
+						"$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig/cloneURL"
+					},
+					"commit": {
+						"$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig/commit"
+					},
+					"initSubmodules": {
+						"type": "boolean",
+						"description": "Whether to initialize git submodules"
+					},
+					"ref": {
+						"$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig/ref"
+					}
 				},
 				"kubernetes": {
 					"$ref": "#/definitions/kubernetesConfig"

--- a/v2/apiserver/schemas/project.json
+++ b/v2/apiserver/schemas/project.json
@@ -207,19 +207,17 @@
 					"description": "The amount of storage to be provisioned for a worker"
 				},
 				"git": {
-					"cloneURL": {
-						"$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig/cloneURL"
-					},
-					"commit": {
-						"$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig/commit"
-					},
-					"initSubmodules": {
-						"type": "boolean",
-						"description": "Whether to initialize git submodules"
-					},
-					"ref": {
-						"$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig/ref"
-					}
+					"allOf": [
+						{ "$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig" },
+						{
+							"additionalProperties": {
+								"initSubmodules": {
+									"type": "boolean",
+									"description": "Whether to initialize git submodules"
+								}
+							}
+						}
+					]
 				},
 				"kubernetes": {
 					"$ref": "#/definitions/kubernetesConfig"

--- a/v2/apiserver/schemas/project.json
+++ b/v2/apiserver/schemas/project.json
@@ -4,46 +4,6 @@
 
 	"definitions": {
 
-		"empty": {
-			"type": "string",
-			"enum": [
-				""
-			]
-		},
-
-		"identifier": {
-			"type": "string",
-			"pattern": "^[a-z][a-z\\d-]*[a-z\\d]$",
-			"minLength": 3,
-			"maxLength": 50
-		},
-
-		"description": {
-			"type": "string",
-			"minLength": 3,
-			"maxLength": 80
-		},
-
-		"url": {
-			"type": "string",
-			"pattern": "^[\\w:/\\-\\.\\?=@]*$",
-			"minLength": 5,
-			"maxLength": 250
-		},
-
-		"label": {
-			"type": "string",
-			"pattern": "^[\\w:/\\-\\.\\?=\\*]*$",
-			"minLength": 1,
-			"maxLength": 250
-		},
-
-		"apiVersion": {
-			"type": "string",
-			"description": "The major version of the Brigade API with which this object conforms",
-			"enum": ["brigade.sh/v2"]
-		},
-
 		"kind": {
 			"type": "string",
 			"description": "The type of object represented by the document",
@@ -97,7 +57,7 @@
 				"source": {
 					"allOf": [
 						{
-							"$ref": "#/definitions/url"
+							"$ref": "file:///brigade/schemas/common.json#/definitions/url"
 						}
 					],
 					"description": "The name of the event source"
@@ -107,7 +67,7 @@
 					"description": "Types of events from the source",
 					"minItems": 1,
 					"items": {
-						"$ref": "#/definitions/label"
+						"$ref": "file:///brigade/schemas/common.json#/definitions/label"
 					}
 				},
 				"labels": {
@@ -118,7 +78,7 @@
 					"additionalProperties": true,
 					"patternProperties": {
 						"^[\\w:/\\-\\.\\?=\\*]*$": {
-							"$ref": "#/definitions/label"
+							"$ref": "file:///brigade/schemas/common.json#/definitions/label"
 						}
 					}
 				}
@@ -201,42 +161,8 @@
 					],
 					"description": "Kubernetes secrets that can be used as image pull secrets for job images",
 					"items": {
-						"$ref": "#/definitions/identifier"
+						"$ref": "file:///brigade/schemas/common.json#/definitions/identifier"
 					}
-				}
-			}
-		},
-
-		"gitConfig": {
-			"type": "object",
-			"description": "Worker configuration pertaining specifically to git",
-			"additionalProperties": false,
-			"properties": {
-				"cloneURL": {
-					"oneOf": [
-						{
-							"$ref": "#/definitions/empty"
-						},
-						{
-							"$ref": "#/definitions/url"
-						}
-					],
-					"description": "The URL for cloning a git project"
-        },
-				"commit": {
-					"type": "string",
-					"pattern": "^[a-fA-F0-9]*$",
-					"minLength": 8,
-					"maxLength": 40,
-					"description": "A git commit sha"
-				},
-				"ref": {
-					"type": "string",
-					"description": "A reference to a git branch or tag"
-				},
-				"initSubmodules": {
-					"type": "boolean",
-					"description": "Whether to initialize git submodules"
 				}
 			}
 		},
@@ -253,7 +179,7 @@
 					],
 					"description": "Kubernetes secrets that can be used as image pull secrets for the worker's images",
 					"items": {
-						"$ref": "#/definitions/identifier"
+						"$ref": "file:///brigade/schemas/common.json#/definitions/identifier"
 					}
 				}
 			}
@@ -281,7 +207,7 @@
 					"description": "The amount of storage to be provisioned for a worker"
 				},
 				"git": {
-					"$ref": "#/definitions/gitConfig"
+					"$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig"
 				},
 				"kubernetes": {
 					"$ref": "#/definitions/kubernetesConfig"
@@ -325,7 +251,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "#/definitions/apiVersion"
+			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"
@@ -336,10 +262,10 @@
 		"description": {
 			"oneOf": [
 				{
-					"$ref": "#/definitions/empty"
+					"$ref": "file:///brigade/schemas/common.json#/definitions/empty"
 				},
 				{
-					"$ref": "#/definitions/description"
+					"$ref": "file:///brigade/schemas/common.json#/definitions/description"
 				}
 			],
 			"description": "A brief description of the project"

--- a/v2/apiserver/schemas/secret.json
+++ b/v2/apiserver/schemas/secret.json
@@ -4,12 +4,6 @@
 
 	"definitions": {
 
-		"apiVersion": {
-			"type": "string",
-			"description": "The major version of the Brigade API with which this object conforms",
-			"enum": ["brigade.sh/v2"]
-		},
-
 		"kind": {
 			"type": "string",
 			"description": "The type of object represented by the document",
@@ -24,7 +18,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "#/definitions/apiVersion"
+			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"

--- a/v2/apiserver/schemas/service-account.json
+++ b/v2/apiserver/schemas/service-account.json
@@ -4,25 +4,6 @@
 
 	"definitions": {
 
-		"identifier": {
-			"type": "string",
-			"pattern": "^[a-z][a-z\\d-]*[a-z\\d]$",
-			"minLength": 3,
-			"maxLength": 50
-		},
-
-		"description": {
-			"type": "string",
-			"minLength": 3,
-			"maxLength": 80
-		},
-
-		"apiVersion": {
-			"type": "string",
-			"description": "The major version of the Brigade API with which this object conforms",
-			"enum": ["brigade.sh/v2"]
-		},
-
 		"kind": {
 			"type": "string",
 			"description": "The type of object represented by the document",
@@ -38,7 +19,7 @@
 				"id": {
 					"allOf": [
 						{
-							"$ref": "#/definitions/identifier"
+							"$ref": "file:///brigade/schemas/common.json#/definitions/identifier"
 						}
 					],
 					"description": "A meaningful identifier for the service account"
@@ -53,7 +34,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "#/definitions/apiVersion"
+			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"
@@ -64,7 +45,7 @@
 		"description": {
 			"allOf": [
 				{
-					"$ref": "#/definitions/description"
+					"$ref": "file:///brigade/schemas/common.json#/definitions/description"
 				}
 			],
 			"description": "A brief description of the service account"

--- a/v2/apiserver/schemas/worker-status.json
+++ b/v2/apiserver/schemas/worker-status.json
@@ -4,12 +4,6 @@
 
 	"definitions": {
 
-		"apiVersion": {
-			"type": "string",
-			"description": "The major version of the Brigade API with which this object conforms",
-			"enum": ["brigade.sh/v2"]
-		},
-
 		"kind": {
 			"type": "string",
 			"description": "The type of object represented by the document",
@@ -24,7 +18,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "#/definitions/apiVersion"
+			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"


### PR DESCRIPTION
* Consolidates common/shared schema definitions in a separate schema file.

Note: here I've settled on using the full file reference when referencing this common file.  When I attempt to use a relative reference, e.g. `"common.json#/definitions/url"`, we get:

```
open /brigade/schemas/github.com/brigadecore/brigade/v2/common.json: no such file or directory
```

But I can't tell where/how the full reference is resolved as this.  I would expect it to be resolved as `/brigade/schemas/common.json`, since that's where we place all of them in the apiserver image.

For what it's worth, we _could_ use the relative reference as shown above if we added the following line to the apiserver Dockerfile:

`COPY v2/apiserver/schemas/common.json /brigade/schemas/github.com/brigadecore/brigade/v2/common.json`

(I've tried placing *all* schemas there, but then we hit the same error, just doubled, b/c the same `github.com/brigadecore/brigade/v2` is added in no matter what.)

Closes https://github.com/brigadecore/brigade/issues/1220
