### PR TITLE
make examples reference project schema

### DIFF
--- a/examples/javascript/dependencies-demo.yaml
+++ b/examples/javascript/dependencies-demo.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
 apiVersion: brigade.sh/v2
 kind: Project
 metadata:

--- a/examples/javascript/hello-world.yaml
+++ b/examples/javascript/hello-world.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
 apiVersion: brigade.sh/v2
 kind: Project
 metadata:

--- a/examples/javascript/pipeline-demo.yaml
+++ b/examples/javascript/pipeline-demo.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
 apiVersion: brigade.sh/v2
 kind: Project
 metadata:

--- a/examples/typescript/dependencies-demo.yaml
+++ b/examples/typescript/dependencies-demo.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
 apiVersion: brigade.sh/v2
 kind: Project
 metadata:

--- a/examples/typescript/hello-world.yaml
+++ b/examples/typescript/hello-world.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
 apiVersion: brigade.sh/v2
 kind: Project
 metadata:

--- a/examples/typescript/pipeline-demo.yaml
+++ b/examples/typescript/pipeline-demo.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
 apiVersion: brigade.sh/v2
 kind: Project
 metadata:


### PR DESCRIPTION
Provided you have the popular Red Hat YAML plugin for VS Code, this change provides context help when tinkering with examples.