### PR TITLE
fix(role-assignment.json): allow for url/domain-like scopes

### DIFF
--- a/v2/apiserver/schemas/role-assignment.json
+++ b/v2/apiserver/schemas/role-assignment.json
@@ -50,7 +50,7 @@
 				"scope": {
 					"type": "string",
 					"description": "The event source this role should be scoped to",
-					"pattern": "^[a-z][a-z\\d-]*[a-z\\d]$",
+					"pattern": "^[a-z][a-z\\d./-]*[a-z\\d]$",
 					"minLength": 3,
 					"maxLength": 50
 				}

--- a/v2/apiserver/schemas/role-assignment.json
+++ b/v2/apiserver/schemas/role-assignment.json
@@ -50,7 +50,7 @@
 				"scope": {
 					"type": "string",
 					"description": "The event source this role should be scoped to",
-					"pattern": "^[a-z][a-z\\d./-]*[a-z\\d]$",
+					"pattern": "^[a-zA-Z][a-zA-Z\\d./-]*[a-zA-Z\\d]$",
 					"minLength": 3,
 					"maxLength": 50
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Updates the event scope to allow for domain/url-like sources.

I'm assuming adding `.` and `/` chars are sufficient for our needs and we didn't need to allow for `:` or other chars for full url support.

Closes https://github.com/brigadecore/brigade/issues/1301

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
