### PR TITLE
fix(git_initializer_test.go): don't overwrite err when checking cause

### DIFF
--- a/v2/tests/git_initializer_test.go
+++ b/v2/tests/git_initializer_test.go
@@ -272,7 +272,7 @@ func TestMain(t *testing.T) {
 
 			// Delete the test project (we're sharing the name between tests)
 			err = client.Core().Projects().Delete(ctx, tc.project.ID)
-			if err, ok := errors.Cause(err).(*meta.ErrNotFound); !ok {
+			if _, ok := errors.Cause(err).(*meta.ErrNotFound); !ok {
 				require.NoError(t, err, "error deleting project")
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

😅 This is a fix for when we check the cause of the error that results from deleting a project.  We don't want to overwrite `err` here.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
