### PR TITLE
tidy up client-side rest machinery

### DIFF
--- a/sdk/v2/authn/service_accounts.go
+++ b/sdk/v2/authn/service_accounts.go
@@ -124,7 +124,6 @@ func (s *serviceAccountsClient) Create(
 		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/service-accounts",
-			AuthHeaders: s.BearerTokenAuthHeaders(),
 			ReqBodyObj:  serviceAccount,
 			SuccessCode: http.StatusCreated,
 			RespObj:     &token,
@@ -143,7 +142,6 @@ func (s *serviceAccountsClient) List(
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        "v2/service-accounts",
-			AuthHeaders: s.BearerTokenAuthHeaders(),
 			QueryParams: s.AppendListQueryParams(nil, opts),
 			SuccessCode: http.StatusOK,
 			RespObj:     &serviceAccounts,
@@ -161,7 +159,6 @@ func (s *serviceAccountsClient) Get(
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/service-accounts/%s", id),
-			AuthHeaders: s.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 			RespObj:     &serviceAccount,
 		},
@@ -174,7 +171,6 @@ func (s *serviceAccountsClient) Lock(ctx context.Context, id string) error {
 		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/service-accounts/%s/lock", id),
-			AuthHeaders: s.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 		},
 	)
@@ -190,7 +186,6 @@ func (s *serviceAccountsClient) Unlock(
 		rm.OutboundRequest{
 			Method:      http.MethodDelete,
 			Path:        fmt.Sprintf("v2/service-accounts/%s/lock", id),
-			AuthHeaders: s.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 			RespObj:     &token,
 		},

--- a/sdk/v2/authn/users.go
+++ b/sdk/v2/authn/users.go
@@ -116,7 +116,6 @@ func (u *usersClient) List(
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        "v2/users",
-			AuthHeaders: u.BearerTokenAuthHeaders(),
 			QueryParams: u.AppendListQueryParams(nil, opts),
 			SuccessCode: http.StatusOK,
 			RespObj:     &users,
@@ -131,7 +130,6 @@ func (u *usersClient) Get(ctx context.Context, id string) (User, error) {
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/users/%s", id),
-			AuthHeaders: u.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 			RespObj:     &user,
 		},
@@ -144,7 +142,6 @@ func (u *usersClient) Lock(ctx context.Context, id string) error {
 		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/users/%s/lock", id),
-			AuthHeaders: u.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 		},
 	)
@@ -156,7 +153,6 @@ func (u *usersClient) Unlock(ctx context.Context, id string) error {
 		rm.OutboundRequest{
 			Method:      http.MethodDelete,
 			Path:        fmt.Sprintf("v2/users/%s/lock", id),
-			AuthHeaders: u.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 		},
 	)

--- a/sdk/v2/core/events.go
+++ b/sdk/v2/core/events.go
@@ -208,7 +208,6 @@ func (e *eventsClient) Create(
 		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/events",
-			AuthHeaders: e.BearerTokenAuthHeaders(),
 			ReqBodyObj:  event,
 			SuccessCode: http.StatusCreated,
 			RespObj:     &events,
@@ -238,7 +237,6 @@ func (e *eventsClient) List(
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        "v2/events",
-			AuthHeaders: e.BearerTokenAuthHeaders(),
 			QueryParams: e.AppendListQueryParams(queryParams, opts),
 			SuccessCode: http.StatusOK,
 			RespObj:     &events,
@@ -256,7 +254,6 @@ func (e *eventsClient) Get(
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/events/%s", id),
-			AuthHeaders: e.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 			RespObj:     &event,
 		},
@@ -269,7 +266,6 @@ func (e *eventsClient) Cancel(ctx context.Context, id string) error {
 		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/events/%s/cancellation", id),
-			AuthHeaders: e.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 		},
 	)
@@ -296,7 +292,6 @@ func (e *eventsClient) CancelMany(
 		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/events/cancellations",
-			AuthHeaders: e.BearerTokenAuthHeaders(),
 			QueryParams: queryParams,
 			SuccessCode: http.StatusOK,
 			RespObj:     &result,
@@ -310,7 +305,6 @@ func (e *eventsClient) Delete(ctx context.Context, id string) error {
 		rm.OutboundRequest{
 			Method:      http.MethodDelete,
 			Path:        fmt.Sprintf("v2/events/%s", id),
-			AuthHeaders: e.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 		},
 	)
@@ -337,7 +331,6 @@ func (e *eventsClient) DeleteMany(
 		rm.OutboundRequest{
 			Method:      http.MethodDelete,
 			Path:        "v2/events",
-			AuthHeaders: e.BearerTokenAuthHeaders(),
 			QueryParams: queryParams,
 			SuccessCode: http.StatusOK,
 			RespObj:     &result,

--- a/sdk/v2/core/jobs.go
+++ b/sdk/v2/core/jobs.go
@@ -245,7 +245,6 @@ func (j *jobsClient) Create(
 		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/events/%s/worker/jobs/%s", eventID, jobName),
-			AuthHeaders: j.BearerTokenAuthHeaders(),
 			ReqBodyObj:  job,
 			SuccessCode: http.StatusCreated,
 		},
@@ -266,7 +265,6 @@ func (j *jobsClient) Start(
 				eventID,
 				jobName,
 			),
-			AuthHeaders: j.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 		},
 	)
@@ -287,7 +285,6 @@ func (j *jobsClient) GetStatus(
 				eventID,
 				jobName,
 			),
-			AuthHeaders: j.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 			RespObj:     &status,
 		},
@@ -308,7 +305,6 @@ func (j *jobsClient) WatchStatus(
 				eventID,
 				jobName,
 			),
-			AuthHeaders: j.BearerTokenAuthHeaders(),
 			QueryParams: map[string]string{
 				"watch": "true",
 			},
@@ -342,7 +338,6 @@ func (j *jobsClient) UpdateStatus(
 				eventID,
 				jobName,
 			),
-			AuthHeaders: j.BearerTokenAuthHeaders(),
 			ReqBodyObj:  status,
 			SuccessCode: http.StatusOK,
 		},
@@ -363,7 +358,6 @@ func (j *jobsClient) Cleanup(
 				eventID,
 				jobName,
 			),
-			AuthHeaders: j.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 		},
 	)

