### PR TITLE
feat(*): delete logs on event and project deletion

### DIFF
--- a/charts/brigade/templates/logger/secret.yaml
+++ b/charts/brigade/templates/logger/secret.yaml
@@ -54,9 +54,10 @@ stringData:
       <record>
         component ${record.dig("kubernetes", "labels", "brigade_sh/component")}
         event     ${record.dig("kubernetes", "labels", "brigade_sh/event")}
+        project   ${record.dig("kubernetes", "labels", "brigade_sh/project")}
         container ${record.dig("kubernetes", "container_name")}
       </record>
-      keep_keys component,event,worker,container,time,log
+      keep_keys component,event,project,worker,container,time,log
     </filter>
 
     <filter job>
@@ -66,10 +67,11 @@ stringData:
       <record>
         component ${record.dig("kubernetes", "labels", "brigade_sh/component")}
         event     ${record.dig("kubernetes", "labels", "brigade_sh/event")}
+        project   ${record.dig("kubernetes", "labels", "brigade_sh/project")}
         job       ${record.dig("kubernetes", "labels", "brigade_sh/job")}
         container ${record.dig("kubernetes", "container_name")}
       </record>
-      keep_keys component,event,worker,job,container,time,log
+      keep_keys component,event,project,worker,job,container,time,log
     </filter>
 
     <match worker job>

--- a/charts/brigade/templates/logger/secret.yaml
+++ b/charts/brigade/templates/logger/secret.yaml
@@ -96,11 +96,6 @@ stringData:
 
       collection logs
 
-      {{- if or .Values.mongodb.enabled (not .Values.externalMongodb.isCosmosdb) }}
-      capped
-      capped_size 1024m
-      {{- end }}
-
       time_key time
 
       <buffer>

--- a/v2/apiserver/internal/core/common_test.go
+++ b/v2/apiserver/internal/core/common_test.go
@@ -238,3 +238,47 @@ func (m *mockSubstrate) DeleteWorkerAndJobs(
 ) error {
 	return m.DeleteWorkerAndJobsFn(ctx, project, event)
 }
+
+type mockLogsStore struct {
+	StreamLogsFn func(
+		ctx context.Context,
+		project Project,
+		event Event,
+		selector LogsSelector,
+		opts LogStreamOptions,
+	) (<-chan LogEntry, error)
+
+	DeleteEventLogsFn func(
+		ctx context.Context,
+		id string,
+	) error
+
+	DeleteProjectLogsFn func(
+		ctx context.Context,
+		id string,
+	) error
+}
+
+func (m *mockLogsStore) StreamLogs(
+	ctx context.Context,
+	project Project,
+	event Event,
+	selector LogsSelector,
+	opts LogStreamOptions,
+) (<-chan LogEntry, error) {
+	return m.StreamLogsFn(ctx, project, event, selector, opts)
+}
+
+func (m *mockLogsStore) DeleteEventLogs(
+	ctx context.Context,
+	id string,
+) error {
+	return m.DeleteEventLogsFn(ctx, id)
+}
+
+func (m *mockLogsStore) DeleteProjectLogs(
+	ctx context.Context,
+	id string,
+) error {
+	return m.DeleteProjectLogsFn(ctx, id)
+}

--- a/v2/apiserver/internal/core/events.go
+++ b/v2/apiserver/internal/core/events.go
@@ -237,7 +237,7 @@ type eventsService struct {
 	authorize           libAuthz.AuthorizeFn
 	projectsStore       ProjectsStore
 	eventsStore         EventsStore
-	logsStore           LogsStore
+	logsStore           CoolLogsStore
 	substrate           Substrate
 	createSingleEventFn func(context.Context, Project, Event) (Event, error)
 }
