### PR TITLE
use array to store worker's jobs instead of map

### DIFF
--- a/sdk/v2/core/jobs_test.go
+++ b/sdk/v2/core/jobs_test.go
@@ -27,6 +27,7 @@ func TestJobsClientCreate(t *testing.T) {
 	const testEventID = "12345"
 	const testJobName = "Italian"
 	testJob := Job{
+		Name: testJobName,
 		Spec: JobSpec{
 			PrimaryContainer: JobContainerSpec{
 				ContainerSpec: ContainerSpec{
@@ -39,13 +40,12 @@ func TestJobsClientCreate(t *testing.T) {
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				defer r.Body.Close()
-				require.Equal(t, http.MethodPut, r.Method)
+				require.Equal(t, http.MethodPost, r.Method)
 				require.Equal(
 					t,
 					fmt.Sprintf(
-						"/v2/events/%s/worker/jobs/%s",
+						"/v2/events/%s/worker/jobs",
 						testEventID,
-						testJobName,
 					),
 					r.URL.Path,
 				)
@@ -64,7 +64,6 @@ func TestJobsClientCreate(t *testing.T) {
 	err := client.Create(
 		context.Background(),
 		testEventID,
-		testJobName,
 		testJob,
 	)
 	require.NoError(t, err)

--- a/sdk/v2/core/workers.go
+++ b/sdk/v2/core/workers.go
@@ -138,7 +138,19 @@ type Worker struct {
 	Status WorkerStatus `json:"status"`
 	// Jobs contains details of all Jobs spawned by the Worker during handling of
 	// the Event.
-	Jobs map[string]Job `json:"jobs,omitempty"`
+	Jobs []Job `json:"jobs,omitempty"`
+}
+
+// Job retrieves a Job by name. It returns a boolean indicating whether the
+// returned Job is the one requested (true) or a zero value (false) because no
+// Job with the specified name belongs to this Worker.
+func (w *Worker) Job(jobName string) (Job, bool) {
+	for _, j := range w.Jobs {
+		if j.Name == jobName {
+			return j, true
+		}
+	}
+	return Job{}, false
 }
 
 // WorkerSpec is the technical blueprint for a Worker.

--- a/v2/apiserver/internal/core/jobs_test.go
+++ b/v2/apiserver/internal/core/jobs_test.go
@@ -76,8 +76,10 @@ func TestJobsServiceCreate(t *testing.T) {
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
 							Worker: Worker{
-								Jobs: map[string]Job{
-									testJobName: {},
+								Jobs: []Job{
+									{
+										Name: testJobName,
+									},
 								},
 							},
 						}, nil
@@ -228,7 +230,7 @@ func TestJobsServiceCreate(t *testing.T) {
 					},
 				},
 				jobsStore: &mockJobsStore{
-					CreateFn: func(context.Context, string, string, Job) error {
+					CreateFn: func(context.Context, string, Job) error {
 						return errors.New("something went wrong")
 					},
 				},
@@ -264,7 +266,7 @@ func TestJobsServiceCreate(t *testing.T) {
 					},
 				},
 				jobsStore: &mockJobsStore{
-					CreateFn: func(context.Context, string, string, Job) error {
+					CreateFn: func(context.Context, string, Job) error {
 						return nil
 					},
 				},
@@ -311,7 +313,7 @@ func TestJobsServiceCreate(t *testing.T) {
 					},
 				},
 				jobsStore: &mockJobsStore{
-					CreateFn: func(context.Context, string, string, Job) error {
+					CreateFn: func(context.Context, string, Job) error {
 						return nil
 					},
 				},
@@ -361,7 +363,7 @@ func TestJobsServiceCreate(t *testing.T) {
 					},
 				},
 				jobsStore: &mockJobsStore{
-					CreateFn: func(_ context.Context, _ string, _ string, job Job) error {
+					CreateFn: func(_ context.Context, _ string, job Job) error {
 						// Assert that all expected environment redactions occurred
 						for k := range testEnvironment {
 							v, ok := job.Spec.PrimaryContainer.Environment[k]
@@ -413,8 +415,8 @@ func TestJobsServiceCreate(t *testing.T) {
 				testCase.service.Create(
 					context.Background(),
 					testEventID,
-					testJobName,
 					Job{
+						Name: testJobName,
 						Spec: JobSpec{
 							PrimaryContainer: JobContainerSpec{
 								ContainerSpec: ContainerSpec{
@@ -499,8 +501,9 @@ func TestJobsServiceStart(t *testing.T) {
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
 							Worker: Worker{
-								Jobs: map[string]Job{
-									testJobName: {
+								Jobs: []Job{
+									{
+										Name: testJobName,
 										Status: &JobStatus{
 											Phase: JobPhaseRunning,
 										},
@@ -524,8 +527,9 @@ func TestJobsServiceStart(t *testing.T) {
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
 							Worker: Worker{
-								Jobs: map[string]Job{
-									testJobName: {
+								Jobs: []Job{
+									{
+										Name: testJobName,
 										Status: &JobStatus{
 											Phase: JobPhasePending,
 										},
@@ -555,8 +559,9 @@ func TestJobsServiceStart(t *testing.T) {
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
 							Worker: Worker{
-								Jobs: map[string]Job{
-									testJobName: {
+								Jobs: []Job{
+									{
+										Name: testJobName,
 										Status: &JobStatus{
 											Phase: JobPhasePending,
 										},
@@ -595,8 +600,9 @@ func TestJobsServiceStart(t *testing.T) {
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
 							Worker: Worker{
-								Jobs: map[string]Job{
-									testJobName: {
+								Jobs: []Job{
+									{
+										Name: testJobName,
 										Status: &JobStatus{
 											Phase: JobPhasePending,
 										},
@@ -640,8 +646,9 @@ func TestJobsServiceStart(t *testing.T) {
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
 							Worker: Worker{
-								Jobs: map[string]Job{
-									testJobName: {
+								Jobs: []Job{
+									{
+										Name: testJobName,
 										Status: &JobStatus{
 											Phase: JobPhasePending,
 										},
@@ -745,8 +752,9 @@ func TestJobsServiceGetStatus(t *testing.T) {
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
 							Worker: Worker{
-								Jobs: map[string]Job{
-									testJobName: {
+								Jobs: []Job{
+									{
+										Name:   testJobName,
 										Status: &testJobStatus,
 									},
 								},
@@ -834,8 +842,9 @@ func TestJobsServiceWatchStatus(t *testing.T) {
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
 							Worker: Worker{
-								Jobs: map[string]Job{
-									testJobName: {
+								Jobs: []Job{
+									{
+										Name:   testJobName,
 										Status: &testJobStatus,
 									},
 								},
@@ -1004,8 +1013,10 @@ func TestJobsServiceCleanup(t *testing.T) {
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
 							Worker: Worker{
-								Jobs: map[string]Job{
-									testJobName: {},
+								Jobs: []Job{
+									{
+										Name: testJobName,
+									},
 								},
 							},
 						}, nil
@@ -1031,8 +1042,10 @@ func TestJobsServiceCleanup(t *testing.T) {
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
 							Worker: Worker{
-								Jobs: map[string]Job{
-									testJobName: {},
+								Jobs: []Job{
+									{
+										Name: testJobName,
+									},
 								},
 							},
 						}, nil
@@ -1063,8 +1076,10 @@ func TestJobsServiceCleanup(t *testing.T) {
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
 							Worker: Worker{
-								Jobs: map[string]Job{
-									testJobName: {},
+								Jobs: []Job{
+									{
+										Name: testJobName,
+									},
 								},
 							},
 						}, nil
@@ -1099,12 +1114,7 @@ func TestJobsServiceCleanup(t *testing.T) {
 }
 
 type mockJobsStore struct {
-	CreateFn func(
-		ctx context.Context,
-		eventID string,
-		jobName string,
-		job Job,
-	) error
+	CreateFn       func(ctx context.Context, eventID string, job Job) error
 	UpdateStatusFn func(
 		ctx context.Context,
 		eventID string,
@@ -1116,10 +1126,9 @@ type mockJobsStore struct {
 func (m *mockJobsStore) Create(
 	ctx context.Context,
 	eventID string,
-	jobName string,
 	job Job,
 ) error {
-	return m.CreateFn(ctx, eventID, jobName, job)
+	return m.CreateFn(ctx, eventID, job)
 }
 
 func (m *mockJobsStore) UpdateStatus(

--- a/v2/apiserver/internal/core/kubernetes/substrate.go
+++ b/v2/apiserver/internal/core/kubernetes/substrate.go
@@ -565,9 +565,9 @@ func (s *substrate) StartJob(
 	event core.Event,
 	jobName string,
 ) error {
-	jobSpec := event.Worker.Jobs[jobName].Spec
+	job, _ := event.Worker.Job(jobName)
 	if err :=
-		s.createJobPodFn(ctx, project, event, jobName, jobSpec); err != nil {
+		s.createJobPodFn(ctx, project, event, jobName, job.Spec); err != nil {
 		return errors.Wrapf(
 			err,
 			"error creating pod for event %q job %q",

--- a/v2/apiserver/internal/core/logs.go
+++ b/v2/apiserver/internal/core/logs.go
@@ -150,7 +150,7 @@ func (l *logsService) Stream(
 
 	if selector.Job != "" {
 		// Make sure the job exists
-		job, ok := event.Worker.Jobs[selector.Job]
+		job, ok := event.Worker.Job(selector.Job)
 		if !ok {
 			return nil, &meta.ErrNotFound{
 				Type: "Job",
@@ -158,7 +158,7 @@ func (l *logsService) Stream(
 			}
 		}
 		if selector.Container != selector.Job {
-			if _, ok = job.Spec.SidecarContainers[selector.Container]; !ok {
+			if _, ok := job.Spec.SidecarContainers[selector.Container]; !ok {
 				return nil, &meta.ErrNotFound{
 					Type: "JobContainer",
 					ID:   selector.Container,

--- a/v2/apiserver/internal/core/logs_test.go
+++ b/v2/apiserver/internal/core/logs_test.go
@@ -118,8 +118,10 @@ func TestLogsServiceStream(t *testing.T) {
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
 							Worker: Worker{
-								Jobs: map[string]Job{
-									"foo": {},
+								Jobs: []Job{
+									{
+										Name: "foo",
+									},
 								},
 							},
 						}, nil

--- a/v2/apiserver/internal/core/mongodb/jobs_store_test.go
+++ b/v2/apiserver/internal/core/mongodb/jobs_store_test.go
@@ -37,7 +37,7 @@ func TestJobsStoreCreate(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error updating spec of event")
+				require.Contains(t, err.Error(), "error creating event")
 			},
 		},
 		{
@@ -87,8 +87,9 @@ func TestJobsStoreCreate(t *testing.T) {
 				store.Create(
 					context.Background(),
 					testEvent,
-					testJobName,
-					core.Job{},
+					core.Job{
+						Name: testJobName,
+					},
 				),
 			)
 		})

--- a/v2/apiserver/internal/core/rest/jobs_endpoints.go
+++ b/v2/apiserver/internal/core/rest/jobs_endpoints.go
@@ -29,9 +29,9 @@ type JobsEndpoints struct {
 func (j *JobsEndpoints) Register(router *mux.Router) {
 	// Create job
 	router.HandleFunc(
-		"/v2/events/{eventID}/worker/jobs/{jobName}",
+		"/v2/events/{eventID}/worker/jobs",
 		j.AuthFilter.Decorate(j.create),
-	).Methods(http.MethodPut)
+	).Methods(http.MethodPost)
 
 	// Start job
 	router.HandleFunc(
@@ -70,7 +70,6 @@ func (j *JobsEndpoints) create(w http.ResponseWriter, r *http.Request) {
 				return nil, j.Service.Create(
 					r.Context(),
 					mux.Vars(r)["eventID"],
-					mux.Vars(r)["jobName"],
 					job,
 				)
 			},

--- a/v2/apiserver/internal/core/workers.go
+++ b/v2/apiserver/internal/core/workers.go
@@ -106,7 +106,19 @@ type Worker struct {
 	HashedToken string `json:"-" bson:"hashedToken"`
 	// Jobs contains details of all Jobs spawned by the Worker during handling of
 	// the Event.
-	Jobs map[string]Job `json:"jobs,omitempty" bson:"jobs,omitempty"`
+	Jobs []Job `json:"jobs,omitempty" bson:"jobs"`
+}
+
+// Job retrieves a Job by name. It returns a boolean indicating whether the
+// returned Job is the one requested (true) or a zero value (false) because no
+// Job with the specified name belongs to this Worker.
+func (w *Worker) Job(jobName string) (Job, bool) {
+	for _, j := range w.Jobs {
+		if j.Name == jobName {
+			return j, true
+		}
+	}
+	return Job{}, false
 }
 
 // WorkerSpec is the technical blueprint for a Worker.

--- a/v2/apiserver/schemas/job.json
+++ b/v2/apiserver/schemas/job.json
@@ -143,6 +143,14 @@
 		"kind": {
 			"$ref": "#/definitions/kind"
 		},
+		"name": {
+			"allOf": [
+				{
+					"$ref": "file:///brigade/schemas/common.json#/definitions/identifier"
+				}
+			],
+			"description": "The job's name; must be unique per worker"
+		},
 		"spec": {
 			"$ref": "#/definitions/jobSpec"
 		}

--- a/v2/scheduler/jobs.go
+++ b/v2/scheduler/jobs.go
@@ -156,7 +156,7 @@ outerLoop:
 				continue // Next message
 			}
 
-			job, exists := event.Worker.Jobs[jobName]
+			job, exists := event.Worker.Job(jobName)
 			if !exists {
 				s.jobLoopErrFn(
 					errors.Errorf(

--- a/v2/scheduler/jobs_test.go
+++ b/v2/scheduler/jobs_test.go
@@ -331,8 +331,9 @@ func TestRunJobLoop(t *testing.T) {
 						cancelFn()
 						return core.Event{
 							Worker: &core.Worker{
-								Jobs: map[string]core.Job{
-									"bar": {
+								Jobs: []core.Job{
+									{
+										Name: "bar",
 										Status: &core.JobStatus{
 											Phase: core.JobPhaseRunning,
 										},
@@ -390,8 +391,9 @@ func TestRunJobLoop(t *testing.T) {
 					getEventFn: func(context.Context, string) (core.Event, error) {
 						return core.Event{
 							Worker: &core.Worker{
-								Jobs: map[string]core.Job{
-									"bar": {
+								Jobs: []core.Job{
+									{
+										Name: "bar",
 										Status: &core.JobStatus{
 											Phase: core.JobPhasePending,
 										},
@@ -451,8 +453,9 @@ func TestRunJobLoop(t *testing.T) {
 					getEventFn: func(context.Context, string) (core.Event, error) {
 						return core.Event{
 							Worker: &core.Worker{
-								Jobs: map[string]core.Job{
-									"bar": {
+								Jobs: []core.Job{
+									{
+										Name: "bar",
 										Status: &core.JobStatus{
 											Phase: core.JobPhasePending,
 										},

--- a/v2/worker/src/jobs.ts
+++ b/v2/worker/src/jobs.ts
@@ -28,14 +28,15 @@ export class Job extends BrigadierJob {
             rejectUnauthorized: false
           }
         ),
-        method: "put",
-        url: `${this.event.worker.apiAddress}/v2/events/${this.event.id}/worker/jobs/${this.name}`,
+        method: "post",
+        url: `${this.event.worker.apiAddress}/v2/events/${this.event.id}/worker/jobs`,
         headers: {
           Authorization: `Bearer ${this.event.worker.apiToken}`
         },
         data: {
           apiVersion: "brigade.sh/v2",
           kind: "Job",
+          name: this.name,
           spec: {
             primaryContainer: this.primaryContainer,
             sidecarContainers: this.sidecarContainers,


### PR DESCRIPTION
Fixes #1191 

The main challenge to cascading cancelations was to do it efficiently. Transitioning from workers having a map of job names --> job to workers having an _array_ of jobs with intrinsic names (the were extrinsic before) allows us to cascade cancellations much more efficiently on the database end.

The side effect of this change is that jobs associated with a given worker are an ordered list now instead of an unordered map. I initially I had preferred the map because map semantics enforced unique job names and didn't directly imply execution order. The downside to the map, however, was that if retrieving and displaying an event multiple times, the order of the jobs appears to shift around. `watch brig event get -i <id>` was really triggering my OCD. After cutting over to an array, the order of jobs in the list is the order in which the jobs were created.... I think that actually makes a lot of sense.