--- a/sdk/v2/core/logs.go
+++ b/sdk/v2/core/logs.go
@@ -96,7 +96,6 @@ func (l *logsClient) Stream(
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/events/%s/logs", eventID),
-			AuthHeaders: l.BearerTokenAuthHeaders(),
 			QueryParams: queryParams,
 			SuccessCode: http.StatusOK,
 		},

--- a/sdk/v2/core/projects.go
+++ b/sdk/v2/core/projects.go
@@ -204,7 +204,6 @@ func (p *projectsClient) Create(
 		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/projects",
-			AuthHeaders: p.BearerTokenAuthHeaders(),
 			ReqBodyObj:  project,
 			SuccessCode: http.StatusCreated,
 			RespObj:     &createdProject,
@@ -222,7 +221,6 @@ func (p *projectsClient) CreateFromBytes(
 		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/projects",
-			AuthHeaders: p.BearerTokenAuthHeaders(),
 			ReqBodyObj:  projectBytes,
 			SuccessCode: http.StatusCreated,
 			RespObj:     &createdProject,
@@ -241,7 +239,6 @@ func (p *projectsClient) List(
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        "v2/projects",
-			AuthHeaders: p.BearerTokenAuthHeaders(),
 			QueryParams: p.AppendListQueryParams(nil, opts),
 			SuccessCode: http.StatusOK,
 			RespObj:     &projects,
@@ -259,7 +256,6 @@ func (p *projectsClient) Get(
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/projects/%s", id),
-			AuthHeaders: p.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 			RespObj:     &project,
 		},
@@ -276,7 +272,6 @@ func (p *projectsClient) Update(
 		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/projects/%s", project.ID),
-			AuthHeaders: p.BearerTokenAuthHeaders(),
 			ReqBodyObj:  project,
 			SuccessCode: http.StatusOK,
 			RespObj:     &updatedProject,
@@ -295,7 +290,6 @@ func (p *projectsClient) UpdateFromBytes(
 		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/projects/%s", projectID),
-			AuthHeaders: p.BearerTokenAuthHeaders(),
 			ReqBodyObj:  projectBytes,
 			SuccessCode: http.StatusOK,
 			RespObj:     &updatedProject,
@@ -309,7 +303,6 @@ func (p *projectsClient) Delete(ctx context.Context, id string) error {
 		rm.OutboundRequest{
 			Method:      http.MethodDelete,
 			Path:        fmt.Sprintf("v2/projects/%s", id),
-			AuthHeaders: p.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 		},
 	)

--- a/sdk/v2/core/secrets.go
+++ b/sdk/v2/core/secrets.go
@@ -110,7 +110,6 @@ func (s *secretsClient) List(
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/projects/%s/secrets", projectID),
-			AuthHeaders: s.BearerTokenAuthHeaders(),
 			QueryParams: s.AppendListQueryParams(nil, opts),
 			SuccessCode: http.StatusOK,
 			RespObj:     &secrets,
@@ -132,7 +131,6 @@ func (s *secretsClient) Set(
 				projectID,
 				secret.Key,
 			),
-			AuthHeaders: s.BearerTokenAuthHeaders(),
 			ReqBodyObj:  secret,
 			SuccessCode: http.StatusOK,
 		},
@@ -153,7 +151,6 @@ func (s *secretsClient) Unset(
 				projectID,
 				key,
 			),
-			AuthHeaders: s.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 		},
 	)

--- a/sdk/v2/core/substrate.go
+++ b/sdk/v2/core/substrate.go
@@ -56,7 +56,6 @@ func (s *substrateClient) CountRunningWorkers(
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        "v2/substrate/running-workers",
-			AuthHeaders: s.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 			RespObj:     &count,
 		},
@@ -72,7 +71,6 @@ func (s *substrateClient) CountRunningJobs(
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        "v2/substrate/running-jobs",
-			AuthHeaders: s.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 			RespObj:     &count,
 		},

--- a/sdk/v2/core/workers.go
+++ b/sdk/v2/core/workers.go
@@ -293,7 +293,6 @@ func (w *workersClient) Start(ctx context.Context, eventID string) error {
 		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/events/%s/worker/start", eventID),
-			AuthHeaders: w.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 		},
 	)
@@ -309,7 +308,6 @@ func (w *workersClient) GetStatus(
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        fmt.Sprintf("v2/events/%s/worker/status", eventID),
-			AuthHeaders: w.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 			RespObj:     &status,
 		},
@@ -323,9 +321,8 @@ func (w *workersClient) WatchStatus(
 	resp, err := w.SubmitRequest(
 		ctx,
 		rm.OutboundRequest{
-			Method:      http.MethodGet,
-			Path:        fmt.Sprintf("v2/events/%s/worker/status", eventID),
-			AuthHeaders: w.BearerTokenAuthHeaders(),
+			Method: http.MethodGet,
+			Path:   fmt.Sprintf("v2/events/%s/worker/status", eventID),
 			QueryParams: map[string]string{
 				"watch": "true",
 			},
@@ -354,7 +351,6 @@ func (w *workersClient) UpdateStatus(
 		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/events/%s/worker/status", eventID),
-			AuthHeaders: w.BearerTokenAuthHeaders(),
 			ReqBodyObj:  status,
 			SuccessCode: http.StatusOK,
 		},
@@ -367,7 +363,6 @@ func (w *workersClient) Cleanup(ctx context.Context, eventID string) error {
 		rm.OutboundRequest{
 			Method:      http.MethodPut,
 			Path:        fmt.Sprintf("v2/events/%s/worker/cleanup", eventID),
-			AuthHeaders: w.BearerTokenAuthHeaders(),
 			SuccessCode: http.StatusOK,
 		},
 	)

--- a/sdk/v2/internal/restmachinery/client.go
+++ b/sdk/v2/internal/restmachinery/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -49,30 +48,6 @@ func NewBaseClient(
 		APIAddress: apiAddress,
 		APIToken:   apiToken,
 		HTTPClient: retryClient.StandardClient(),
-	}
-}
-
-// BasicAuthHeaders returns a map[string]string populated with a Basic Auth
-// header based on the provided username and password.
-func (b *BaseClient) BasicAuthHeaders(
-	username string,
-	password string,
-) map[string]string {
-	return map[string]string{
-		"Authorization": fmt.Sprintf(
-			"Basic %s",
-			base64.StdEncoding.EncodeToString(
-				[]byte(fmt.Sprintf("%s:%s", username, password)),
-			),
-		),
-	}
-}
-
-// BearerTokenAuthHeaders returns a map[string]string populated with an
-// authentication header that makes use of the client's bearer token.
-func (b *BaseClient) BearerTokenAuthHeaders() map[string]string {
-	return map[string]string{
-		"Authorization": fmt.Sprintf("Bearer %s", b.APIToken),
 	}
 }
 
@@ -171,8 +146,8 @@ func (b *BaseClient) SubmitRequest(
 		r.URL.RawQuery = q.Encode()
 	}
 	r.Header.Add("Accept", "application/json")
-	for k, v := range req.AuthHeaders {
-		r.Header.Add(k, v)
+	if req.IncludeAuthHeader == nil || *req.IncludeAuthHeader {
+		r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", b.APIToken))
 	}
 	for k, v := range req.Headers {
 		r.Header.Add(k, v)

--- a/sdk/v2/internal/restmachinery/client_test.go
+++ b/sdk/v2/internal/restmachinery/client_test.go
@@ -14,29 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBaseClientBasicAuthHeaders(t *testing.T) {
-	const testUsername = "bruce@wayneenterprises.com"
-	const testPassword = "ironmansucks"
-	client := BaseClient{}
-	headers := client.BasicAuthHeaders(testUsername, testPassword)
-	header, ok := headers["Authorization"]
-	require.True(t, ok)
-	require.Contains(t, header, "Basic")
-	require.NotContains(t, header, testUsername)
-	require.NotContains(t, header, testPassword)
-}
-
-func TestBaseClientBearerTokenAuthHeaders(t *testing.T) {
-	client := BaseClient{
-		APIToken: "11235813213455",
-	}
-	headers := client.BearerTokenAuthHeaders()
-	header, ok := headers["Authorization"]
-	require.True(t, ok)
-	require.Contains(t, header, "Bearer")
-	require.Contains(t, header, client.APIToken)
-}
-
 func TestBaseClientAppendListQueryParams(t *testing.T) {
 	queryParams := map[string]string{}
 	listOpts := meta.ListOptions{
@@ -129,7 +106,7 @@ func TestBaseClientSubmitRequest(t *testing.T) {
 		{
 			name: "with auth header",
 			req: OutboundRequest{
-				AuthHeaders: map[string]string{
+				Headers: map[string]string{
 					"Authorization": "Basic dG9ueUBzdGFya2luZHVzdHJpZXMuY29tOmlhbWlyb25tYW4=", // nolint: lll
 				},
 			},

--- a/sdk/v2/internal/restmachinery/outbound_request.go
+++ b/sdk/v2/internal/restmachinery/outbound_request.go
@@ -8,8 +8,10 @@ type OutboundRequest struct {
 	Path string
 	// QueryParams optionally specifies any URL query parameters to be used.
 	QueryParams map[string]string
-	// AuthHeaders optionally specifies any authentication headers to be used.
-	AuthHeaders map[string]string
+	// IncludeAuthHeader specifies whether to automatically include an
+	// Authorization header with the client's bearer token in the outbound
+	// request. If nil, this will default to true (included).
+	IncludeAuthHeader *bool
 	// Headers optionally specifies any miscellaneous HTTP headers to be used.
 	Headers map[string]string
 	// ReqBodyObj optionally provides an object that can be marshaled to create


### PR DESCRIPTION
While working on a TS equivalent of this SDK, I found some optimizations I could port over so that more boilerplate is accounted for by the client-side rest machinery.