### PR TITLE
feat(sessions_store.go): add index on 'expires' field for ttl cleanup

### DIFF
--- a/v2/apiserver/internal/authn/mongodb/sessions_store.go
+++ b/v2/apiserver/internal/authn/mongodb/sessions_store.go
@@ -26,6 +26,9 @@ func NewSessionsStore(database *mongo.Database) (authn.SessionsStore, error) {
 		context.WithTimeout(context.Background(), createIndexTimeout)
 	defer cancel()
 	unique := true
+	// Set the default expiration value to 0 so that each record's 'expires'
+	// field is used to determine actual expiration
+	defaultExpiry := int32(0)
 	collection := database.Collection("sessions")
 	if _, err := collection.Indexes().CreateMany(
 		ctx,
@@ -44,6 +47,14 @@ func NewSessionsStore(database *mongo.Database) (authn.SessionsStore, error) {
 				},
 				Options: &options.IndexOptions{
 					Unique: &unique,
+				},
+			},
+			{
+				Keys: bson.M{
+					"expires": 1,
+				},
+				Options: &options.IndexOptions{
+					ExpireAfterSeconds: &defaultExpiry,
 				},
 			},
 		},

--- a/v2/apiserver/internal/system/authn/token_auth.go
+++ b/v2/apiserver/internal/system/authn/token_auth.go
@@ -176,7 +176,8 @@ func (t *tokenAuthFilter) Decorate(handle http.HandlerFunc) http.HandlerFunc {
 					w,
 					http.StatusUnauthorized,
 					&meta.ErrAuthentication{
-						Reason: "Session not found. Please log in again.",
+						Reason: "Session not found or may have expired. " +
+							"Please log in again.",
 					},
 				)
 				return
@@ -224,6 +225,10 @@ func (t *tokenAuthFilter) Decorate(handle http.HandlerFunc) http.HandlerFunc {
 			)
 			return
 		}
+		// Note: although we have records in the sessions collection configured
+		// for TTL cleanup by mongo (per Expires), we wish to keep this check
+		// in case this setting is configurable in the future or mongo otherwise
+		// fails to clean them up.
 		if session.Expires != nil && time.Now().UTC().After(*session.Expires) {
 			t.writeResponse(
 				w,


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds an expiry index for each document in the sessions collection, to auto-cleanup per the 'expires' field

Closes https://github.com/brigadecore/brigade/issues/1146

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
