### PR TITLE
don't allow client disconnects to interrupt writes

### DIFF
--- a/v2/apiserver/internal/lib/restmachinery/request_context_filter.go
+++ b/v2/apiserver/internal/lib/restmachinery/request_context_filter.go
@@ -6,11 +6,11 @@ import (
 )
 
 // requestContextFilter is a filter that can decorate an HTTP handler function
-// such that requests are examined and IFF the request utilizes an HTTP method
-// that commonly mutates the system (for instance, POST commonly is used for
-// creates and PUT and PATCH are commonly used for updates), then the request's
-// context is REPLACED with the background context. The usefulness of this lies
-// in creating a guarantee that operations that mutate the system are
+// such that requests are examined and if and only if the request utilizes an
+// HTTP method that commonly mutates the system (for instance, POST commonly is
+// used for creates and PUT and PATCH are commonly used for updates), then the
+// request's context is REPLACED with the background context. The usefulness of
+// this lies in creating a guarantee that operations that mutate the system are
 // uninterruptible by impatient clients that might hang up in the middle of a
 // request that is running long, perhaps due to retry logic with exponential
 // backoff. The client can hang up if they wish, but operations that mutate the

--- a/v2/apiserver/internal/lib/restmachinery/request_context_filter.go
+++ b/v2/apiserver/internal/lib/restmachinery/request_context_filter.go
@@ -1,0 +1,43 @@
+package restmachinery
+
+import (
+	"context"
+	"net/http"
+)
+
+// requestContextFilter is a filter that can decorate an HTTP handler function
+// such that requests are examined and IFF the request utilizes an HTTP method
+// that commonly mutates the system (for instance, POST commonly is used for
+// creates and PUT and PATCH are commonly used for updates), then the request's
+// context is REPLACED with the background context. The usefulness of this lies
+// in creating a guarantee that operations that mutate the system are
+// uninterruptible by impatient clients that might hang up in the middle of a
+// request that is running long, perhaps due to retry logic with exponential
+// backoff. The client can hang up if they wish, but operations that mutate the
+// system will continue in the background until they have succeeded or failed
+// independently of any client action. This filter, when used, MUST be the first
+// (outermost) filter in the chain of filters/handlers. By being first in the
+// chain, this filter does not need to be concerned with discovering and copying
+// values that may have been poked into the context by other filters (for
+// example, a principal object added to the context by an authentication
+// filter).
+type requestContextFilter struct{}
+
+func (r *requestContextFilter) Decorate(
+	handle http.HandlerFunc,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		switch req.Method {
+		case http.MethodDelete:
+			fallthrough
+		case http.MethodPatch:
+			fallthrough
+		case http.MethodPost:
+			fallthrough
+		case http.MethodPut:
+			handle(w, req.WithContext(context.Background()))
+		default:
+			handle(w, req)
+		}
+	}
+}

--- a/v2/apiserver/internal/lib/restmachinery/server.go
+++ b/v2/apiserver/internal/lib/restmachinery/server.go
@@ -51,14 +51,18 @@ func NewServer(endpoints []Endpoints, config *ServerConfig) Server {
 
 	return &server{
 		config: *config,
-		handler: cors.New(
-			cors.Options{
-				AllowCredentials: true,
-				AllowedOrigins:   []string{"*"},
-				AllowedMethods:   []string{"DELETE", "GET", "POST", "PUT"},
-				AllowedHeaders:   []string{"Authorization", "Content-Type"},
-			},
-		).Handler(router),
+		handler: http.HandlerFunc( // Make a handler from a function
+			(&requestContextFilter{}).Decorate( // Our request context filter
+				cors.New( // CORS filter
+					cors.Options{
+						AllowCredentials: true,
+						AllowedOrigins:   []string{"*"},
+						AllowedMethods:   []string{"DELETE", "GET", "POST", "PUT"},
+						AllowedHeaders:   []string{"Authorization", "Content-Type"},
+					},
+				).Handler(router).ServeHTTP,
+			),
+		),
 	}
 }
 


### PR DESCRIPTION
#1304 got me thinking. There was some discussion related to that PR having to do with an infinite retry we currently have when writing new events to a queue and how that should probably just change to one of our usual exponential backoffs.

Well... that got me thinking more about how a request to do something like create an event, for instance, could run long (and still ultimately succeed) if it got into a backoff situation. And what happens if an impatient client hangs up in the meantime?

Just about everything we do throughout the whole system is currently interruptible by a canceled context... and request-bound contexts are canceled the moment the client disconnects.

Do we actually _want_ that behavior in certain cases? Suppose when creating a new event, the event is successfully written to the database in a pending status, but then the whole process is interrupted before the event's ID is written to the scheduler's queue-- this would leave us in an invalid state, with an event whose worker is in a pending phase with no path for transitioning out of that phase (short of an end-user  manually canceling or deleting the event).

It seems we'd be in better shape if requests utilizing HTTP methods that commonly mutate the underlying system (e.g. DELETE, PATCH, POST, and PUT) were considered _uninterruptible_. That can be achieved by substituting the background context for the default request-bound context.

This PR implements a new filter that does just that, and adds that filter as the first in our filter chain.