### PR TITLE
fix display of job names in cli event get command

### DIFF
--- a/v2/cli/event_commands.go
+++ b/v2/cli/event_commands.go
@@ -542,7 +542,7 @@ func eventGet(c *cli.Context) error {
 			fmt.Printf("\nEvent %q jobs:\n\n", event.ID)
 			table = uitable.New()
 			table.AddRow("NAME", "STARTED", "ENDED", "PHASE")
-			for jobName, job := range event.Worker.Jobs {
+			for _, job := range event.Worker.Jobs {
 				jobStatus := job.Status
 				var started, ended string
 				if jobStatus.Started != nil {
@@ -554,7 +554,7 @@ func eventGet(c *cli.Context) error {
 						duration.ShortHumanDuration(time.Since(*jobStatus.Ended))
 				}
 				table.AddRow(
-					jobName,
+					job.Name,
 					started,
 					ended,
 					jobStatus.Phase,


### PR DESCRIPTION
After we switched from maps of jobs to arrays of jobs, `event get` ops in the CLI have ben showing job indices instead of job name. This PR fixes that.