### PR TITLE
fix(integration tests): ignore error if of ErrNotFound variety on initial project delete

### DIFF
--- a/v2/tests/git_initializer_test.go
+++ b/v2/tests/git_initializer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/brigadecore/brigade/sdk/v2/core"
 	"github.com/brigadecore/brigade/sdk/v2/meta"
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -271,7 +272,9 @@ func TestMain(t *testing.T) {
 
 			// Delete the test project (we're sharing the name between tests)
 			err = client.Core().Projects().Delete(ctx, tc.project.ID)
-			require.NoError(t, err, "error deleting project")
+			if err, ok := errors.Cause(err).(*meta.ErrNotFound); !ok {
+				require.NoError(t, err, "error deleting project")
+			}
 
 			// Create the test project
 			_, err = client.Core().Projects().Create(ctx, tc.project)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Only check for project delete error if not of the ErrNotFound variety.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
