### PR TITLE
fix(fluentd): strip tailing whitespace from worker/job logs

### DIFF
--- a/charts/brigade/templates/logger/secret.yaml
+++ b/charts/brigade/templates/logger/secret.yaml
@@ -52,6 +52,8 @@ stringData:
       enable_ruby
       renew_record true
       <record>
+        # strip tailing whitespace from log
+        log ${record["log"].rstrip}
         component ${record.dig("kubernetes", "labels", "brigade_sh/component")}
         event     ${record.dig("kubernetes", "labels", "brigade_sh/event")}
         project   ${record.dig("kubernetes", "labels", "brigade_sh/project")}
@@ -65,6 +67,8 @@ stringData:
       enable_ruby
       renew_record true
       <record>
+        # strip tailing whitespace from log
+        log ${record["log"].rstrip}
         component ${record.dig("kubernetes", "labels", "brigade_sh/component")}
         event     ${record.dig("kubernetes", "labels", "brigade_sh/event")}
         project   ${record.dig("kubernetes", "labels", "brigade_sh/project")}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds a fluentd record filter to remove trailing whitespace from worker and job logs headed for mongo

Closes https://github.com/brigadecore/brigade/issues/1261

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
