### PR TITLE
switch from krancour/go-tools to official brigadecore/go-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,7 @@ CLIENT_ARCH ?= $(shell go env GOARCH)
 
 ifneq ($(SKIP_DOCKER),true)
 	PROJECT_ROOT := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-	# https://github.com/krancour/go-tools
-	# https://hub.docker.com/repository/docker/krancour/go-tools
-	GO_DEV_IMAGE := krancour/go-tools:v0.1.0
+	GO_DEV_IMAGE := brigadecore/go-tools:v0.1.0
 	JS_DEV_IMAGE := node:12.3.1-stretch
 
 	GO_DOCKER_CMD := docker run \

--- a/brig/Dockerfile
+++ b/brig/Dockerfile
@@ -1,4 +1,4 @@
-FROM krancour/go-tools:v0.1.0
+FROM brigadecore/go-tools:v0.1.0
 ARG LDFLAGS
 ENV CGO_ENABLED=0
 WORKDIR /go/src/github.com/brigadecore/brigade

--- a/brigade-api/Dockerfile
+++ b/brigade-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM krancour/go-tools:v0.1.0
+FROM brigadecore/go-tools:v0.1.0
 ARG LDFLAGS
 ENV CGO_ENABLED=0
 WORKDIR /go/src/github.com/brigadecore/brigade

--- a/brigade-controller/Dockerfile
+++ b/brigade-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM krancour/go-tools:v0.1.0
+FROM brigadecore/go-tools:v0.1.0
 ARG LDFLAGS
 ENV CGO_ENABLED=0
 WORKDIR /go/src/github.com/brigadecore/brigade

--- a/brigade-cr-gateway/Dockerfile
+++ b/brigade-cr-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM krancour/go-tools:v0.1.0
+FROM brigadecore/go-tools:v0.1.0
 ARG LDFLAGS
 ENV CGO_ENABLED=0
 WORKDIR /go/src/github.com/brigadecore/brigade

--- a/brigade-generic-gateway/Dockerfile
+++ b/brigade-generic-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM krancour/go-tools:v0.1.0
+FROM brigadecore/go-tools:v0.1.0
 ARG LDFLAGS
 ENV CGO_ENABLED=0
 WORKDIR /go/src/github.com/brigadecore/brigade

--- a/brigade-vacuum/Dockerfile
+++ b/brigade-vacuum/Dockerfile
@@ -1,4 +1,4 @@
-FROM krancour/go-tools:v0.1.0
+FROM brigadecore/go-tools:v0.1.0
 ARG LDFLAGS
 ENV CGO_ENABLED=0
 WORKDIR /go/src/github.com/brigadecore/brigade

--- a/brigade.js
+++ b/brigade.js
@@ -9,7 +9,7 @@ const projectName = "brigade";
 const projectOrg = "brigadecore";
 
 // Go build defaults
-const goImg = "krancour/go-tools:v0.1.0";
+const goImg = "brigadecore/go-tools:v0.1.0";
 const gopath = "/go";
 const localPath = gopath + `/src/github.com/${projectOrg}/${projectName}`;
 


### PR DESCRIPTION
We'e been using our official `brigadecore/go-tools` to build the `v2` branch for quite some time now.

This PR cuts 1.x in `master` over to `brigadecore/go-tools` from its less official progenitor, `krancour/go-tools`.