### PR TITLE
chore(server_test.go): disable flaky test

### DIFF
--- a/v2/apiserver/internal/lib/restmachinery/server_test.go
+++ b/v2/apiserver/internal/lib/restmachinery/server_test.go
@@ -187,16 +187,19 @@ func TestListenAndServe(t *testing.T) {
 				require.Equal(t, ctx.Err(), err)
 			},
 		},
-		{
-			name: "TLS not enabled",
-			setup: func() *ServerConfig {
-				return nil
-			},
-			assertions: func(ctx context.Context, err error) {
-				require.Error(t, err)
-				require.Equal(t, ctx.Err(), err)
-			},
-		},
+		// TODO: re-enable if/when we can fix its tendency for intermittent failure
+		// https://github.com/brigadecore/brigade/issues/1137
+		//
+		// {
+		// 	name: "TLS not enabled",
+		// 	setup: func() *ServerConfig {
+		// 		return nil
+		// 	},
+		// 	assertions: func(ctx context.Context, err error) {
+		// 		require.Error(t, err)
+		// 		require.Equal(t, ctx.Err(), err)
+		// 	},
+		// },
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

@krancour @radu-matei and I have all tried to pin down the reason for this test's flakiness (https://github.com/brigadecore/brigade/issues/1137) but alas, haven't been successful.  Since it still proves to be a disruption in CI for PRs, etc, I vote we disable it for now.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
