### PR TITLE
[WIP] Replace groups with composite jobs

### DIFF
--- a/v2/brigadier/src/groups.ts
+++ b/v2/brigadier/src/groups.ts
@@ -1,12 +1,21 @@
 import { Job } from "./jobs"
 
+/**
+ * @deprecated Use Job.sequence or Job.parallel instead
+ */
 export class Group {
 
+  /**
+   * @deprecated Use Job.parallel followed by Job#run instead
+   */
   public static async runAll(jobs: Job[]): Promise<void[]> {
     const group = new Group(jobs)
     return group.runAll()
   }
 
+  /**
+   * @deprecated Use Job.sequence followed by Job#run instead
+   */
   public static async runEach(jobs: Job[]): Promise<void> {
     const group = new Group(jobs)
     return group.runEach()

--- a/v2/brigadier/src/index.ts
+++ b/v2/brigadier/src/index.ts
@@ -1,4 +1,4 @@
 export { events } from "./events"
 export { Group } from "./groups"
-export { Job, Container, JobHost } from "./jobs"
+export { Job, Container, JobHost, ContainerJob } from "./jobs"
 export { logger } from "./logger"

--- a/v2/brigadier/src/jobs.ts
+++ b/v2/brigadier/src/jobs.ts
@@ -2,7 +2,66 @@ import { Event } from "./events"
 
 const defaultTimeout: number = 1000 * 60 * 15
 
-export class Job {
+/**
+ * A Brigade job.
+ * 
+ * The factory methods on this type create jobs in various ways. Jobs do not
+ * run immediately when created. You must call the Job#run method to start
+ * the job running.
+ */
+export abstract class Job {
+  /**
+   * Runs the job.
+   */
+  public abstract run(): Promise<void>;
+
+  /**
+   * Specifies a job that runs in a container. By default, the container is simply
+   * executed (via its default entry point). Set the ContinerJob#tasks property to run
+   * specific commands in the container instead.
+   * @param name The name of the job
+   * @param image The container image to run in this job
+   * @param event The event that triggered the job
+   */
+  public static container(name: string, image: string,  event: Event): ContainerJob {
+    return new ContainerJob(name, image, event);
+  }
+
+  /**
+   * Specifies a job that consists of sub-jobs running in parallel.
+   * When run, all sub-jobs are started simultaneously (subject to scheduling
+   * constraints). The parallel job completes when all sub-jobs have
+   * completed.
+   * @param jobs The jobs to be run in parallel
+   */
+  public static parallel(jobs: Job[]): ParallelJob {
+    return new ParallelJob(jobs);
+  }
+
+  /**
+   * Specifies a job that consists of sub-jobs running one after another.
+   * A new sub-job is started only when the previous one completes.
+   * The sequence completes when the last job has completed (or when any
+   * job fails).
+   * @param jobs The jobs to be run in sequence
+   */
+  public static sequence(jobs: Job[]): SequentialJob {
+    return new SequentialJob(jobs);
+  }
+
+  /**
+   * Specifies a job that can be retried. The job will be run and re-run
+   * until either it succeeds or it has been tried `maxAttempts` times.
+   * (If maxAttempts is zero or less the job will not be tried at all.)
+   * @param job The job to be run and retried if necessary
+   * @param maxAttempts The maximum number of times to attempt the job
+   */
+  public static retryable(job: Job, maxAttempts: number): RetryableJob {
+    return new RetryableJob(job, maxAttempts);
+  }
+}
+
+export class ContainerJob extends Job {
   public name: string
   public primaryContainer: Container
   public sidecarContainers: { [key: string]: Container } = {}
@@ -15,6 +74,7 @@ export class Job {
     image: string,
     event: Event
   ) {
+    super();
     this.name = name
     this.primaryContainer = new Container(image)
     this.event = event
@@ -49,4 +109,48 @@ export class Container {
 export class JobHost {
   public os?: string
   public nodeSelector: { [key: string]: string } = {}
+}
+
+export class ParallelJob extends Job {
+  constructor(private readonly jobs: Job[]) {
+    super();
+  }
+
+  public async run(): Promise<void> {
+    const promises = this.jobs.map((job) => job.run());
+    await Promise.all(promises);
+  }
+}
+
+export class SequentialJob extends Job {
+  constructor(private readonly jobs: Job[]) {
+    super();
+  }
+
+  public async run(): Promise<void> {
+    for (const job of this.jobs) {
+      await job.run();
+    }
+  }
+}
+
+export class RetryableJob extends Job {
+  constructor(private readonly job: Job, private readonly maxAttempts: number) {
+    super();
+  }
+
+  public async run(): Promise<void> {
+    let attemptCount = 0;
+    while (attemptCount < this.maxAttempts) {
+      attemptCount++;
+      try {
+        await this.job.run();
+        return;
+      } catch (e) {
+        if (attemptCount >= this.maxAttempts) {
+          throw e;
+        }
+      }
+    }
+  }
 }

--- a/v2/brigadier/test/jobs.ts
+++ b/v2/brigadier/test/jobs.ts
@@ -4,26 +4,29 @@ import { assert } from "chai"
 import { Event } from "../src/events"
 import { Job, Container, JobHost } from "../src/jobs"
 
+import { MockJob } from "./mocks"
+
 describe("jobs", () => {
+
+  const event: Event = {
+    id: "123456789",
+    project: {
+      id: "manhattan",
+      secrets: {}
+    },
+    source: "foo",
+    type: "bar",
+    worker: {
+      apiAddress: "",
+      apiToken: "",
+      configFilesDirectory: "",
+      defaultConfigFiles: {}
+    }
+  }
 
   describe("Job", () => {
     describe("#constructor", () => {
-      const event: Event = {
-        id: "123456789",
-        project: {
-          id: "manhattan",
-          secrets: {}
-        },
-        source: "foo",
-        type: "bar",
-        worker: {
-          apiAddress: "",
-          apiToken: "",
-          configFilesDirectory: "",
-          defaultConfigFiles: {}
-        }
-      }
-      const job = new Job("my-name", "debian:latest", event)
+      const job = Job.container("my-name", "debian:latest", event)
       it("initializes fields properly", () => {
         assert.equal(job.name, "my-name")
         assert.deepEqual(new Container("debian:latest"), job.primaryContainer)
@@ -62,4 +65,126 @@ describe("jobs", () => {
     })
   })
 
+  describe("SequentialJob", () => {
+    it("runs sub-jobs in sequence", (done) => {
+      const ledger: string[] = []
+      const job0 = new MockJob("first", "debian:latest", event, () => {
+        ledger.push("first")
+      })
+      const job1 = new MockJob("second", "debian:latest", event, () => {
+        ledger.push("second")
+      })
+      const job2 = new MockJob("third", "debian:latest", event, () => {
+        ledger.push("third")
+      })
+      const sequence = Job.sequence([job0, job1, job2])
+      sequence.run().then(() => {
+        assert.deepEqual(ledger, ["first", "second", "third"])
+        done()
+      })
+    })
+    it("stops processing on an error", (done) => {
+      const ledger: string[] = []
+      const job0 = new MockJob("first", "debian:latest", event, () => {
+        ledger.push("first")
+      })
+      const job1 = new MockJob("second", "debian:latest", event, () => {
+        ledger.push("second")
+      })
+      job1.fail = true
+      const job2 = new MockJob("third", "debian:latest", event, () => {
+        ledger.push("third")
+      })
+      Job.sequence([job0, job1, job2]).run().then(() => {
+        done("expected error on job 1")
+      }).catch(msg => {
+        assert.equal(msg, "Failed")
+        assert.equal(ledger.length, 2)  // job0 and job1 pushed, but then job1 failed
+        done()
+      })
+    })
+  })
+
+  describe("ParallelJob", () => {
+    it("runs jobs asynchronously", (done) => {
+      const ledger: string[] = []
+      const job0 = new MockJob("first", "debian:latest", event, () => {
+        ledger.push("first")
+      })
+      job0.delay = 10
+      const job1 = new MockJob("second", "debian:latest", event, () => {
+        ledger.push("second")
+      })
+      job1.delay = 5
+      const job2 = new MockJob("third", "debian:latest", event, () => {
+        ledger.push("third")
+      })
+      job2.delay = 1
+      Job.parallel([job0, job1, job2]).run().then(() => {
+        // If these were executed concurrently, they should finish in reverse
+        // order because of the specific delay values on each.
+        assert.deepEqual(ledger, ["third", "second", "first"])
+        done()
+      })
+    })
+    it("stops processing on an error", (done) => {
+      const job0 = new MockJob("first", "debian:latest", event, () => () => {
+        // Do nothing
+      })
+      const job1 = new MockJob("second", "debian:latest", event, () => () => {
+        // Do nothing
+      })
+      job1.fail = true
+      const job2 = new MockJob("third", "debian:latest", event, () => () => {
+        // Do nothing
+      })
+      Job.parallel([job0, job1, job2]).run().then(() => {
+        done("expected error on job 2")
+      }).catch(msg => {
+        assert.equal(msg, "Failed")
+        done()
+      })
+    })
+  })
+
+  describe("RetryableJob", () => {
+    it("runs once if the job succeeds", (done) => {
+      const ledger: number[] = []
+      let index = 0
+      const job = new MockJob("first", "debian:latest", event, () => {
+        ledger.push(++index)
+      })
+      Job.retryable(job, 5).run().then(() => {
+        assert.deepEqual(ledger, [1])
+        done()
+      })
+    })
+    it("retries on an error, until it succeeds", (done) => {
+      const ledger: number[] = []
+      let index = 0
+      const job = new MockJob("first", "debian:latest", event, () => {
+        ledger.push(++index)
+        job.fail = index < 3
+      })
+      Job.retryable(job, 5).run().then(() => {
+        assert.deepEqual(ledger, [1, 2, 3])
+        done()
+      })
+    })
+    it("stops retrying after maxAttempts", (done) => {
+      const ledger: number[] = []
+      let index = 0
+      const job = new MockJob("first", "debian:latest", event, () => {
+        ledger.push(++index)
+      })
+      job.fail = true
+      Job.retryable(job, 5).run().then(() => {
+        done("expected error")
+      }).catch(msg => {
+        assert.equal(msg, "Failed")
+        assert.deepEqual(ledger, [1, 2, 3, 4, 5])
+        done()
+      })
+    })
+  })
 })

--- a/v2/brigadier/test/mocks.ts
+++ b/v2/brigadier/test/mocks.ts
@@ -1,11 +1,11 @@
 import { setTimeout } from "timers"
 
 import { Event } from "../src/events"
-import { Job } from "../src/jobs"
+import { ContainerJob } from "../src/jobs"
 
 // MockJob extends Job to make success or failure configurable. This allows us
 // to force Job failures when a test case requires it.
-export class MockJob extends Job {
+export class MockJob extends ContainerJob {
   public fail = false
   public delay = 1 // Just enough to cause the event loop to sleep.
   public handler: () => void

--- a/v2/worker/src/brigadier.ts
+++ b/v2/worker/src/brigadier.ts
@@ -9,5 +9,5 @@ export { Container, Group, JobHost }  from "../../brigadier/src"
 
 // These are custom implementations of resources ordinarily found in Brigadier
 export { events } from "./events"
-export { Job } from "./jobs"
+export { ContainerJob } from "./jobs"
 export { logger } from "./logger"

--- a/v2/worker/src/jobs.ts
+++ b/v2/worker/src/jobs.ts
@@ -7,11 +7,11 @@ import axios from "axios"
 import { Logger } from "winston" 
 
 import { Event } from "../../brigadier/src/events"
-import { Job as BrigadierJob } from "../../brigadier/src"
+import { ContainerJob as BrigadierContainerJob } from "../../brigadier/src"
 
 import { logger } from "./brigadier"
 
-export class Job extends BrigadierJob {
+export class ContainerJob extends BrigadierContainerJob {
   logger: Logger
 
   constructor(name: string, image: string, event: Event) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR (https://github.com/brigadecore/brigade/blob/master/docs/topics/developers.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).

2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
-->

**What this PR does / why we need it**:

The current Brigadier library allows you to run a set of jobs in parallel or in sequence using the `Group` class.  However, this restricts composition to a single level.  For example, this does not support running a set of pipelines in parallel where each pipeline is sequential.  Of course users can code this up themselves using JavaScript (just as they could code up groups), but it would be nice to build this in.

This PR therefore proposes that jobs can be composed to create new jobs.  For example, the `Job.sequence(...)` combinator produces a Job which, when run, runs all its sub-jobs in sequence, e.g.:

```javascript
function renderFrame(source) {
  return Job.sequence([
    Job.container(`triangulate-${source}`, "blender/triangles:v0.9.0"),
    Job.container(`reticulate-${source}`, "itowlson/reticulate:v1.3.0"),
    Job.container(`render-${source}`, "blender/render:v0.8.0")
  ]);
}
```

Because the result of this is a Job, it can itself be passed to the `Job.parallel` combinator.  The result of this is a more composable API surface for job definition.

```
function renderAllFrames(sources) {
  const pipelines = sources.map((source) => renderFrames(source));
  return Job.parallel(pipelines);
}

on("render", (e) => {
  Job.sequence([
    renderAllFrames(e.sources),
    stitchFramesToMovie()
  ]).run();
});
```

As an exploration of how this approach might enable further idioms, the PR also includes a `Job.retryable` combinator which produces a job that attempts a sub-job but retries if it fails.

This is a proposal for feedback (and I can only apologise that it has come so late in the 2.x release cycle.)

**Special notes for your reviewer**:

1. At this stage the Group class is kept but marked as deprecated.  This maximises backward compatibility.

2. I tentatively used Job for the base/factory type and renamed the current Job class to ContainerJob.  This blows backward compatibility out of the water and I am concerned it could cause problems, especially for JavaScript users who will not get it typechecked.  A safer approach might be to declare a `Runnable` interface - the combinators would then compose Runnables into Runnables, and container jobs could go back to being called Job.  But an interface cannot contain static methods, so what would we call the class where those factory methods lived?  (Assuming we even like factory methods - I feel `Job.sequence(...)` is nicer than `new SequentialJob(...)` but others might disagree?)

3. We could also consider dot-notation syntax for some of this e.g. `job1.followedBy(job2)`, `job1.inParallelWith(job2)`, `job.withRetry(5)`.  I think the combinators work better on the whole, but very much open to discussion.

4. I updated the unit tests and added some JSDoc, but I haven't updated the samples or other conceptual documentation.  We can do this once we agree on item 2.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

NOTE: contains some documentation but not enough to ship with