@@ -247,7 +247,7 @@ func NewEventsService(
 	authorizeFn libAuthz.AuthorizeFn,
 	projectsStore ProjectsStore,
 	eventsStore EventsStore,
-	logsStore LogsStore,
+	logsStore CoolLogsStore,
 	substrate Substrate,
 ) EventsService {
 	e := &eventsService{
@@ -603,7 +603,7 @@ func (e *eventsService) Delete(ctx context.Context, id string) error {
 		)
 	}
 
-	return e.logsStore.Delete(ctx, event)
+	return e.logsStore.DeleteEventLogs(ctx, id)
 }
 
 func (e *eventsService) DeleteMany(
@@ -667,9 +667,9 @@ func (e *eventsService) DeleteMany(
 					))
 				}
 
-				if err := e.logsStore.Delete(
+				if err := e.logsStore.DeleteEventLogs(
 					context.Background(), // deliberately not using ctx
-					event,
+					event.ID,
 				); err != nil {
 					log.Println(errors.Wrapf(
 						err,

--- a/v2/apiserver/internal/core/events_test.go
+++ b/v2/apiserver/internal/core/events_test.go
@@ -929,7 +929,7 @@ func TestEventsServiceDelete(t *testing.T) {
 					},
 				},
 				logsStore: &mockLogsStore{
-					DeleteFn: func(context.Context, Event) error {
+					DeleteEventLogsFn: func(context.Context, string) error {
 						return errors.New("error deleting logs")
 					},
 				},
@@ -962,7 +962,7 @@ func TestEventsServiceDelete(t *testing.T) {
 					},
 				},
 				logsStore: &mockLogsStore{
-					DeleteFn: func(context.Context, Event) error {
+					DeleteEventLogsFn: func(context.Context, string) error {
 						return nil
 					},
 				},

--- a/v2/apiserver/internal/core/kubernetes/logs_store.go
+++ b/v2/apiserver/internal/core/kubernetes/logs_store.go
@@ -117,12 +117,3 @@ func podNameFromSelector(eventID string, selector core.LogsSelector) string {
 	}
 	return myk8s.JobPodName(eventID, selector.Job) // We want job logs
 }
-
-// TODO: Delete for the k8s/warm logs store isn't really applicable... should
-// we no-op and return nil *or* explicitly return an error?
-//
-// Or, do we only expose the method on the mongodb implementation and then
-// invoke after type assertion?
-func (l *logsStore) Delete(ctx context.Context, event core.Event) error {
-	return nil
-}

--- a/v2/apiserver/internal/core/kubernetes/logs_store.go
+++ b/v2/apiserver/internal/core/kubernetes/logs_store.go
@@ -117,3 +117,12 @@ func podNameFromSelector(eventID string, selector core.LogsSelector) string {
 	}
 	return myk8s.JobPodName(eventID, selector.Job) // We want job logs
 }
+
+// TODO: Delete for the k8s/warm logs store isn't really applicable... should
+// we no-op and return nil *or* explicitly return an error?
+//
+// Or, do we only expose the method on the mongodb implementation and then
+// invoke after type assertion?
+func (l *logsStore) Delete(ctx context.Context, event core.Event) error {
+	return nil
+}

--- a/v2/apiserver/internal/core/logs.go
+++ b/v2/apiserver/internal/core/logs.go
@@ -206,7 +206,19 @@ type LogsStore interface {
 		selector LogsSelector,
 		opts LogStreamOptions,
 	) (<-chan LogEntry, error)
+}
 
-	// Delete deletes all logs associated with the provided event.
-	Delete(ctx context.Context, event Event) error
+// CoolLogsStore is an interface for components that implement "cool" Log
+// persistence concerns.  These log store types are intended to act as
+// longterm storehouses for worker and job logs after they have reached a
+// terminal state. Thus, log deletion methods are prudent for managing
+// the size of the underlying store.
+type CoolLogsStore interface {
+	LogsStore
+
+	// DeleteEventLogs deletes all logs associated with the provided event.
+	DeleteEventLogs(ctx context.Context, id string) error
+
+	// DeleteProjectLogs deletes all logs associated with the provided project.
+	DeleteProjectLogs(ctx context.Context, id string) error
 }

--- a/v2/apiserver/internal/core/logs.go
+++ b/v2/apiserver/internal/core/logs.go
@@ -206,4 +206,7 @@ type LogsStore interface {
 		selector LogsSelector,
 		opts LogStreamOptions,
 	) (<-chan LogEntry, error)
+
+	// Delete deletes all logs associated with the provided event.
+	Delete(ctx context.Context, event Event) error
 }

