### PR TITLE
feat(*): add logic to cancel jobs on event cancellation

### DIFF
--- a/v2/apiserver/internal/core/events.go
+++ b/v2/apiserver/internal/core/events.go
@@ -564,11 +564,15 @@ func (e *eventsService) CancelMany(
 	go func() {
 		for _, event := range events.Items {
 			for job := range event.Worker.Jobs {
-				if err = e.jobsStore.Cancel(
+				err = e.jobsStore.Cancel(
 					context.Background(),
 					event.ID,
 					job,
-				); err != nil {
+				)
+				if _, ok := errors.Cause(err).(*meta.ErrNotFound); ok {
+					continue
+				}
+				if err != nil {
 					log.Println(
 						errors.Wrapf(
 							err,

--- a/v2/apiserver/internal/core/events.go
+++ b/v2/apiserver/internal/core/events.go
@@ -563,24 +563,20 @@ func (e *eventsService) CancelMany(
 	// efficient way to do this?
 	go func() {
 		for _, event := range events.Items {
-			// Only iterate through a worker's jobs if the worker status is not
-			// Pending; otherwise no jobs would have been created.
-			if event.Worker.Status.Phase != WorkerPhasePending {
-				for job := range event.Worker.Jobs {
-					if err = e.jobsStore.Cancel(
-						context.Background(),
-						event.ID,
-						job,
-					); err != nil {
-						log.Println(
-							errors.Wrapf(
-								err,
-								"error canceling event %q worker job %q",
-								event.ID,
-								job,
-							),
-						)
-					}
+			for job := range event.Worker.Jobs {
+				if err = e.jobsStore.Cancel(
+					context.Background(),
+					event.ID,
+					job,
+				); err != nil {
+					log.Println(
+						errors.Wrapf(
+							err,
+							"error canceling event %q worker job %q",
+							event.ID,
+							job,
+						),
+					)
 				}
 			}
 

--- a/v2/apiserver/internal/core/events_test.go
+++ b/v2/apiserver/internal/core/events_test.go
@@ -799,42 +799,6 @@ func TestEventsServiceCancelMany(t *testing.T) {
 			},
 		},
 		{
-			name: "error canceling worker jobs in store",
-			selector: EventsSelector{
-				ProjectID:    "blue-book",
-				WorkerPhases: []WorkerPhase{WorkerPhaseFailed},
-			},
-			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
-				projectsStore: &mockProjectsStore{
-					GetFn: func(context.Context, string) (Project, error) {
-						return Project{}, nil
-					},
-				},
-				eventsStore: &mockEventsStore{
-					CancelManyFn: func(
-						context.Context,
-						EventsSelector,
-					) (EventList, error) {
-						return EventList{}, errors.New("jobs store error")
-					},
-				},
-				jobsStore: &mockJobsStore{
-					CancelFn: func(ctx context.Context,
-						eventID string,
-						jobName string,
-					) error {
-						return errors.New("jobs store error")
-					},
-				},
-			},
-			assertions: func(err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error canceling event")
-				require.Contains(t, err.Error(), "jobs store error")
-			},
-		},
-		{
 			name: "success",
 			selector: EventsSelector{
 				ProjectID:    "blue-book",

--- a/v2/apiserver/internal/core/mongodb/events_store.go
+++ b/v2/apiserver/internal/core/mongodb/events_store.go
@@ -219,9 +219,6 @@ func (e *eventsStore) Cancel(ctx context.Context, id string) error {
 		return errors.Wrapf(err, "error updating status of event %q worker", id)
 	}
 
-	// TODO: If the event was running when it was canceled, its jobs need to be
-	// canceled also.
-
 	if res.MatchedCount == 0 {
 		return &meta.ErrConflict{
 			Type: "Event",
@@ -320,9 +317,6 @@ func (e *eventsStore) CancelMany(
 			return events, errors.Wrap(err, "error updating events")
 		}
 	}
-
-	// TODO: If any event was running when it was canceled, its jobs need to be
-	// canceled also.
 
 	delete(criteria, "worker.status.phase")
 	criteria["canceled"] = cancellationTime

--- a/v2/apiserver/internal/core/mongodb/jobs_store.go
+++ b/v2/apiserver/internal/core/mongodb/jobs_store.go
@@ -3,6 +3,7 @@ package mongodb
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/brigadecore/brigade/v2/apiserver/internal/core"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/mongodb"
@@ -23,6 +24,43 @@ func NewJobsStore(database *mongo.Database) (core.JobsStore, error) {
 	return &jobsStore{
 		collection: database.Collection("events"),
 	}, nil
+}
+
+func (j *jobsStore) Cancel(ctx context.Context, id, job string) error {
+	status, err := j.GetStatus(ctx, id, job)
+	if err != nil {
+		return errors.Wrapf(err, "unable to get status of job %q", job)
+	}
+
+	now := time.Now()
+	updatedStatus := core.JobStatus{
+		Ended: &now,
+	}
+
+	// TODO: need to check if job phase already terminal?
+	// Or does existing logic in events store prevent this?
+	switch status.Phase {
+	case core.JobPhasePending:
+		updatedStatus.Phase = core.JobPhaseCanceled
+	case core.JobPhaseRunning, core.JobPhaseStarting:
+		updatedStatus.Phase = core.JobPhaseAborted
+	}
+
+	if err := j.UpdateStatus(
+		ctx,
+		id,
+		job,
+		updatedStatus,
+	); err != nil {
+		return errors.Wrapf(
+			err,
+			"error updating status of worker job %q for event %q",
+			job,
+			id,
+		)
+	}
+
+	return nil
 }
 
 func (j *jobsStore) Create(
@@ -55,6 +93,44 @@ func (j *jobsStore) Create(
 		}
 	}
 	return nil
+}
+
+func (j *jobsStore) GetStatus(
+	ctx context.Context,
+	eventID string,
+	jobName string,
+) (core.JobStatus, error) {
+	// The jobsStore's collection is the events collection
+	// So, find the event and then inspect the decoded object
+	event := core.Event{}
+	res := j.collection.FindOne(ctx, bson.M{"id": eventID})
+	err := res.Decode(&event)
+	if err == mongo.ErrNoDocuments {
+		return core.JobStatus{}, &meta.ErrNotFound{
+			Type: "Event",
+			ID:   eventID,
+		}
+	}
+	if err != nil {
+		return core.JobStatus{},
+			errors.Wrapf(
+				res.Err(),
+				"error finding/decoding event %q for worker job %q",
+				eventID,
+				jobName,
+			)
+	}
+
+	job, ok := event.Worker.Jobs[jobName]
+	if !ok {
+		return core.JobStatus{},
+			&meta.ErrNotFound{
+				Type: "Job",
+				ID:   jobName,
+			}
+	}
+
+	return *job.Status, nil
 }
 
 func (j *jobsStore) UpdateStatus(

--- a/v2/apiserver/internal/core/mongodb/jobs_store_test.go
+++ b/v2/apiserver/internal/core/mongodb/jobs_store_test.go
@@ -14,6 +14,136 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+func TestJobsStoreCancel(t *testing.T) {
+	const testEvent = "123456789"
+	const testJobName = "italian"
+	testCases := []struct {
+		name       string
+		collection mongodb.Collection
+		assertions func(err error)
+	}{
+		// TODO: it'd be great to test the one bit of logic
+		// around updating to canceled if pending and aborted if starting/running
+		{
+			name: "error getting job status",
+			collection: &mongoTesting.MockCollection{
+				FindOneFn: func(
+					context.Context,
+					interface{},
+					...*options.FindOneOptions,
+				) *mongo.SingleResult {
+					res, err := mongoTesting.MockSingleResult(
+						mongo.ErrNoDocuments,
+					)
+					require.NoError(t, err)
+					return res
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "unable to get status of job")
+			},
+		},
+		{
+			name: "error updating job status",
+			collection: &mongoTesting.MockCollection{
+				FindOneFn: func(
+					context.Context,
+					interface{},
+					...*options.FindOneOptions,
+				) *mongo.SingleResult {
+					res, err := mongoTesting.MockSingleResult(
+						core.Event{
+							ObjectMeta: meta.ObjectMeta{
+								ID: testEvent,
+							},
+							Worker: core.Worker{
+								Jobs: map[string]core.Job{
+									testJobName: {
+										Status: &core.JobStatus{
+											Phase: core.JobPhaseSucceeded,
+										},
+									},
+								},
+							},
+						},
+					)
+					require.NoError(t, err)
+					return res
+				},
+				UpdateOneFn: func(
+					context.Context,
+					interface{},
+					interface{},
+					...*options.UpdateOptions,
+				) (*mongo.UpdateResult, error) {
+					return nil, errors.New("something went wrong")
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "error updating status of worker job")
+			},
+		},
+		{
+			name: "success",
+			collection: &mongoTesting.MockCollection{
+				FindOneFn: func(
+					context.Context,
+					interface{},
+					...*options.FindOneOptions,
+				) *mongo.SingleResult {
+					res, err := mongoTesting.MockSingleResult(
+						core.Event{
+							ObjectMeta: meta.ObjectMeta{
+								ID: testEvent,
+							},
+							Worker: core.Worker{
+								Jobs: map[string]core.Job{
+									testJobName: {
+										Status: &core.JobStatus{
+											Phase: core.JobPhaseSucceeded,
+										},
+									},
+								},
+							},
+						},
+					)
+					require.NoError(t, err)
+					return res
+				},
+				UpdateOneFn: func(
+					context.Context,
+					interface{},
+					interface{},
+					...*options.UpdateOptions,
+				) (*mongo.UpdateResult, error) {
+					return &mongo.UpdateResult{
+						MatchedCount: 1,
+					}, nil
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := &jobsStore{
+				collection: testCase.collection,
+			}
+			testCase.assertions(
+				store.Cancel(
+					context.Background(),
+					testEvent,
+					testJobName,
+				),
+			)
+		})
+	}
+}
+
 func TestJobsStoreCreate(t *testing.T) {
 	const testEvent = "123456789"
 	const testJobName = "italian"
@@ -89,6 +219,128 @@ func TestJobsStoreCreate(t *testing.T) {
 					testEvent,
 					testJobName,
 					core.Job{},
+				),
+			)
+		})
+	}
+}
+
+func TestJobsStoreGetStatus(t *testing.T) {
+	const testEvent = "123456789"
+	const testJobName = "italian"
+	testCases := []struct {
+		name       string
+		collection mongodb.Collection
+		assertions func(status core.JobStatus, err error)
+	}{
+		{
+			name: "unanticipated error",
+			collection: &mongoTesting.MockCollection{
+				FindOneFn: func(
+					context.Context,
+					interface{},
+					...*options.FindOneOptions,
+				) *mongo.SingleResult {
+					res, err := mongoTesting.MockSingleResult(
+						errors.New("something went wrong"),
+					)
+					require.NoError(t, err)
+					return res
+				},
+			},
+			assertions: func(status core.JobStatus, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error finding/decoding event")
+			},
+		},
+		{
+			name: "event not found",
+			collection: &mongoTesting.MockCollection{
+				FindOneFn: func(
+					context.Context,
+					interface{},
+					...*options.FindOneOptions,
+				) *mongo.SingleResult {
+					res, err := mongoTesting.MockSingleResult(
+						mongo.ErrNoDocuments,
+					)
+					require.NoError(t, err)
+					return res
+				},
+			},
+			assertions: func(status core.JobStatus, err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrNotFound{}, err)
+			},
+		},
+		{
+			name: "job not found",
+			collection: &mongoTesting.MockCollection{
+				FindOneFn: func(
+					context.Context,
+					interface{},
+					...*options.FindOneOptions,
+				) *mongo.SingleResult {
+					res, err := mongoTesting.MockSingleResult(
+						core.Event{
+							ObjectMeta: meta.ObjectMeta{
+								ID: testEvent,
+							},
+						},
+					)
+					require.NoError(t, err)
+					return res
+				},
+			},
+			assertions: func(status core.JobStatus, err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrNotFound{}, err)
+			},
+		},
+		{
+			name: "success",
+			collection: &mongoTesting.MockCollection{
+				FindOneFn: func(
+					context.Context,
+					interface{},
+					...*options.FindOneOptions,
+				) *mongo.SingleResult {
+					res, err := mongoTesting.MockSingleResult(
+						core.Event{
+							ObjectMeta: meta.ObjectMeta{
+								ID: testEvent,
+							},
+							Worker: core.Worker{
+								Jobs: map[string]core.Job{
+									testJobName: {
+										Status: &core.JobStatus{
+											Phase: core.JobPhaseSucceeded,
+										},
+									},
+								},
+							},
+						},
+					)
+					require.NoError(t, err)
+					return res
+				},
+			},
+			assertions: func(status core.JobStatus, err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := &jobsStore{
+				collection: testCase.collection,
+			}
+			testCase.assertions(
+				store.GetStatus(
+					context.Background(),
+					testEvent,
+					testJobName,
 				),
 			)
 		})

--- a/v2/apiserver/main.go
+++ b/v2/apiserver/main.go
@@ -124,6 +124,7 @@ func main() {
 		authorizer.Authorize,
 		projectsStore,
 		eventsStore,
+		jobsStore,
 		substrate,
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds logic to cancel any/all worker jobs when their corresponding event is cancelled

Close https://github.com/brigadecore/brigade/issues/1191

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
