### PR TITLE
feat(events): stream canceled/deleted (many) events

### DIFF
--- a/v2/apiserver/internal/core/common_test.go
+++ b/v2/apiserver/internal/core/common_test.go
@@ -59,7 +59,7 @@ type mockEventsStore struct {
 	GetByHashedWorkerTokenFn func(context.Context, string) (Event, error)
 	CancelFn                 func(context.Context, string) error
 	CancelManyFn             func(context.Context, EventsSelector,
-	) (EventList, error)
+	) (<-chan Event, <-chan error, error)
 	DeleteFn     func(context.Context, string) error
 	DeleteManyFn func(context.Context, EventsSelector) (EventList, error)
 }
@@ -94,7 +94,7 @@ func (m *mockEventsStore) Cancel(ctx context.Context, id string) error {
 func (m *mockEventsStore) CancelMany(
 	ctx context.Context,
 	selector EventsSelector,
-) (EventList, error) {
+) (<-chan Event, <-chan error, error) {
 	return m.CancelManyFn(ctx, selector)
 }
 

--- a/v2/apiserver/internal/core/common_test.go
+++ b/v2/apiserver/internal/core/common_test.go
@@ -58,8 +58,10 @@ type mockEventsStore struct {
 	GetFn                    func(context.Context, string) (Event, error)
 	GetByHashedWorkerTokenFn func(context.Context, string) (Event, error)
 	CancelFn                 func(context.Context, string) error
-	CancelManyFn             func(context.Context, EventsSelector,
-	) (<-chan Event, <-chan error, error)
+	CancelManyFn             func(
+		context.Context,
+		EventsSelector,
+	) (<-chan Event, error)
 	DeleteFn     func(context.Context, string) error
 	DeleteManyFn func(context.Context, EventsSelector) (EventList, error)
 }
@@ -94,7 +96,7 @@ func (m *mockEventsStore) Cancel(ctx context.Context, id string) error {
 func (m *mockEventsStore) CancelMany(
 	ctx context.Context,
 	selector EventsSelector,
-) (<-chan Event, <-chan error, error) {
+) (<-chan Event, error) {
 	return m.CancelManyFn(ctx, selector)
 }
 

--- a/v2/apiserver/internal/core/common_test.go
+++ b/v2/apiserver/internal/core/common_test.go
@@ -61,9 +61,12 @@ type mockEventsStore struct {
 	CancelManyFn             func(
 		context.Context,
 		EventsSelector,
-	) (<-chan Event, error)
+	) (<-chan Event, int64, error)
 	DeleteFn     func(context.Context, string) error
-	DeleteManyFn func(context.Context, EventsSelector) (<-chan Event, error)
+	DeleteManyFn func(
+		context.Context,
+		EventsSelector,
+	) (<-chan Event, int64, error)
 }
 
 func (m *mockEventsStore) Create(ctx context.Context, event Event) error {
@@ -96,7 +99,7 @@ func (m *mockEventsStore) Cancel(ctx context.Context, id string) error {
 func (m *mockEventsStore) CancelMany(
 	ctx context.Context,
 	selector EventsSelector,
-) (<-chan Event, error) {
+) (<-chan Event, int64, error) {
 	return m.CancelManyFn(ctx, selector)
 }
 
@@ -107,7 +110,7 @@ func (m *mockEventsStore) Delete(ctx context.Context, id string) error {
 func (m *mockEventsStore) DeleteMany(
 	ctx context.Context,
 	selector EventsSelector,
-) (<-chan Event, error) {
+) (<-chan Event, int64, error) {
 	return m.DeleteManyFn(ctx, selector)
 }
 

--- a/v2/apiserver/internal/core/common_test.go
+++ b/v2/apiserver/internal/core/common_test.go
@@ -63,7 +63,7 @@ type mockEventsStore struct {
 		EventsSelector,
 	) (<-chan Event, error)
 	DeleteFn     func(context.Context, string) error
-	DeleteManyFn func(context.Context, EventsSelector) (EventList, error)
+	DeleteManyFn func(context.Context, EventsSelector) (<-chan Event, error)
 }
 
 func (m *mockEventsStore) Create(ctx context.Context, event Event) error {
@@ -107,7 +107,7 @@ func (m *mockEventsStore) Delete(ctx context.Context, id string) error {
 func (m *mockEventsStore) DeleteMany(
 	ctx context.Context,
 	selector EventsSelector,
-) (EventList, error) {
+) (<-chan Event, error) {
 	return m.DeleteManyFn(ctx, selector)
 }
 

--- a/v2/apiserver/internal/core/events.go
+++ b/v2/apiserver/internal/core/events.go
@@ -551,22 +551,20 @@ func (e *eventsService) CancelMany(
 	for i := 0; i < concurrency; i++ {
 		go func() {
 			for {
-				select {
-				case event, ok := <-eventCh:
-					if !ok { // event channel closed; we're done
-						return
-					}
-					if err := e.substrate.DeleteWorkerAndJobs(
-						context.Background(), // deliberately not using ctx
-						project,
-						event,
-					); err != nil {
-						log.Println(errors.Wrapf(
-							err,
-							"error deleting event %q worker and jobs from the substrate",
-							event.ID,
-						))
-					}
+				event, ok := <-eventCh
+				if !ok { // event channel closed; we're done
+					return
+				}
+				if err := e.substrate.DeleteWorkerAndJobs(
+					context.Background(), // deliberately not using ctx
+					project,
+					event,
+				); err != nil {
+					log.Println(errors.Wrapf(
+						err,
+						"error deleting event %q worker and jobs from the substrate",
+						event.ID,
+					))
 				}
 			}
 		}()
@@ -658,23 +656,20 @@ func (e *eventsService) DeleteMany(
 	for i := 0; i < concurrency; i++ {
 		go func() {
 			for {
-				select {
-				case event, ok := <-eventCh:
-					if ok {
-						if err := e.substrate.DeleteWorkerAndJobs(
-							context.Background(), // deliberately not using ctx
-							project,
-							event,
-						); err != nil {
-							log.Println(errors.Wrapf(
-								err,
-								"error deleting event %q worker and jobs from the substrate",
-								event.ID,
-							))
-						}
-					} else { // event channel closed; we're done
-						return
-					}
+				event, ok := <-eventCh
+				if !ok { // event channel closed; we're done
+					return
+				}
+				if err := e.substrate.DeleteWorkerAndJobs(
+					context.Background(), // deliberately not using ctx
+					project,
+					event,
+				); err != nil {
+					log.Println(errors.Wrapf(
+						err,
+						"error deleting event %q worker and jobs from the substrate",
+						event.ID,
+					))
 				}
 			}
 		}()

--- a/v2/apiserver/internal/core/events.go
+++ b/v2/apiserver/internal/core/events.go
@@ -550,11 +550,7 @@ func (e *eventsService) CancelMany(
 	}
 	for i := 0; i < concurrency; i++ {
 		go func() {
-			for {
-				event, ok := <-eventCh
-				if !ok { // event channel closed; we're done
-					return
-				}
+			for event := range eventCh {
 				if err := e.substrate.DeleteWorkerAndJobs(
 					context.Background(), // deliberately not using ctx
 					project,
@@ -655,11 +651,7 @@ func (e *eventsService) DeleteMany(
 	}
 	for i := 0; i < concurrency; i++ {
 		go func() {
-			for {
-				event, ok := <-eventCh
-				if !ok { // event channel closed; we're done
-					return
-				}
+			for event := range eventCh {
 				if err := e.substrate.DeleteWorkerAndJobs(
 					context.Background(), // deliberately not using ctx
 					project,

--- a/v2/apiserver/internal/core/events.go
+++ b/v2/apiserver/internal/core/events.go
@@ -553,20 +553,19 @@ func (e *eventsService) CancelMany(
 			for {
 				select {
 				case event, ok := <-eventCh:
-					if ok {
-						if err := e.substrate.DeleteWorkerAndJobs(
-							context.Background(), // deliberately not using ctx
-							project,
-							event,
-						); err != nil {
-							log.Println(errors.Wrapf(
-								err,
-								"error deleting event %q worker and jobs from the substrate",
-								event.ID,
-							))
-						}
-					} else { // event channel closed; we're done
+					if !ok { // event channel closed; we're done
 						return
+					}
+					if err := e.substrate.DeleteWorkerAndJobs(
+						context.Background(), // deliberately not using ctx
+						project,
+						event,
+					); err != nil {
+						log.Println(errors.Wrapf(
+							err,
+							"error deleting event %q worker and jobs from the substrate",
+							event.ID,
+						))
 					}
 				}
 			}

--- a/v2/apiserver/internal/core/events.go
+++ b/v2/apiserver/internal/core/events.go
@@ -537,11 +537,11 @@ func (e *eventsService) CancelMany(
 		)
 	}
 
-	eventCh, count, err := e.eventsStore.CancelMany(ctx, selector)
+	eventCh, affectedCount, err := e.eventsStore.CancelMany(ctx, selector)
 	if err != nil {
 		return result, errors.Wrap(err, "error canceling events in store")
 	}
-	result.Count = count
+	result.Count = affectedCount
 
 	// Fan out to a finite number of goroutines to handle cleanup duties
 	concurrency := 10
@@ -645,11 +645,11 @@ func (e *eventsService) DeleteMany(
 		)
 	}
 
-	eventCh, count, err := e.eventsStore.DeleteMany(ctx, selector)
+	eventCh, affectedCount, err := e.eventsStore.DeleteMany(ctx, selector)
 	if err != nil {
 		return result, errors.Wrap(err, "error deleting events from store")
 	}
-	result.Count = count
+	result.Count = affectedCount
 
 	// Fan out to a finite number of goroutines to handle cleanup duties
 	concurrency := 10
@@ -717,13 +717,15 @@ type EventsStore interface {
 	// CancelMany updates multiple Events specified by the EventsSelector
 	// parameter in the underlying data store to reflect that they have been
 	// canceled. Implementations MUST only cancel events whose Workers have not
-	// already reached a terminal state.
+	// already reached a terminal state and MUST return the total number of
+	// canceled events.
 	CancelMany(context.Context, EventsSelector) (<-chan Event, int64, error)
 	// Delete unconditionally deletes the specified Event from the underlying data
 	// store. If the specified Event does not exist, implementations MUST
 	// return a *meta.ErrNotFound error.
 	Delete(context.Context, string) error
 	// DeleteMany unconditionally deletes multiple Events specified by the
-	// EventsSelector parameter from the underlying data store.
+	// EventsSelector parameter from the underlying data store.  Implementations
+	// MUST return the total number of deleted events.
 	DeleteMany(context.Context, EventsSelector) (<-chan Event, int64, error)
 }

--- a/v2/apiserver/internal/core/events_test.go
+++ b/v2/apiserver/internal/core/events_test.go
@@ -747,8 +747,8 @@ func TestEventsServiceCancelMany(t *testing.T) {
 					CancelManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (EventList, error) {
-						return EventList{}, errors.New("events store error")
+					) (<-chan Event, <-chan error, error) {
+						return nil, nil, errors.New("events store error")
 					},
 				},
 			},
@@ -775,8 +775,8 @@ func TestEventsServiceCancelMany(t *testing.T) {
 					CancelManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (EventList, error) {
-						return EventList{}, nil
+					) (<-chan Event, <-chan error, error) {
+						return nil, nil, nil
 					},
 				},
 			},

--- a/v2/apiserver/internal/core/events_test.go
+++ b/v2/apiserver/internal/core/events_test.go
@@ -747,8 +747,8 @@ func TestEventsServiceCancelMany(t *testing.T) {
 					CancelManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (<-chan Event, error) {
-						return nil, errors.New("events store error")
+					) (<-chan Event, int64, error) {
+						return nil, 0, errors.New("events store error")
 					},
 				},
 			},
@@ -775,10 +775,10 @@ func TestEventsServiceCancelMany(t *testing.T) {
 					CancelManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (<-chan Event, error) {
+					) (<-chan Event, int64, error) {
 						eventCh := make(chan Event)
 						defer close(eventCh)
-						return eventCh, nil
+						return eventCh, 0, nil
 					},
 				},
 			},
@@ -1035,8 +1035,8 @@ func TestEventsServiceDeleteMany(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (<-chan Event, error) {
-						return nil, errors.New("events store error")
+					) (<-chan Event, int64, error) {
+						return nil, 0, errors.New("events store error")
 					},
 				},
 			},
@@ -1063,10 +1063,10 @@ func TestEventsServiceDeleteMany(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (<-chan Event, error) {
+					) (<-chan Event, int64, error) {
 						eventCh := make(chan Event)
 						defer close(eventCh)
-						return eventCh, nil
+						return eventCh, 0, nil
 					},
 				},
 			},

--- a/v2/apiserver/internal/core/events_test.go
+++ b/v2/apiserver/internal/core/events_test.go
@@ -747,8 +747,8 @@ func TestEventsServiceCancelMany(t *testing.T) {
 					CancelManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (<-chan Event, <-chan error, error) {
-						return nil, nil, errors.New("events store error")
+					) (<-chan Event, error) {
+						return nil, errors.New("events store error")
 					},
 				},
 			},
@@ -775,8 +775,10 @@ func TestEventsServiceCancelMany(t *testing.T) {
 					CancelManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (<-chan Event, <-chan error, error) {
-						return nil, nil, nil
+					) (<-chan Event, error) {
+						eventCh := make(chan Event)
+						defer close(eventCh)
+						return eventCh, nil
 					},
 				},
 			},

--- a/v2/apiserver/internal/core/events_test.go
+++ b/v2/apiserver/internal/core/events_test.go
@@ -1035,8 +1035,8 @@ func TestEventsServiceDeleteMany(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (EventList, error) {
-						return EventList{}, errors.New("events store error")
+					) (<-chan Event, error) {
+						return nil, errors.New("events store error")
 					},
 				},
 			},
@@ -1063,8 +1063,10 @@ func TestEventsServiceDeleteMany(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (EventList, error) {
-						return EventList{}, nil
+					) (<-chan Event, error) {
+						eventCh := make(chan Event)
+						defer close(eventCh)
+						return eventCh, nil
 					},
 				},
 			},

--- a/v2/apiserver/internal/core/kubernetes/substrate.go
+++ b/v2/apiserver/internal/core/kubernetes/substrate.go
@@ -643,40 +643,45 @@ func (s *substrate) DeleteWorkerAndJobs(
 		},
 	).AsSelector().String()
 
-	// Delete all pods related to this Event
-	if err := s.kubeClient.CoreV1().Pods(
-		project.Kubernetes.Namespace,
-	).DeleteCollection(
-		ctx,
-		metav1.DeleteOptions{},
-		metav1.ListOptions{
-			LabelSelector: labelSelector,
-		},
-	); err != nil {
-		return errors.Wrapf(
-			err,
-			"error deleting event %q pods in namespace %q",
-			event.ID,
+	// If a worker's phase is CANCELED, it could have only reached this terminal
+	// phase if it was previously in PENDING and hence, no pods would have been
+	// created. Therefore, we just skip to cleaning up the event secret(s) below.
+	if event.Worker.Status.Phase != core.WorkerPhaseCanceled {
+		// Delete all pods related to this Event
+		if err := s.kubeClient.CoreV1().Pods(
 			project.Kubernetes.Namespace,
-		)
-	}
+		).DeleteCollection(
+			ctx,
+			metav1.DeleteOptions{},
+			metav1.ListOptions{
+				LabelSelector: labelSelector,
+			},
+		); err != nil {
+			return errors.Wrapf(
+				err,
+				"error deleting event %q pods in namespace %q",
+				event.ID,
+				project.Kubernetes.Namespace,
+			)
+		}
 
-	// Delete all persistent volume claims related to this Event
-	if err := s.kubeClient.CoreV1().PersistentVolumeClaims(
-		project.Kubernetes.Namespace,
-	).DeleteCollection(
-		ctx,
-		metav1.DeleteOptions{},
-		metav1.ListOptions{
-			LabelSelector: labelSelector,
-		},
-	); err != nil {
-		return errors.Wrapf(
-			err,
-			"error deleting event %q persistent volume claims in namespace %q",
-			event.ID,
+		// Delete all persistent volume claims related to this Event
+		if err := s.kubeClient.CoreV1().PersistentVolumeClaims(
 			project.Kubernetes.Namespace,
-		)
+		).DeleteCollection(
+			ctx,
+			metav1.DeleteOptions{},
+			metav1.ListOptions{
+				LabelSelector: labelSelector,
+			},
+		); err != nil {
+			return errors.Wrapf(
+				err,
+				"error deleting event %q persistent volume claims in namespace %q",
+				event.ID,
+				project.Kubernetes.Namespace,
+			)
+		}
 	}
 
 	// Delete all secrets related to this Event

--- a/v2/apiserver/internal/core/kubernetes/substrate.go
+++ b/v2/apiserver/internal/core/kubernetes/substrate.go
@@ -643,10 +643,10 @@ func (s *substrate) DeleteWorkerAndJobs(
 		},
 	).AsSelector().String()
 
-	// If a worker's phase is CANCELED, it could have only reached this terminal
-	// phase if it was previously in PENDING and hence, no pods would have been
+	// If a worker's phase is CANCELED or PENDING, no pods would have been
 	// created. Therefore, we just skip to cleaning up the event secret(s) below.
-	if event.Worker.Status.Phase != core.WorkerPhaseCanceled {
+	if event.Worker.Status.Phase != core.WorkerPhaseCanceled &&
+		event.Worker.Status.Phase != core.WorkerPhasePending {
 		// Delete all pods related to this Event
 		if err := s.kubeClient.CoreV1().Pods(
 			project.Kubernetes.Namespace,

--- a/v2/apiserver/internal/core/mongodb/events_store.go
+++ b/v2/apiserver/internal/core/mongodb/events_store.go
@@ -388,9 +388,7 @@ func (e *eventsStore) CancelMany(
 			if err := cur.Decode(&event); err != nil {
 				log.Println(errors.Wrap(err, "error decoding event"))
 			}
-			select {
-			case eventCh <- event:
-			}
+			eventCh <- event
 		}
 	}()
 	return eventCh, affectedCount, nil

--- a/v2/apiserver/internal/core/mongodb/events_store.go
+++ b/v2/apiserver/internal/core/mongodb/events_store.go
@@ -477,9 +477,7 @@ func (e *eventsStore) DeleteMany(
 			if err := cur.Decode(&event); err != nil {
 				log.Println(errors.Wrap(err, "error decoding event"))
 			}
-			select {
-			case eventCh <- event:
-			}
+			eventCh <- event
 		}
 		// Final deletion
 		if _, err := e.collection.DeleteMany(

--- a/v2/apiserver/internal/core/mongodb/events_store.go
+++ b/v2/apiserver/internal/core/mongodb/events_store.go
@@ -257,6 +257,7 @@ func (e *eventsStore) Cancel(ctx context.Context, id string) error {
 	return nil
 }
 
+// nolint: gocyclo
 func (e *eventsStore) CancelMany(
 	ctx context.Context,
 	selector core.EventsSelector,

--- a/v2/apiserver/internal/core/mongodb/events_store_test.go
+++ b/v2/apiserver/internal/core/mongodb/events_store_test.go
@@ -622,38 +622,6 @@ func TestEventsStoreCancelMany(t *testing.T) {
 		},
 
 		{
-			name: "error counting canceled events",
-			eventsSelector: core.EventsSelector{
-				WorkerPhases: []core.WorkerPhase{
-					core.WorkerPhasePending,
-					core.WorkerPhaseRunning,
-				},
-			},
-			collection: &mongoTesting.MockCollection{
-				UpdateManyFn: func(
-					context.Context,
-					interface{},
-					interface{},
-					...*options.UpdateOptions,
-				) (*mongo.UpdateResult, error) {
-					return &mongo.UpdateResult{}, nil
-				},
-				CountDocumentsFn: func(
-					context.Context,
-					interface{},
-					...*options.CountOptions,
-				) (int64, error) {
-					return 0, errors.New("something went wrong")
-				},
-			},
-			assertions: func(err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error counting canceled events")
-				require.Contains(t, err.Error(), "something went wrong")
-			},
-		},
-
-		{
 			name: "error finding canceled events",
 			eventsSelector: core.EventsSelector{
 				WorkerPhases: []core.WorkerPhase{
@@ -669,13 +637,6 @@ func TestEventsStoreCancelMany(t *testing.T) {
 					...*options.UpdateOptions,
 				) (*mongo.UpdateResult, error) {
 					return &mongo.UpdateResult{}, nil
-				},
-				CountDocumentsFn: func(
-					context.Context,
-					interface{},
-					...*options.CountOptions,
-				) (int64, error) {
-					return 0, nil
 				},
 				FindFn: func(
 					context.Context,
@@ -708,13 +669,6 @@ func TestEventsStoreCancelMany(t *testing.T) {
 					...*options.UpdateOptions,
 				) (*mongo.UpdateResult, error) {
 					return &mongo.UpdateResult{}, nil
-				},
-				CountDocumentsFn: func(
-					context.Context,
-					interface{},
-					...*options.CountOptions,
-				) (int64, error) {
-					return 0, nil
 				},
 				FindFn: func(
 					context.Context,
@@ -852,42 +806,6 @@ func TestEventsStoreDeleteMany(t *testing.T) {
 		},
 
 		{
-			name: "error counting deleted events",
-			eventsSelector: core.EventsSelector{
-				WorkerPhases: []core.WorkerPhase{
-					core.WorkerPhasePending,
-					core.WorkerPhaseRunning,
-				},
-			},
-			collection: &mongoTesting.MockCollection{
-				UpdateManyFn: func(
-					context.Context,
-					interface{},
-					interface{},
-					...*options.UpdateOptions,
-				) (*mongo.UpdateResult, error) {
-					return &mongo.UpdateResult{}, nil
-				},
-				CountDocumentsFn: func(
-					context.Context,
-					interface{},
-					...*options.CountOptions,
-				) (int64, error) {
-					return 0, errors.New("something went wrong")
-				},
-			},
-			assertions: func(err error) {
-				require.Error(t, err)
-				require.Contains(
-					t,
-					err.Error(),
-					"error counting deleted events",
-				)
-				require.Contains(t, err.Error(), "something went wrong")
-			},
-		},
-
-		{
 			name: "error finding deleted events",
 			eventsSelector: core.EventsSelector{
 				WorkerPhases: []core.WorkerPhase{
@@ -903,13 +821,6 @@ func TestEventsStoreDeleteMany(t *testing.T) {
 					...*options.UpdateOptions,
 				) (*mongo.UpdateResult, error) {
 					return &mongo.UpdateResult{}, nil
-				},
-				CountDocumentsFn: func(
-					context.Context,
-					interface{},
-					...*options.CountOptions,
-				) (int64, error) {
-					return 0, nil
 				},
 				FindFn: func(
 					context.Context,
@@ -946,13 +857,6 @@ func TestEventsStoreDeleteMany(t *testing.T) {
 					...*options.UpdateOptions,
 				) (*mongo.UpdateResult, error) {
 					return &mongo.UpdateResult{}, nil
-				},
-				CountDocumentsFn: func(
-					context.Context,
-					interface{},
-					...*options.CountOptions,
-				) (int64, error) {
-					return 0, nil
 				},
 				FindFn: func(
 					context.Context,

--- a/v2/apiserver/internal/core/mongodb/events_store_test.go
+++ b/v2/apiserver/internal/core/mongodb/events_store_test.go
@@ -778,7 +778,7 @@ func TestEventsStoreDeleteMany(t *testing.T) {
 		name           string
 		eventsSelector core.EventsSelector
 		collection     mongodb.Collection
-		assertions     func(core.EventList, error)
+		assertions     func(error)
 	}{
 
 		{
@@ -798,7 +798,7 @@ func TestEventsStoreDeleteMany(t *testing.T) {
 					return nil, errors.New("something went wrong")
 				},
 			},
-			assertions: func(events core.EventList, err error) {
+			assertions: func(err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "error logically deleting events")
 				require.Contains(t, err.Error(), "something went wrong")
@@ -830,7 +830,7 @@ func TestEventsStoreDeleteMany(t *testing.T) {
 					return nil, errors.New("something went wrong")
 				},
 			},
-			assertions: func(events core.EventList, err error) {
+			assertions: func(err error) {
 				require.Error(t, err)
 				require.Contains(
 					t,
@@ -875,7 +875,7 @@ func TestEventsStoreDeleteMany(t *testing.T) {
 					return nil, errors.New("something went wrong")
 				},
 			},
-			assertions: func(events core.EventList, err error) {
+			assertions: func(err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "error deleting events")
 				require.Contains(t, err.Error(), "something went wrong")
@@ -916,7 +916,7 @@ func TestEventsStoreDeleteMany(t *testing.T) {
 					return &mongo.DeleteResult{}, nil
 				},
 			},
-			assertions: func(_ core.EventList, err error) {
+			assertions: func(err error) {
 				require.NoError(t, err)
 			},
 		},
@@ -926,9 +926,9 @@ func TestEventsStoreDeleteMany(t *testing.T) {
 			store := &eventsStore{
 				collection: testCase.collection,
 			}
-			events, err :=
+			_, err :=
 				store.DeleteMany(context.Background(), testCase.eventsSelector)
-			testCase.assertions(events, err)
+			testCase.assertions(err)
 		})
 	}
 }

--- a/v2/apiserver/internal/core/mongodb/events_store_test.go
+++ b/v2/apiserver/internal/core/mongodb/events_store_test.go
@@ -551,7 +551,7 @@ func TestEventsStoreCancelMany(t *testing.T) {
 		name           string
 		eventsSelector core.EventsSelector
 		collection     mongodb.Collection
-		assertions     func(core.EventList, error)
+		assertions     func(err error)
 	}{
 
 		{
@@ -568,9 +568,8 @@ func TestEventsStoreCancelMany(t *testing.T) {
 					return nil, nil
 				},
 			},
-			assertions: func(events core.EventList, err error) {
+			assertions: func(err error) {
 				require.NoError(t, err)
-				require.Empty(t, events.Items)
 			},
 		},
 
@@ -591,7 +590,7 @@ func TestEventsStoreCancelMany(t *testing.T) {
 					return nil, errors.New("something went wrong")
 				},
 			},
-			assertions: func(events core.EventList, err error) {
+			assertions: func(err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "error updating events")
 				require.Contains(t, err.Error(), "something went wrong")
@@ -615,7 +614,7 @@ func TestEventsStoreCancelMany(t *testing.T) {
 					return nil, errors.New("something went wrong")
 				},
 			},
-			assertions: func(events core.EventList, err error) {
+			assertions: func(err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "error updating events")
 				require.Contains(t, err.Error(), "something went wrong")
@@ -647,7 +646,7 @@ func TestEventsStoreCancelMany(t *testing.T) {
 					return nil, errors.New("something went wrong")
 				},
 			},
-			assertions: func(events core.EventList, err error) {
+			assertions: func(err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "error finding canceled events")
 				require.Contains(t, err.Error(), "something went wrong")
@@ -681,7 +680,7 @@ func TestEventsStoreCancelMany(t *testing.T) {
 					return cursor, nil
 				},
 			},
-			assertions: func(events core.EventList, err error) {
+			assertions: func(err error) {
 				require.NoError(t, err)
 			},
 		},
@@ -691,9 +690,9 @@ func TestEventsStoreCancelMany(t *testing.T) {
 			store := &eventsStore{
 				collection: testCase.collection,
 			}
-			events, err :=
+			_, _, error :=
 				store.CancelMany(context.Background(), testCase.eventsSelector)
-			testCase.assertions(events, err)
+			testCase.assertions(error)
 		})
 	}
 }

--- a/v2/apiserver/internal/core/mongodb/events_store_test.go
+++ b/v2/apiserver/internal/core/mongodb/events_store_test.go
@@ -690,7 +690,7 @@ func TestEventsStoreCancelMany(t *testing.T) {
 			store := &eventsStore{
 				collection: testCase.collection,
 			}
-			_, _, error :=
+			_, error :=
 				store.CancelMany(context.Background(), testCase.eventsSelector)
 			testCase.assertions(error)
 		})

--- a/v2/apiserver/internal/core/projects.go
+++ b/v2/apiserver/internal/core/projects.go
@@ -341,7 +341,7 @@ func (p *projectsService) Delete(ctx context.Context, id string) error {
 	}
 
 	// Delete all events associated with this project
-	if _, err := p.eventsStore.DeleteMany(
+	if _, _, err := p.eventsStore.DeleteMany(
 		ctx,
 		EventsSelector{ProjectID: id, WorkerPhases: WorkerPhasesAll()},
 	); err != nil {

--- a/v2/apiserver/internal/core/projects_test.go
+++ b/v2/apiserver/internal/core/projects_test.go
@@ -348,8 +348,9 @@ func TestProjectServiceDelete(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (<-chan Event, error) {
+					) (<-chan Event, int64, error) {
 						return nil,
+							0,
 							errors.New("error deleting events associated with project")
 					},
 				},
@@ -379,8 +380,8 @@ func TestProjectServiceDelete(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (<-chan Event, error) {
-						return nil, nil
+					) (<-chan Event, int64, error) {
+						return nil, 0, nil
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
@@ -415,8 +416,8 @@ func TestProjectServiceDelete(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (<-chan Event, error) {
-						return nil, nil
+					) (<-chan Event, int64, error) {
+						return nil, 0, nil
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
@@ -447,8 +448,8 @@ func TestProjectServiceDelete(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (<-chan Event, error) {
-						return nil, nil
+					) (<-chan Event, int64, error) {
+						return nil, 0, nil
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
@@ -484,8 +485,8 @@ func TestProjectServiceDelete(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (<-chan Event, error) {
-						return nil, nil
+					) (<-chan Event, int64, error) {
+						return nil, 0, nil
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{

--- a/v2/apiserver/internal/core/projects_test.go
+++ b/v2/apiserver/internal/core/projects_test.go
@@ -348,8 +348,8 @@ func TestProjectServiceDelete(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (EventList, error) {
-						return EventList{},
+					) (<-chan Event, error) {
+						return nil,
 							errors.New("error deleting events associated with project")
 					},
 				},
@@ -379,8 +379,8 @@ func TestProjectServiceDelete(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (EventList, error) {
-						return EventList{}, nil
+					) (<-chan Event, error) {
+						return nil, nil
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
@@ -415,8 +415,8 @@ func TestProjectServiceDelete(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (EventList, error) {
-						return EventList{}, nil
+					) (<-chan Event, error) {
+						return nil, nil
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
@@ -447,8 +447,8 @@ func TestProjectServiceDelete(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (EventList, error) {
-						return EventList{}, nil
+					) (<-chan Event, error) {
+						return nil, nil
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
@@ -484,8 +484,8 @@ func TestProjectServiceDelete(t *testing.T) {
 					DeleteManyFn: func(
 						context.Context,
 						EventsSelector,
-					) (EventList, error) {
-						return EventList{}, nil
+					) (<-chan Event, error) {
+						return nil, nil
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{


### PR DESCRIPTION
**What this PR does / why we need it**:

* Updates the Cancel/DeleteMany logic for events to stream instead of accrue in memory a potentially large collection of canceled/deleted events

See https://github.com/brigadecore/brigade/pull/1262#issuecomment-773420895

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