--- a/v2/apiserver/internal/core/logs_test.go
+++ b/v2/apiserver/internal/core/logs_test.go
@@ -333,35 +333,3 @@ func TestLogsServiceStream(t *testing.T) {
 		})
 	}
 }
-
-type mockLogsStore struct {
-	StreamLogsFn func(
-		ctx context.Context,
-		project Project,
-		event Event,
-		selector LogsSelector,
-		opts LogStreamOptions,
-	) (<-chan LogEntry, error)
-
-	DeleteFn func(
-		ctx context.Context,
-		event Event,
-	) error
-}
-
-func (m *mockLogsStore) StreamLogs(
-	ctx context.Context,
-	project Project,
-	event Event,
-	selector LogsSelector,
-	opts LogStreamOptions,
-) (<-chan LogEntry, error) {
-	return m.StreamLogsFn(ctx, project, event, selector, opts)
-}
-
-func (m *mockLogsStore) Delete(
-	ctx context.Context,
-	event Event,
-) error {
-	return m.DeleteFn(ctx, event)
-}

--- a/v2/apiserver/internal/core/logs_test.go
+++ b/v2/apiserver/internal/core/logs_test.go
@@ -342,6 +342,11 @@ type mockLogsStore struct {
 		selector LogsSelector,
 		opts LogStreamOptions,
 	) (<-chan LogEntry, error)
