### PR TITLE
fix list subscribed project

### DIFF
--- a/v2/apiserver/internal/core/mongodb/projects_store.go
+++ b/v2/apiserver/internal/core/mongodb/projects_store.go
@@ -127,9 +127,7 @@ func (p *projectsStore) ListSubscribers(
 		},
 	}
 	if len(event.Labels) > 0 {
-		subscriptionMatchCriteria["labels"] = bson.M{
-			"labels": event.Labels,
-		}
+		subscriptionMatchCriteria["labels"] = event.Labels
 	}
 	findOptions := options.Find()
 	findOptions.SetSort(


### PR DESCRIPTION
Hacking on a new GitHub gateway exposed this bug-- label criteria are nested like this:

```
{
  ...
  "labels": {
    "labels": {
      "foo": "bar"
    }
  }
}
```

It's probably obvious that isn't what was intended and it is stopping us from locating projects subscribed to a particular event.

This worked at one time until that code was "simplified" (i.e. screwed up by yours truly).

Unit tests didn't catch this because the mocked out database doesn't perform actual queries.

Once our integration tests are up and running, we might consider a second set of persistence-related tests that execute against a real MongoDB instance.