### PR TITLE
chore(*): bump kaniko tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ifneq ($(SKIP_DOCKER),true)
 		-w /workspaces/brigade \
 		$(JS_DEV_IMAGE)
 
-	KANIKO_IMAGE := brigadecore/kaniko:v0.1.0
+	KANIKO_IMAGE := brigadecore/kaniko:v0.2.0
 
 	KANIKO_DOCKER_CMD := docker run \
 		-it \

--- a/brigade.js
+++ b/brigade.js
@@ -6,7 +6,7 @@ const { Check } = require("@brigadecore/brigade-utils");
 
 const goImg = "brigadecore/go-tools:v0.1.0";
 const jsImg = "node:12.3.1-stretch";
-const kanikoImg = "brigadecore/kaniko:v0.1.0";
+const kanikoImg = "brigadecore/kaniko:v0.2.0";
 const localPath = "/workspaces/brigade";
 
 // Run Go unit tests


### PR DESCRIPTION
**What this PR does / why we need it**:

* Bumps the kaniko image version to fix issue mentioned in https://github.com/brigadecore/kaniko/issues/1

Depends on https://github.com/brigadecore/kaniko/pull/2 (and subsequent tag/push of image)

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