+
+	DeleteFn func(
+		ctx context.Context,
+		event Event,
+	) error
 }
 
 func (m *mockLogsStore) StreamLogs(
@@ -352,4 +357,11 @@ func (m *mockLogsStore) StreamLogs(
 	opts LogStreamOptions,
 ) (<-chan LogEntry, error) {
 	return m.StreamLogsFn(ctx, project, event, selector, opts)
+}
+
+func (m *mockLogsStore) Delete(
+	ctx context.Context,
+	event Event,
+) error {
+	return m.DeleteFn(ctx, event)
 }

--- a/v2/apiserver/internal/core/mongodb/logs_store.go
+++ b/v2/apiserver/internal/core/mongodb/logs_store.go
@@ -22,7 +22,7 @@ type logsStore struct {
 // and stored log entries-- a process which necessarily introduces some latency.
 // Callers should favor another implementation of the core.LogsStore interface
 // and fall back on this implementation when the other fails.
-func NewLogsStore(database *mongo.Database) core.LogsStore {
+func NewLogsStore(database *mongo.Database) core.CoolLogsStore {
 	return &logsStore{
 		collection: database.Collection("logs"),
 	}
@@ -85,16 +85,36 @@ func criteriaFromSelector(
 	return criteria
 }
 
-// Delete deletes all logs associated with the provided event from the
+// DeleteEventLogs deletes all logs associated with the provided event from the
 // underlying mongo store.
-func (l *logsStore) Delete(ctx context.Context, event core.Event) error {
+func (l *logsStore) DeleteEventLogs(
+	ctx context.Context,
+	id string,
+) error {
 	if _, err := l.collection.DeleteMany(
 		ctx,
 		bson.M{
-			"event": event.ID,
+			"event": id,
 		},
 	); err != nil {
-		return errors.Wrapf(err, "error deleting logs for event %q", event.ID)
+		return errors.Wrapf(err, "error deleting logs for event %q", id)
+	}
+	return nil
+}
+
+// DeleteProjectLogs deletes all logs associated with the provided project from
+// the underlying mongo store.
+func (l *logsStore) DeleteProjectLogs(
+	ctx context.Context,
+	id string,
+) error {
+	if _, err := l.collection.DeleteMany(
+		ctx,
+		bson.M{
+			"project": id,
+		},
+	); err != nil {
+		return errors.Wrapf(err, "error deleting logs for project %q", id)
 	}
 	return nil
 }

--- a/v2/apiserver/internal/core/mongodb/logs_store.go
+++ b/v2/apiserver/internal/core/mongodb/logs_store.go
@@ -84,3 +84,17 @@ func criteriaFromSelector(
 	criteria["container"] = selector.Container
 	return criteria
 }
+
+// Delete deletes all logs associated with the provided event from the
+// underlying mongo store.
+func (l *logsStore) Delete(ctx context.Context, event core.Event) error {
+	if _, err := l.collection.DeleteMany(
+		ctx,
+		bson.M{
+			"event": event.ID,
+		},
+	); err != nil {
+		return errors.Wrapf(err, "error deleting logs for event %q", event.ID)
+	}
+	return nil
+}

--- a/v2/apiserver/internal/core/projects.go
+++ b/v2/apiserver/internal/core/projects.go
@@ -162,6 +162,7 @@ type projectsService struct {
 	authorize            libAuthz.AuthorizeFn
 	projectsStore        ProjectsStore
 	eventsStore          EventsStore
+	logsStore            CoolLogsStore
 	roleAssignmentsStore authz.RoleAssignmentsStore
 	substrate            Substrate
 }
@@ -171,6 +172,7 @@ func NewProjectsService(
 	authorizeFn libAuthz.AuthorizeFn,
 	projectsStore ProjectsStore,
 	eventsStore EventsStore,
+	logsStore CoolLogsStore,
 	roleAssignmentsStore authz.RoleAssignmentsStore,
 	substrate Substrate,
 ) ProjectsService {
@@ -178,6 +180,7 @@ func NewProjectsService(
 		authorize:            authorizeFn,
 		projectsStore:        projectsStore,
 		eventsStore:          eventsStore,
+		logsStore:            logsStore,
 		roleAssignmentsStore: roleAssignmentsStore,
 		substrate:            substrate,
 	}
@@ -348,6 +351,15 @@ func (p *projectsService) Delete(ctx context.Context, id string) error {
 		return errors.Wrapf(
 			err,
 			"error deleting all events associated with project %q",
+			id,
+		)
+	}
+
+	// Delete all logs associated with this project
+	if err := p.logsStore.DeleteProjectLogs(ctx, id); err != nil {
+		return errors.Wrapf(
+			err,
+			"error deleting all logs associated with project %q",
 			id,
 		)
 	}

--- a/v2/apiserver/main.go
+++ b/v2/apiserver/main.go
@@ -42,7 +42,7 @@ func main() {
 	}
 
 	// Data stores
-	var coolLogsStore core.LogsStore
+	var coolLogsStore core.CoolLogsStore
 	var eventsStore core.EventsStore
 	var jobsStore core.JobsStore
 	var projectsStore core.ProjectsStore
@@ -151,6 +151,7 @@ func main() {
 		authorizer.Authorize,
 		projectsStore,
 		eventsStore,
+		coolLogsStore,
 		roleAssignmentsStore,
 		substrate,
 	)

--- a/v2/apiserver/main.go
+++ b/v2/apiserver/main.go
@@ -124,6 +124,7 @@ func main() {
 		authorizer.Authorize,
 		projectsStore,
 		eventsStore,
+		coolLogsStore,
 		substrate,
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adds logic to delete logs from cool storage (mongo) on event and project deletion
- In doing so, converts the logs collection from capped to regular (no manual deletes/removals possible with a capped collection)

Closes https://github.com/brigadecore/brigade/issues/1271

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
