### PR TITLE
brigadier-- ditch maps, prefer objects with constrained key type

### DIFF
--- a/v2/brigadier/src/events.ts
+++ b/v2/brigadier/src/events.ts
@@ -15,10 +15,10 @@ export interface Event {
 export type EventHandler = (event: Event) => void
 
 export class EventRegistry {
-  protected handlers = new Map<string, EventHandler>()
+  protected handlers: { [key: string]: EventHandler } = {}
   
   public on(eventSource: string, eventType: string, eventHandler: EventHandler): this {
-    this.handlers.set(`${eventSource}:${eventType}`, eventHandler)
+    this.handlers[`${eventSource}:${eventType}`] = eventHandler
     return this
   }
 }

--- a/v2/brigadier/src/jobs.ts
+++ b/v2/brigadier/src/jobs.ts
@@ -5,7 +5,7 @@ const defaultTimeout: number = 1000 * 60 * 15
 export class Job {
   public name: string
   public primaryContainer: Container
-  public sidecarContainers = new Map<string, Container>()
+  public sidecarContainers: { [key: string]: Container } = {}
   public timeout: number = defaultTimeout
   public host: JobHost = new JobHost()
   protected event: Event
@@ -35,7 +35,7 @@ export class Container {
   public workingDirectory = ""
   public command: string[] = []
   public arguments: string[] = []
-  public environment = new Map<string, string>()
+  public environment: { [key: string]: string } = {}
   public workspaceMountPath = ""
   public sourceMountPath = ""
   public privileged = false
@@ -48,5 +48,5 @@ export class Container {
 
 export class JobHost {
   public os?: string
-  public nodeSelector: Map<string, string> = new Map<string, string>()
+  public nodeSelector: { [key: string]: string } = {}
 }

--- a/v2/brigadier/src/projects.ts
+++ b/v2/brigadier/src/projects.ts
@@ -1,4 +1,4 @@
 export interface Project {
   id: string
-  secrets: Map<string, string>
+  secrets: { [key: string]: string }
 }

--- a/v2/brigadier/src/workers.ts
+++ b/v2/brigadier/src/workers.ts
@@ -2,6 +2,6 @@ export interface Worker {
   apiAddress: string
   apiToken: string
   configFilesDirectory: string
-  defaultConfigFiles: Map<string, string>
+  defaultConfigFiles: { [key: string]: string }
   logLevel?: string
 }

--- a/v2/brigadier/test/events.ts
+++ b/v2/brigadier/test/events.ts
@@ -12,7 +12,7 @@ describe("events", () => {
       // EventRegistry and add an accessor so that we can get at handlers.
       class ER extends EventRegistry {
         public getHandler(source: string, type: string): EventHandler | undefined {
-          return this.handlers.get(`${source}:${type}`)
+          return this.handlers[`${source}:${type}`]
         }
       }
       it("adds the handler to the map", () => {

--- a/v2/brigadier/test/groups.ts
+++ b/v2/brigadier/test/groups.ts
@@ -12,7 +12,7 @@ describe("groups", () => {
       id: "123456789",
       project: {
         id: "manhattan",
-        secrets: new Map<string, string>()
+        secrets: {}
       },
       source: "foo",
       type: "bar",
@@ -20,7 +20,7 @@ describe("groups", () => {
         apiAddress: "",
         apiToken: "",
         configFilesDirectory: "",
-        defaultConfigFiles: new Map<string, string>()
+        defaultConfigFiles: {}
       }
     }
     describe("#add", () => {

--- a/v2/brigadier/test/jobs.ts
+++ b/v2/brigadier/test/jobs.ts
@@ -12,7 +12,7 @@ describe("jobs", () => {
         id: "123456789",
         project: {
           id: "manhattan",
-          secrets: new Map<string, string>()
+          secrets: {}
         },
         source: "foo",
         type: "bar",
@@ -20,14 +20,14 @@ describe("jobs", () => {
           apiAddress: "",
           apiToken: "",
           configFilesDirectory: "",
-          defaultConfigFiles: new Map<string, string>()
+          defaultConfigFiles: {}
         }
       }
       const job = new Job("my-name", "debian:latest", event)
       it("initializes fields properly", () => {
         assert.equal(job.name, "my-name")
         assert.deepEqual(new Container("debian:latest"), job.primaryContainer)
-        assert.deepEqual(new Map<string, Container>(), job.sidecarContainers)
+        assert.deepEqual({}, job.sidecarContainers)
         assert.equal(1000 * 60 * 15, job.timeout)
         assert.deepEqual(new JobHost(), job.host)
       })
@@ -42,7 +42,7 @@ describe("jobs", () => {
         assert.equal("IfNotPresent", container.imagePullPolicy)
         assert.deepEqual([], container.command)
         assert.deepEqual([], container.arguments)
-        assert.deepEqual(new Map<string, string>(), container.environment)
+        assert.deepEqual({}, container.environment)
         assert.isEmpty(container.workspaceMountPath)
         assert.isEmpty(container.sourceMountPath)
         assert.isFalse(container.privileged)
@@ -57,7 +57,7 @@ describe("jobs", () => {
       it("initializes fields properly", () => {
         assert.isUndefined(jobHost.os)
         assert.isDefined(jobHost.nodeSelector)
-        assert.equal(0, jobHost.nodeSelector.size)
+        assert.equal(0, Object.keys(jobHost.nodeSelector).length)
       })
     })
   })

--- a/v2/worker/src/events.ts
+++ b/v2/worker/src/events.ts
@@ -3,7 +3,7 @@ import { Event, EventRegistry as BrigadierEventRegistry } from "../../brigadier/
 class EventRegistry extends BrigadierEventRegistry {
 
   public fire(event: Event): void {
-    const handlerFn = this.handlers.get(`${event.source}:${event.type}`)
+    const handlerFn = this.handlers[`${event.source}:${event.type}`]
     if (handlerFn) {
       handlerFn(event) 
     }

--- a/v2/worker/test/events.ts
+++ b/v2/worker/test/events.ts
@@ -20,7 +20,7 @@ describe("events", () => {
             id: "123456789",
             project: {
               id: "manhattan",
-              secrets: new Map<string, string>()
+              secrets: {}
             },
             source: "foo",
             type: "bar",
@@ -28,7 +28,7 @@ describe("events", () => {
               apiAddress: "",
               apiToken: "",
               configFilesDirectory: "",
-              defaultConfigFiles: new Map<string, string>()
+              defaultConfigFiles: {}
             }
           })
           assert.isTrue(handlerCalled)
@@ -40,7 +40,7 @@ describe("events", () => {
             id: "123456789",
             project: {
               id: "manhattan",
-              secrets: new Map<string, string>()
+              secrets: {}
             },
             source: "bat",
             type: "baz",
@@ -48,7 +48,7 @@ describe("events", () => {
               apiAddress: "",
               apiToken: "",
               configFilesDirectory: "",
-              defaultConfigFiles: new Map<string, string>()
+              defaultConfigFiles: {}
             }
           })
           assert.isFalse(handlerCalled)

--- a/v2/worker/test/jobs.ts
+++ b/v2/worker/test/jobs.ts
@@ -13,7 +13,7 @@ describe("jobs", () => {
         id: "123456789",
         project: {
           id: "manhattan",
-          secrets: new Map<string, string>()
+          secrets: {}
         },
         source: "foo",
         type: "bar",
@@ -21,14 +21,14 @@ describe("jobs", () => {
           apiAddress: "",
           apiToken: "",
           configFilesDirectory: "",
-          defaultConfigFiles: new Map<string, string>()
+          defaultConfigFiles: {}
         }
       }
       const job = new Job("my-name", "debian:latest", event)
       it("initializes fields properly", () => {
         assert.equal(job.name, "my-name")
         assert.deepEqual(new Container("debian:latest"), job.primaryContainer)
-        assert.deepEqual(new Map<string, Container>(), job.sidecarContainers)
+        assert.deepEqual({}, job.sidecarContainers)
         assert.equal(1000 * 60 * 15, job.timeout)
         assert.deepEqual(new JobHost(), job.host)
         assert.isDefined(job.logger)


### PR DESCRIPTION
Similar to a recent change in the experimental TS/JS SDK. See https://github.com/krancour/brigade-sdk-for-js/pull/3.

TS Maps don't serialize to JSON in the way one might expect. As a result, I'm pretty sure that in the current state, any sidecar containers, environment variables, host selectors, and more are missing from the JSON representation of a new job when it reaches the server's create job endpoint.

To correct this _and_ to simplify the programming model (TS Maps aren't super pleasant to work with, imho), this PR eliminates all further usage of TS Maps from brigadier, preferring objects with constrained key types instead.

I have vetted the change with a `brigade.ts` that creates some pretty complex jobs.

```
import { Container, events, Job, logger } from "@brigadecore/brigadier"

logger.debug("Hello, World!")

events.on("github.com/brigadecore/brigade/cli", "exec", async event => {
  let fooJob = new Job("foo", "debian:latest", event)
  fooJob.primaryContainer.command = ["sh"]
  fooJob.primaryContainer.arguments = ["-c", "echo $FOO"]
  fooJob.primaryContainer.environment = {
    "FOO": "f000000"
  }
  fooJob.sidecarContainers.sidecar = new Container("debian:latest")
  fooJob.sidecarContainers.sidecar.command = ["sh"]
  fooJob.sidecarContainers.sidecar.arguments = ["-c", "echo $FOO"]
  fooJob.sidecarContainers.sidecar.environment = {
    "FOO": "I'm a sidecar!"
  }
  await fooJob.run()

  let barJob = new Job("bar", "debian:latest", event)
  barJob.primaryContainer.command = ["sh"]
  barJob.primaryContainer.arguments = ["-c", "echo $BAR"]
  barJob.primaryContainer.environment = {
    "BAR": "b@rrrrrr"
  }
  barJob.sidecarContainers.sidecar = new Container("debian:latest")
  barJob.sidecarContainers.sidecar.command = ["sh"]
  barJob.sidecarContainers.sidecar.arguments = ["-c", "echo $BAR"]
  barJob.sidecarContainers.sidecar.environment = {
    "BAR": "I'm a sidecar!"
  }
  await barJob.run()
})
```