### PR TITLE
fix(Makefile): add helm dep up to hack target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,7 @@ hack-push-%: hack-build-%
 .PHONY: hack
 hack: hack-push-images hack-build-cli
 	kubectl get namespace brigade || kubectl create namespace brigade
+	helm dep up charts/brigade && \
 	helm upgrade brigade charts/brigade \
 		--install \
 		--namespace brigade \


### PR DESCRIPTION
**What this PR does / why we need it**:

Now that we [don't track chart dependencies](https://github.com/brigadecore/brigade/pull/1269/commits/2fc9b3d4dfc17bc7210292a43378117f2cfbf679), mongodb being the only one so far, we need to run `helm dep up` to fetch them prior to deploying brigade as part of the `make hack` target.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
