### PR TITLE
change api version to be v2-alpha.1

### DIFF
--- a/examples/git/github-demo.yaml
+++ b/examples/git/github-demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: brigade.sh/v2
+apiVersion: brigade.sh/v2-alpha.1
 kind: Project
 metadata:
   id: github-demo

--- a/examples/javascript/dependencies-demo.yaml
+++ b/examples/javascript/dependencies-demo.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2
+apiVersion: brigade.sh/v2-alpha.1
 kind: Project
 metadata:
   id: dependencies-demo

--- a/examples/javascript/hello-world.yaml
+++ b/examples/javascript/hello-world.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2
+apiVersion: brigade.sh/v2-alpha.1
 kind: Project
 metadata:
   id: hello-world

--- a/examples/javascript/pipeline-demo.yaml
+++ b/examples/javascript/pipeline-demo.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2
+apiVersion: brigade.sh/v2-alpha.1
 kind: Project
 metadata:
   id: pipeline-demo

--- a/examples/typescript/dependencies-demo.yaml
+++ b/examples/typescript/dependencies-demo.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2
+apiVersion: brigade.sh/v2-alpha.1
 kind: Project
 metadata:
   id: dependencies-demo

--- a/examples/typescript/hello-world.yaml
+++ b/examples/typescript/hello-world.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2
+apiVersion: brigade.sh/v2-alpha.1
 kind: Project
 metadata:
   id: hello-world

--- a/examples/typescript/pipeline-demo.yaml
+++ b/examples/typescript/pipeline-demo.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2
+apiVersion: brigade.sh/v2-alpha.1
 kind: Project
 metadata:
   id: pipeline-demo

--- a/sdk/v2/meta/meta.go
+++ b/sdk/v2/meta/meta.go
@@ -4,7 +4,7 @@ import "time"
 
 // APIVersion represents the API and major version thereof with which this
 // version of the Brigade SDK is compatible.
-const APIVersion = "brigade.sh/v2"
+const APIVersion = "brigade.sh/v2-alpha.1"
 
 // TypeMeta represents metadata about a resource type to help clients and
 // servers mutually head off potential confusion over types (and versions

--- a/v2/apiserver/internal/meta/meta.go
+++ b/v2/apiserver/internal/meta/meta.go
@@ -4,7 +4,7 @@ import "time"
 
 // APIVersion represents the API and major version thereof with which this
 // version of the Brigade API server is compatible.
-const APIVersion = "brigade.sh/v2"
+const APIVersion = "brigade.sh/v2-alpha.1"
 
 // TypeMeta represents metadata about a resource type to help clients and
 // servers mutually head off potential confusion over types (and versions of

--- a/v2/apiserver/internal/meta/testing/meta.go
+++ b/v2/apiserver/internal/meta/testing/meta.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const apiVersion = "brigade.sh/v2"
+const apiVersion = "brigade.sh/v2-alpha.1"
 
 func RequireAPIVersionAndType(
 	t *testing.T,

--- a/v2/apiserver/schemas/common.json
+++ b/v2/apiserver/schemas/common.json
@@ -8,7 +8,7 @@
 		"apiVersion": {
 			"type": "string",
 			"description": "The major version of the Brigade API with which this object conforms",
-			"enum": ["brigade.sh/v2"]
+			"enum": ["brigade.sh/v2-alpha.1"]
 		},
 
 		"description": {

--- a/v2/worker/src/jobs.ts
+++ b/v2/worker/src/jobs.ts
@@ -34,7 +34,7 @@ export class Job extends BrigadierJob {
           Authorization: `Bearer ${this.event.worker.apiToken}`
         },
         data: {
-          apiVersion: "brigade.sh/v2",
+          apiVersion: "brigade.sh/v2-alpha.1",
           kind: "Job",
           name: this.name,
           spec: {


### PR DESCRIPTION
I feel as if this CYA maneuver is in order before we cut an alpha release. This way we safeguard ourselves against anyone who may come along months from now trying to use an alpha.1 SDK or CLI with a newer API server that may have taken on breaking changes in the interim.

cc @radu-matei you'd want to account for this in your Rust SDK. I'll handle the JS/TS one.