### PR TITLE
Streamline brigadier publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage.txt
 node_modules/
 dist/
 charts/brigade/charts
+.npmrc
 .DS_Store
 
 # IDEs

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ifneq ($(SKIP_DOCKER),true)
 	JS_DOCKER_CMD := docker run \
 		-it \
 		--rm \
-		-e NPM_PASSWORD=$${NPM_PASSWORD} \
+		-e NPM_TOKEN=$${NPM_TOKEN} \
 		-e SKIP_DOCKER=true \
 		-v $(PROJECT_ROOT):/workspaces/brigade \
 		-w /workspaces/brigade \
@@ -223,11 +223,7 @@ publish: publish-brigadier push-images publish-chart publish-cli
 publish-brigadier: build-brigadier
 	$(JS_DOCKER_CMD) sh -c ' \
 		cd v2/brigadier && \
-		npm install -g npm-cli-login && \
-		npm-cli-login \
-			-u $(NPM_USERNAME) \
-			-e $(NPM_EMAIL) \
-			-p $${NPM_PASSWORD} && \
+		echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc && \
 		yarn publish \
 			--new-version $$(printf $(VERSION) | cut -c 2- ) \
 			--access public \

--- a/brigade.js
+++ b/brigade.js
@@ -83,10 +83,7 @@ jobs[buildBrigadierJobName] = buildBrigadierJob;
 const publishBrigadierJobName = "publish-brigadier";
 const publishBrigadierJob = (e, p) => {
   return new MakeTargetJob(publishBrigadierJobName, jsImg, e, {
-    "NPM_ORG": p.secrets.npmOrg,
-    "NPM_USERNAME": p.secrets.npmUsername,
-    "NPM_EMAIL": p.secrets.npmEmail,
-    "NPM_PASSWORD": p.secrets.npmPassword
+    "NPM_TOKEN": p.secrets.npmToken
   });
 }
 jobs[publishBrigadierJobName] = publishBrigadierJob;


### PR DESCRIPTION
This is a faster, more efficient way to publish brigadier to npmjs.com without a need for any third-party tools.

This approach is _already_ employed by the 1.x brigadier.