### PR TITLE
Add command aliases for CLI

### DIFF
--- a/v2/cli/event_commands.go
+++ b/v2/cli/event_commands.go
@@ -20,8 +20,9 @@ import (
 )
 
 var eventCommand = &cli.Command{
-	Name:  "event",
-	Usage: "Manage events",
+	Name:    "event",
+	Aliases: []string{"events"},
+	Usage:   "Manage events",
 	Subcommands: []*cli.Command{
 		{
 			Name:  "cancel",

--- a/v2/cli/log_command.go
+++ b/v2/cli/log_command.go
@@ -8,8 +8,9 @@ import (
 )
 
 var logsCommand = &cli.Command{
-	Name:  "logs",
-	Usage: "View worker or job logs",
+	Name:    "log",
+	Aliases: []string{"logs"},
+	Usage:   "View worker or job logs",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    flagContainer,

--- a/v2/cli/project_commands.go
+++ b/v2/cli/project_commands.go
@@ -19,8 +19,9 @@ import (
 )
 
 var projectCommand = &cli.Command{
-	Name:  "project",
-	Usage: "Manage projects",
+	Name:    "project",
+	Usage:   "Manage projects",
+	Aliases: []string{"projects"},
 	Subcommands: []*cli.Command{
 		{
 			Name:  "create",

--- a/v2/cli/project_role_commands.go
+++ b/v2/cli/project_role_commands.go
@@ -50,8 +50,8 @@ var (
 )
 
 var projectRolesCommands = &cli.Command{
-	Name:    "roles",
-	Aliases: []string{"role"},
+	Name:    "role",
+	Aliases: []string{"roles"},
 	Usage:   "Manage project roles",
 	Subcommands: []*cli.Command{
 		{

--- a/v2/cli/role_commands.go
+++ b/v2/cli/role_commands.go
@@ -39,8 +39,8 @@ var (
 )
 
 var rolesCommands = &cli.Command{
-	Name:    "roles",
-	Aliases: []string{"role"},
+	Name:    "role",
+	Aliases: []string{"roles"},
 	Usage:   "Manage system roles for users or service accounts",
 	Subcommands: []*cli.Command{
 		{

--- a/v2/cli/secret_commands.go
+++ b/v2/cli/secret_commands.go
@@ -16,8 +16,8 @@ import (
 )
 
 var secretsCommand = &cli.Command{
-	Name:    "secrets",
-	Aliases: []string{"secret"},
+	Name:    "secret",
+	Aliases: []string{"secrets"},
 	Usage:   "Manage project secrets",
 	Subcommands: []*cli.Command{
 		{

--- a/v2/cli/service_account_commands.go
+++ b/v2/cli/service_account_commands.go
@@ -20,7 +20,7 @@ import (
 
 var serviceAccountCommand = &cli.Command{
 	Name:    "service-account",
-	Aliases: []string{"sa"},
+	Aliases: []string{"sa", "service-accounts"},
 	Usage:   "Manage service accounts",
 	Subcommands: []*cli.Command{
 		{

--- a/v2/cli/user_commands.go
+++ b/v2/cli/user_commands.go
@@ -15,8 +15,9 @@ import (
 )
 
 var userCommand = &cli.Command{
-	Name:  "user",
-	Usage: "Manage users",
+	Name:    "user",
+	Usage:   "Manage users",
+	Aliases: []string{"users"},
 	Subcommands: []*cli.Command{
 		{
 			Name:  "get",


### PR DESCRIPTION
closes #1216 

This commit adds plural aliases for the `brig` event, project, service accounts, and user commands.