### PR TITLE
ref(git_initializer_test.go): add finer-grained assertions and more test scenarios

### DIFF
--- a/sdk/v2/core/jobs.go
+++ b/sdk/v2/core/jobs.go
@@ -20,6 +20,9 @@ const (
 	// JobPhaseAborted represents the state wherein a Job was forcefully
 	// stopped during execution.
 	JobPhaseAborted JobPhase = "ABORTED"
+	// JobPhaseCanceled represents the state wherein a pending Job was
+	// canceled prior to execution.
+	JobPhaseCanceled JobPhase = "CANCELED"
 	// JobPhaseFailed represents the state wherein a Job has run to
 	// completion but experienced errors.
 	JobPhaseFailed JobPhase = "FAILED"
@@ -48,6 +51,25 @@ const (
 	// (Pod's) state.
 	JobPhaseUnknown JobPhase = "UNKNOWN"
 )
+
+// IsTerminal returns a bool indicating whether the JobPhase is terminal.
+func (j JobPhase) IsTerminal() bool {
+	switch j {
+	case JobPhaseAborted:
+		fallthrough
+	case JobPhaseCanceled:
+		fallthrough
+	case JobPhaseFailed:
+		fallthrough
+	case JobPhaseSchedulingFailed:
+		fallthrough
+	case JobPhaseSucceeded:
+		fallthrough
+	case JobPhaseTimedOut:
+		return true
+	}
+	return false
+}
 
 // Job represents a component spawned by a Worker to complete a single task
 // in the course of handling an Event.

--- a/v2/tests/git_initializer_test.go
+++ b/v2/tests/git_initializer_test.go
@@ -54,8 +54,8 @@ var testcases = []testcase{
 		) {
 			assertWorkerPhase(t, ctx, client, e, core.WorkerPhaseSucceeded)
 			assertWorkerLogs(t, ctx, client, e, "brigade-worker version")
-			assertJobPhase(t, ctx, client, e, core.JobPhaseSucceeded)
-			assertJobLogs(t, ctx, client, e, "README.md")
+			assertJobPhase(t, ctx, client, e, testJobName, core.JobPhaseSucceeded)
+			assertJobLogs(t, ctx, client, e, testJobName, "README.md")
 		},
 	},
 	{
@@ -78,8 +78,8 @@ var testcases = []testcase{
 		) {
 			assertWorkerPhase(t, ctx, client, e, core.WorkerPhaseSucceeded)
 			assertWorkerLogs(t, ctx, client, e, "brigade-worker version")
-			assertJobPhase(t, ctx, client, e, core.JobPhaseSucceeded)
-			assertJobLogs(t, ctx, client, e, "README.md")
+			assertJobPhase(t, ctx, client, e, testJobName, core.JobPhaseSucceeded)
+			assertJobLogs(t, ctx, client, e, testJobName, "README.md")
 		},
 	},
 	{
@@ -102,8 +102,8 @@ var testcases = []testcase{
 		) {
 			assertWorkerPhase(t, ctx, client, e, core.WorkerPhaseSucceeded)
 			assertWorkerLogs(t, ctx, client, e, "brigade-worker version")
-			assertJobPhase(t, ctx, client, e, core.JobPhaseSucceeded)
-			assertJobLogs(t, ctx, client, e, "README.md")
+			assertJobPhase(t, ctx, client, e, testJobName, core.JobPhaseSucceeded)
+			assertJobLogs(t, ctx, client, e, testJobName, "README.md")
 		},
 	},
 	{
@@ -126,8 +126,8 @@ var testcases = []testcase{
 		) {
 			assertWorkerPhase(t, ctx, client, e, core.WorkerPhaseSucceeded)
 			assertWorkerLogs(t, ctx, client, e, "brigade-worker version")
-			assertJobPhase(t, ctx, client, e, core.JobPhaseSucceeded)
-			assertJobLogs(t, ctx, client, e, "README.md")
+			assertJobPhase(t, ctx, client, e, testJobName, core.JobPhaseSucceeded)
+			assertJobLogs(t, ctx, client, e, testJobName, "README.md")
 		},
 	},
 	{
@@ -150,8 +150,8 @@ var testcases = []testcase{
 		) {
 			assertWorkerPhase(t, ctx, client, e, core.WorkerPhaseSucceeded)
 			assertWorkerLogs(t, ctx, client, e, "brigade-worker version")
-			assertJobPhase(t, ctx, client, e, core.JobPhaseSucceeded)
-			assertJobLogs(t, ctx, client, e, ".submodules")
+			assertJobPhase(t, ctx, client, e, testJobName, core.JobPhaseSucceeded)
+			assertJobLogs(t, ctx, client, e, testJobName, ".submodules")
 		},
 	},
 	{
@@ -213,8 +213,8 @@ var testcases = []testcase{
 		) {
 			assertWorkerPhase(t, ctx, client, e, core.WorkerPhaseFailed)
 			assertWorkerLogs(t, ctx, client, e, "brigade-worker version")
-			assertJobPhase(t, ctx, client, e, core.JobPhaseFailed)
-			assertJobLogs(t, ctx, client, e, "Goodbye World")
+			assertJobPhase(t, ctx, client, e, testJobName, core.JobPhaseFailed)
+			assertJobLogs(t, ctx, client, e, testJobName, "Goodbye World")
 		},
 	},
 }
@@ -347,12 +347,13 @@ func assertJobPhase(
 	ctx context.Context,
 	client sdk.APIClient,
 	e core.Event,
+	job string,
 	wantPhase core.JobPhase,
 ) {
 	statusCh, errCh, err := client.Core().Events().Workers().Jobs().WatchStatus(
 		ctx,
 		e.ID,
-		testJobName,
+		job,
 	)
 	require.NoError(t, err, "error encountered attempting to watch job status")
 
@@ -419,6 +420,7 @@ func assertJobLogs(
 	ctx context.Context,
 	client sdk.APIClient,
 	e core.Event,
+	job string,
 	wantLogs string,
 ) {
 	assertLogs(
@@ -426,7 +428,7 @@ func assertJobLogs(
 		ctx,
 		client,
 		e,
-		&core.LogsSelector{Job: testJobName},
+		&core.LogsSelector{Job: job},
 		wantLogs,
 	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds finer-grained assertions (worker and job logs/terminal phases, vcs logs, etc.) for the git initializer integration tests
* Adds a test scenario around a job failure (which should provoke both job and worker terminal phases of failed)

Closes https://github.com/brigadecore/brigade/issues/1224

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
