### PR TITLE
ref(*): add/use resource consts

### DIFF
--- a/sdk/v2/authn/users.go
+++ b/sdk/v2/authn/users.go
@@ -12,8 +12,8 @@ import (
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
-// UserLabel represents the canonical User label string
-const UserLabel = "User"
+// UserKind represents the canonical User kind string
+const UserKind = "User"
 
 // User represents a (human) Brigade user.
 type User struct {
@@ -37,7 +37,7 @@ func (u User) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       UserLabel,
+				Kind:       UserKind,
 			},
 			Alias: (Alias)(u),
 		},

--- a/sdk/v2/authn/users.go
+++ b/sdk/v2/authn/users.go
@@ -12,6 +12,9 @@ import (
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
+// UserLabel represents the canonical User label string
+const UserLabel = "User"
+
 // User represents a (human) Brigade user.
 type User struct {
 	// ObjectMeta encapsulates User metadata.
@@ -34,7 +37,7 @@ func (u User) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       "User",
+				Kind:       UserLabel,
 			},
 			Alias: (Alias)(u),
 		},

--- a/sdk/v2/core/events.go
+++ b/sdk/v2/core/events.go
@@ -12,8 +12,8 @@ import (
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
-// EventLabel represents the canonical Event label string
-const EventLabel = "Event"
+// EventKind represents the canonical Event kind string
+const EventKind = "Event"
 
 // Event represents an occurrence in some upstream system. Once accepted into
 // the system, Brigade amends each Event with a plan for handling it in the form
@@ -79,7 +79,7 @@ func (e Event) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       EventLabel,
+				Kind:       EventKind,
 			},
 			Alias: (Alias)(e),
 		},

--- a/sdk/v2/core/events.go
+++ b/sdk/v2/core/events.go
@@ -12,6 +12,9 @@ import (
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
+// EventLabel represents the canonical Event label string
+const EventLabel = "Event"
+
 // Event represents an occurrence in some upstream system. Once accepted into
 // the system, Brigade amends each Event with a plan for handling it in the form
 // of a Worker. An Event's status is, implicitly, the status of its Worker.
@@ -76,7 +79,7 @@ func (e Event) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       "Event",
+				Kind:       EventLabel,
 			},
 			Alias: (Alias)(e),
 		},

--- a/sdk/v2/core/events_test.go
+++ b/sdk/v2/core/events_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestEventMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(t, Event{}, "Event")
+	metaTesting.RequireAPIVersionAndType(t, Event{}, EventLabel)
 }
 
 func TestEventListMarshalJSON(t *testing.T) {

--- a/sdk/v2/core/events_test.go
+++ b/sdk/v2/core/events_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestEventMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(t, Event{}, EventLabel)
+	metaTesting.RequireAPIVersionAndType(t, Event{}, EventKind)
 }
 
 func TestEventListMarshalJSON(t *testing.T) {

--- a/sdk/v2/core/jobs.go
+++ b/sdk/v2/core/jobs.go
@@ -13,6 +13,9 @@ import (
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
+// JobLabel represents the canonical Job label string
+const JobLabel = "Job"
+
 // JobPhase represents where a Job is within its lifecycle.
 type JobPhase string
 
@@ -93,7 +96,7 @@ func (j Job) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       "Job",
+				Kind:       JobLabel,
 			},
 			Alias: (Alias)(j),
 		},

--- a/sdk/v2/core/jobs.go
+++ b/sdk/v2/core/jobs.go
@@ -13,8 +13,8 @@ import (
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
-// JobLabel represents the canonical Job label string
-const JobLabel = "Job"
+// JobKind represents the canonical Job kind string
+const JobKind = "Job"
 
 // JobPhase represents where a Job is within its lifecycle.
 type JobPhase string
@@ -96,7 +96,7 @@ func (j Job) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       JobLabel,
+				Kind:       JobKind,
 			},
 			Alias: (Alias)(j),
 		},

--- a/sdk/v2/core/projects.go
+++ b/sdk/v2/core/projects.go
@@ -11,6 +11,9 @@ import (
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
+// ProjectLabel represents the canonical Project label string
+const ProjectLabel = "Project"
+
 // Project is Brigade's fundamental configuration, management, and isolation
 // construct.
 // - Configuration: Users define Projects to pair EventSubscriptions with
@@ -49,7 +52,7 @@ func (p Project) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       "Project",
+				Kind:       ProjectLabel,
 			},
 			Alias: (Alias)(p),
 		},

--- a/sdk/v2/core/projects.go
+++ b/sdk/v2/core/projects.go
@@ -11,8 +11,8 @@ import (
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
-// ProjectLabel represents the canonical Project label string
-const ProjectLabel = "Project"
+// ProjectKind represents the canonical Project kind string
+const ProjectKind = "Project"
 
 // Project is Brigade's fundamental configuration, management, and isolation
 // construct.
@@ -52,7 +52,7 @@ func (p Project) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       ProjectLabel,
+				Kind:       ProjectKind,
 			},
 			Alias: (Alias)(p),
 		},

--- a/sdk/v2/core/projects_test.go
+++ b/sdk/v2/core/projects_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestProjectMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(t, Project{}, ProjectLabel)
+	metaTesting.RequireAPIVersionAndType(t, Project{}, ProjectKind)
 }
 
 func TestProjectListMarshalJSON(t *testing.T) {

--- a/sdk/v2/core/projects_test.go
+++ b/sdk/v2/core/projects_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestProjectMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(t, Project{}, "Project")
+	metaTesting.RequireAPIVersionAndType(t, Project{}, ProjectLabel)
 }
 
 func TestProjectListMarshalJSON(t *testing.T) {

--- a/v2/apiserver/internal/authn/mongodb/service_accounts_store.go
+++ b/v2/apiserver/internal/authn/mongodb/service_accounts_store.go
@@ -68,7 +68,7 @@ func (s *serviceAccountsStore) Create(
 	if _, err := s.collection.InsertOne(ctx, serviceAccount); err != nil {
 		if mongodb.IsDuplicateKeyError(err) {
 			return &meta.ErrConflict{
-				Type: authn.ServiceAccountLabel,
+				Type: authn.ServiceAccountKind,
 				ID:   serviceAccount.ID,
 				Reason: fmt.Sprintf(
 					"A service account with the ID %q already exists.",
@@ -142,7 +142,7 @@ func (s *serviceAccountsStore) Get(
 	err := res.Decode(&serviceAccount)
 	if err == mongo.ErrNoDocuments {
 		return serviceAccount, &meta.ErrNotFound{
-			Type: authn.ServiceAccountLabel,
+			Type: authn.ServiceAccountKind,
 			ID:   id,
 		}
 	}
@@ -163,7 +163,7 @@ func (s *serviceAccountsStore) GetByHashedToken(
 	err := res.Decode(&serviceAccount)
 	if err == mongo.ErrNoDocuments {
 		return serviceAccount, &meta.ErrNotFound{
-			Type: authn.ServiceAccountLabel,
+			Type: authn.ServiceAccountKind,
 		}
 	}
 	if err != nil {
@@ -188,7 +188,7 @@ func (s *serviceAccountsStore) Lock(ctx context.Context, id string) error {
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: authn.ServiceAccountLabel,
+			Type: authn.ServiceAccountKind,
 			ID:   id,
 		}
 	}
@@ -217,7 +217,7 @@ func (s *serviceAccountsStore) Unlock(
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: authn.ServiceAccountLabel,
+			Type: authn.ServiceAccountKind,
 			ID:   id,
 		}
 	}

--- a/v2/apiserver/internal/authn/mongodb/service_accounts_store.go
+++ b/v2/apiserver/internal/authn/mongodb/service_accounts_store.go
@@ -68,7 +68,7 @@ func (s *serviceAccountsStore) Create(
 	if _, err := s.collection.InsertOne(ctx, serviceAccount); err != nil {
 		if mongodb.IsDuplicateKeyError(err) {
 			return &meta.ErrConflict{
-				Type: "ServiceAccount",
+				Type: authn.ServiceAccountLabel,
 				ID:   serviceAccount.ID,
 				Reason: fmt.Sprintf(
 					"A service account with the ID %q already exists.",
@@ -142,7 +142,7 @@ func (s *serviceAccountsStore) Get(
 	err := res.Decode(&serviceAccount)
 	if err == mongo.ErrNoDocuments {
 		return serviceAccount, &meta.ErrNotFound{
-			Type: "ServiceAccount",
+			Type: authn.ServiceAccountLabel,
 			ID:   id,
 		}
 	}
@@ -163,7 +163,7 @@ func (s *serviceAccountsStore) GetByHashedToken(
 	err := res.Decode(&serviceAccount)
 	if err == mongo.ErrNoDocuments {
 		return serviceAccount, &meta.ErrNotFound{
-			Type: "ServiceAccount",
+			Type: authn.ServiceAccountLabel,
 		}
 	}
 	if err != nil {
@@ -188,7 +188,7 @@ func (s *serviceAccountsStore) Lock(ctx context.Context, id string) error {
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: "ServiceAccount",
+			Type: authn.ServiceAccountLabel,
 			ID:   id,
 		}
 	}
@@ -217,7 +217,7 @@ func (s *serviceAccountsStore) Unlock(
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: "ServiceAccount",
+			Type: authn.ServiceAccountLabel,
 			ID:   id,
 		}
 	}

--- a/v2/apiserver/internal/authn/mongodb/sessions_store.go
+++ b/v2/apiserver/internal/authn/mongodb/sessions_store.go
@@ -88,7 +88,7 @@ func (s *sessionsStore) GetByHashedOAuth2State(
 	err := res.Decode(&session)
 	if err == mongo.ErrNoDocuments {
 		return session, &meta.ErrNotFound{
-			Type: "Session",
+			Type: authn.SessionLabel,
 		}
 	}
 	if err != nil {
@@ -106,7 +106,7 @@ func (s *sessionsStore) GetByHashedToken(
 	err := res.Decode(&session)
 	if err == mongo.ErrNoDocuments {
 		return session, &meta.ErrNotFound{
-			Type: "Session",
+			Type: authn.SessionLabel,
 		}
 	}
 	if err != nil {
@@ -139,7 +139,7 @@ func (s *sessionsStore) Authenticate(
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: "Session",
+			Type: authn.SessionLabel,
 			ID:   sessionID,
 		}
 	}
@@ -153,7 +153,7 @@ func (s *sessionsStore) Delete(ctx context.Context, id string) error {
 	}
 	if res.DeletedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: "Session",
+			Type: authn.SessionLabel,
 			ID:   id,
 		}
 	}

--- a/v2/apiserver/internal/authn/mongodb/sessions_store.go
+++ b/v2/apiserver/internal/authn/mongodb/sessions_store.go
@@ -88,7 +88,7 @@ func (s *sessionsStore) GetByHashedOAuth2State(
 	err := res.Decode(&session)
 	if err == mongo.ErrNoDocuments {
 		return session, &meta.ErrNotFound{
-			Type: authn.SessionLabel,
+			Type: authn.SessionKind,
 		}
 	}
 	if err != nil {
@@ -106,7 +106,7 @@ func (s *sessionsStore) GetByHashedToken(
 	err := res.Decode(&session)
 	if err == mongo.ErrNoDocuments {
 		return session, &meta.ErrNotFound{
-			Type: authn.SessionLabel,
+			Type: authn.SessionKind,
 		}
 	}
 	if err != nil {
@@ -139,7 +139,7 @@ func (s *sessionsStore) Authenticate(
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: authn.SessionLabel,
+			Type: authn.SessionKind,
 			ID:   sessionID,
 		}
 	}
@@ -153,7 +153,7 @@ func (s *sessionsStore) Delete(ctx context.Context, id string) error {
 	}
 	if res.DeletedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: authn.SessionLabel,
+			Type: authn.SessionKind,
 			ID:   id,
 		}
 	}

--- a/v2/apiserver/internal/authn/mongodb/users_store.go
+++ b/v2/apiserver/internal/authn/mongodb/users_store.go
@@ -56,7 +56,7 @@ func (u *usersStore) Create(ctx context.Context, user authn.User) error {
 	if _, err := u.collection.InsertOne(ctx, user); err != nil {
 		if mongodb.IsDuplicateKeyError(err) {
 			return &meta.ErrConflict{
-				Type:   authn.UserLabel,
+				Type:   authn.UserKind,
 				ID:     user.ID,
 				Reason: fmt.Sprintf("A user with the ID %q already exists.", user.ID),
 			}
@@ -126,7 +126,7 @@ func (u *usersStore) Get(
 	err := res.Decode(&user)
 	if err == mongo.ErrNoDocuments {
 		return user, &meta.ErrNotFound{
-			Type: authn.UserLabel,
+			Type: authn.UserKind,
 			ID:   id,
 		}
 	}
@@ -154,7 +154,7 @@ func (u *usersStore) Lock(ctx context.Context, id string) error {
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: authn.UserLabel,
+			Type: authn.UserKind,
 			ID:   id,
 		}
 	}
@@ -179,7 +179,7 @@ func (u *usersStore) Unlock(ctx context.Context, id string) error {
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: authn.UserLabel,
+			Type: authn.UserKind,
 			ID:   id,
 		}
 	}

--- a/v2/apiserver/internal/authn/mongodb/users_store.go
+++ b/v2/apiserver/internal/authn/mongodb/users_store.go
@@ -56,7 +56,7 @@ func (u *usersStore) Create(ctx context.Context, user authn.User) error {
 	if _, err := u.collection.InsertOne(ctx, user); err != nil {
 		if mongodb.IsDuplicateKeyError(err) {
 			return &meta.ErrConflict{
-				Type:   "User",
+				Type:   authn.UserLabel,
 				ID:     user.ID,
 				Reason: fmt.Sprintf("A user with the ID %q already exists.", user.ID),
 			}
@@ -126,7 +126,7 @@ func (u *usersStore) Get(
 	err := res.Decode(&user)
 	if err == mongo.ErrNoDocuments {
 		return user, &meta.ErrNotFound{
-			Type: "User",
+			Type: authn.UserLabel,
 			ID:   id,
 		}
 	}
@@ -154,7 +154,7 @@ func (u *usersStore) Lock(ctx context.Context, id string) error {
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: "User",
+			Type: authn.UserLabel,
 			ID:   id,
 		}
 	}
@@ -179,7 +179,7 @@ func (u *usersStore) Unlock(ctx context.Context, id string) error {
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: "User",
+			Type: authn.UserLabel,
 			ID:   id,
 		}
 	}

--- a/v2/apiserver/internal/authn/service_accounts.go
+++ b/v2/apiserver/internal/authn/service_accounts.go
@@ -12,8 +12,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ServiceAccountLabel represents the canonical Service Account label string
-const ServiceAccountLabel = "ServiceAccount"
+// ServiceAccountKind represents the canonical Service Account kind string
+const ServiceAccountKind = "ServiceAccount"
 
 // ServiceAccount represents a non-human Brigade user, such as an Event
 // gateway.

--- a/v2/apiserver/internal/authn/service_accounts.go
+++ b/v2/apiserver/internal/authn/service_accounts.go
@@ -12,6 +12,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ServiceAccountLabel represents the canonical Service Account label string
+const ServiceAccountLabel = "ServiceAccount"
+
 // ServiceAccount represents a non-human Brigade user, such as an Event
 // gateway.
 type ServiceAccount struct {

--- a/v2/apiserver/internal/authn/sessions.go
+++ b/v2/apiserver/internal/authn/sessions.go
@@ -13,8 +13,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// SessionLabel represents the canonical Session label string
-const SessionLabel = "Session"
+// SessionKind represents the canonical Session kind string
+const SessionKind = "Session"
 
 // OIDCAuthDetails encapsulates all information required for a client
 // authenticating by means of OpenID Connect to complete the authentication

--- a/v2/apiserver/internal/authn/sessions.go
+++ b/v2/apiserver/internal/authn/sessions.go
@@ -13,6 +13,9 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// SessionLabel represents the canonical Session label string
+const SessionLabel = "Session"
+
 // OIDCAuthDetails encapsulates all information required for a client
 // authenticating by means of OpenID Connect to complete the authentication
 // process using a third-party identity provider.

--- a/v2/apiserver/internal/authn/sessions_test.go
+++ b/v2/apiserver/internal/authn/sessions_test.go
@@ -224,7 +224,7 @@ func TestSessionsServiceAuthenticate(t *testing.T) {
 						oauth2State string,
 					) (Session, error) {
 						return Session{}, &meta.ErrNotFound{
-							Type: "Session",
+							Type: SessionLabel,
 						}
 					},
 				},
@@ -235,7 +235,11 @@ func TestSessionsServiceAuthenticate(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, errors.Cause(err))
-				require.Equal(t, "Session", errors.Cause(err).(*meta.ErrNotFound).Type)
+				require.Equal(
+					t,
+					SessionLabel,
+					errors.Cause(err).(*meta.ErrNotFound).Type,
+				)
 			},
 		},
 
@@ -433,7 +437,7 @@ func TestSessionsServiceAuthenticate(t *testing.T) {
 				usersStore: &MockUsersStore{
 					GetFn: func(_ context.Context, id string) (User, error) {
 						return User{}, &meta.ErrNotFound{
-							Type: "User",
+							Type: UserLabel,
 							ID:   id,
 						}
 					},
@@ -504,7 +508,7 @@ func TestSessionsServiceAuthenticate(t *testing.T) {
 				usersStore: &MockUsersStore{
 					GetFn: func(_ context.Context, id string) (User, error) {
 						return User{}, &meta.ErrNotFound{
-							Type: "User",
+							Type: UserLabel,
 							ID:   id,
 						}
 					},
@@ -648,7 +652,7 @@ func TestSessionsServiceGetByToken(t *testing.T) {
 				sessionsStore: &mockSessionsStore{
 					GetByHashedTokenFn: func(context.Context, string) (Session, error) {
 						return Session{}, &meta.ErrNotFound{
-							Type: "Session",
+							Type: SessionLabel,
 						}
 					},
 				},
@@ -656,7 +660,11 @@ func TestSessionsServiceGetByToken(t *testing.T) {
 			assertions: func(session Session, err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, errors.Cause(err))
-				require.Equal(t, "Session", errors.Cause(err).(*meta.ErrNotFound).Type)
+				require.Equal(
+					t,
+					SessionLabel,
+					errors.Cause(err).(*meta.ErrNotFound).Type,
+				)
 			},
 		},
 		{
@@ -700,7 +708,7 @@ func TestSessionsServiceDelete(t *testing.T) {
 				sessionsStore: &mockSessionsStore{
 					DeleteFn: func(context.Context, string) error {
 						return &meta.ErrNotFound{
-							Type: "Session",
+							Type: SessionLabel,
 						}
 					},
 				},
@@ -708,7 +716,11 @@ func TestSessionsServiceDelete(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, errors.Cause(err))
-				require.Equal(t, "Session", errors.Cause(err).(*meta.ErrNotFound).Type)
+				require.Equal(
+					t,
+					SessionLabel,
+					errors.Cause(err).(*meta.ErrNotFound).Type,
+				)
 			},
 		},
 		{

--- a/v2/apiserver/internal/authn/sessions_test.go
+++ b/v2/apiserver/internal/authn/sessions_test.go
@@ -224,7 +224,7 @@ func TestSessionsServiceAuthenticate(t *testing.T) {
 						oauth2State string,
 					) (Session, error) {
 						return Session{}, &meta.ErrNotFound{
-							Type: SessionLabel,
+							Type: SessionKind,
 						}
 					},
 				},
@@ -237,7 +237,7 @@ func TestSessionsServiceAuthenticate(t *testing.T) {
 				require.IsType(t, &meta.ErrNotFound{}, errors.Cause(err))
 				require.Equal(
 					t,
-					SessionLabel,
+					SessionKind,
 					errors.Cause(err).(*meta.ErrNotFound).Type,
 				)
 			},
@@ -437,7 +437,7 @@ func TestSessionsServiceAuthenticate(t *testing.T) {
 				usersStore: &MockUsersStore{
 					GetFn: func(_ context.Context, id string) (User, error) {
 						return User{}, &meta.ErrNotFound{
-							Type: UserLabel,
+							Type: UserKind,
 							ID:   id,
 						}
 					},
@@ -508,7 +508,7 @@ func TestSessionsServiceAuthenticate(t *testing.T) {
 				usersStore: &MockUsersStore{
 					GetFn: func(_ context.Context, id string) (User, error) {
 						return User{}, &meta.ErrNotFound{
-							Type: UserLabel,
+							Type: UserKind,
 							ID:   id,
 						}
 					},
@@ -652,7 +652,7 @@ func TestSessionsServiceGetByToken(t *testing.T) {
 				sessionsStore: &mockSessionsStore{
 					GetByHashedTokenFn: func(context.Context, string) (Session, error) {
 						return Session{}, &meta.ErrNotFound{
-							Type: SessionLabel,
+							Type: SessionKind,
 						}
 					},
 				},
@@ -662,7 +662,7 @@ func TestSessionsServiceGetByToken(t *testing.T) {
 				require.IsType(t, &meta.ErrNotFound{}, errors.Cause(err))
 				require.Equal(
 					t,
-					SessionLabel,
+					SessionKind,
 					errors.Cause(err).(*meta.ErrNotFound).Type,
 				)
 			},
@@ -708,7 +708,7 @@ func TestSessionsServiceDelete(t *testing.T) {
 				sessionsStore: &mockSessionsStore{
 					DeleteFn: func(context.Context, string) error {
 						return &meta.ErrNotFound{
-							Type: SessionLabel,
+							Type: SessionKind,
 						}
 					},
 				},
@@ -718,7 +718,7 @@ func TestSessionsServiceDelete(t *testing.T) {
 				require.IsType(t, &meta.ErrNotFound{}, errors.Cause(err))
 				require.Equal(
 					t,
-					SessionLabel,
+					SessionKind,
 					errors.Cause(err).(*meta.ErrNotFound).Type,
 				)
 			},

--- a/v2/apiserver/internal/authn/users.go
+++ b/v2/apiserver/internal/authn/users.go
@@ -11,6 +11,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// UserLabel represents the canonical User label string
+const UserLabel = "User"
+
 // User represents a (human) Brigade user.
 type User struct {
 	// ObjectMeta encapsulates User metadata.
@@ -32,7 +35,7 @@ func (u User) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       "User",
+				Kind:       UserLabel,
 			},
 			Alias: (Alias)(u),
 		},

--- a/v2/apiserver/internal/authn/users.go
+++ b/v2/apiserver/internal/authn/users.go
@@ -11,8 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// UserLabel represents the canonical User label string
-const UserLabel = "User"
+// UserKind represents the canonical User kind string
+const UserKind = "User"
 
 // User represents a (human) Brigade user.
 type User struct {
@@ -35,7 +35,7 @@ func (u User) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       UserLabel,
+				Kind:       UserKind,
 			},
 			Alias: (Alias)(u),
 		},

--- a/v2/apiserver/internal/core/events.go
+++ b/v2/apiserver/internal/core/events.go
@@ -14,6 +14,9 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+// EventLabel represents the canonical Event label string
+const EventLabel = "Event"
+
 const defaultWorkspaceSize = "10Gi"
 
 // Event represents an occurrence in some upstream system. Once accepted into
@@ -79,7 +82,7 @@ func (e Event) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       "Event",
+				Kind:       EventLabel,
 			},
 			Alias: (Alias)(e),
 		},

--- a/v2/apiserver/internal/core/events.go
+++ b/v2/apiserver/internal/core/events.go
@@ -14,8 +14,8 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-// EventLabel represents the canonical Event label string
-const EventLabel = "Event"
+// EventKind represents the canonical Event kind string
+const EventKind = "Event"
 
 const defaultWorkspaceSize = "10Gi"
 
@@ -82,7 +82,7 @@ func (e Event) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       EventLabel,
+				Kind:       EventKind,
 			},
 			Alias: (Alias)(e),
 		},

--- a/v2/apiserver/internal/core/events_test.go
+++ b/v2/apiserver/internal/core/events_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestEventMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(t, &Event{}, EventLabel)
+	metaTesting.RequireAPIVersionAndType(t, &Event{}, EventKind)
 }
 
 func TestEventListMarshalJSON(t *testing.T) {

--- a/v2/apiserver/internal/core/events_test.go
+++ b/v2/apiserver/internal/core/events_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestEventMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(t, &Event{}, "Event")
+	metaTesting.RequireAPIVersionAndType(t, &Event{}, EventLabel)
 }
 
 func TestEventListMarshalJSON(t *testing.T) {

--- a/v2/apiserver/internal/core/jobs.go
+++ b/v2/apiserver/internal/core/jobs.go
@@ -12,6 +12,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// JobLabel represents the canonical Job label string
+const JobLabel = "Job"
+
 // JobPhase represents where a Job is within its lifecycle.
 type JobPhase string
 
@@ -252,7 +255,7 @@ func (j *jobsService) Create(
 	}
 	if _, ok := event.Worker.Job(job.Name); ok {
 		return &meta.ErrConflict{
-			Type: "Job",
+			Type: JobLabel,
 			ID:   job.Name,
 			Reason: fmt.Sprintf(
 				"Event %q already has a job named %q.",
@@ -399,14 +402,14 @@ func (j *jobsService) Start(
 	job, ok := event.Worker.Job(jobName)
 	if !ok {
 		return &meta.ErrNotFound{
-			Type: "Job",
+			Type: JobLabel,
 			ID:   jobName,
 		}
 	}
 
 	if job.Status.Phase != JobPhasePending {
 		return &meta.ErrConflict{
-			Type: "Job",
+			Type: JobLabel,
 			ID:   jobName,
 			Reason: fmt.Sprintf(
 				"Event %q job %q has already been started.",
@@ -470,7 +473,7 @@ func (j *jobsService) GetStatus(
 	job, ok := event.Worker.Job(jobName)
 	if !ok {
 		return JobStatus{}, &meta.ErrNotFound{
-			Type: "Job",
+			Type: JobLabel,
 			ID:   jobName,
 		}
 	}
@@ -494,7 +497,7 @@ func (j *jobsService) WatchStatus(
 	}
 	if _, ok := event.Worker.Job(jobName); !ok {
 		return nil, &meta.ErrNotFound{
-			Type: "Job",
+			Type: JobLabel,
 			ID:   jobName,
 		}
 	}
@@ -569,7 +572,7 @@ func (j *jobsService) Cleanup(
 	_, ok := event.Worker.Job(jobName)
 	if !ok {
 		return &meta.ErrNotFound{
-			Type: "Job",
+			Type: JobLabel,
 			ID:   jobName,
 		}
 	}

--- a/v2/apiserver/internal/core/jobs.go
+++ b/v2/apiserver/internal/core/jobs.go
@@ -12,8 +12,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// JobLabel represents the canonical Job label string
-const JobLabel = "Job"
+// JobKind represents the canonical Job kind string
+const JobKind = "Job"
 
 // JobPhase represents where a Job is within its lifecycle.
 type JobPhase string
@@ -255,7 +255,7 @@ func (j *jobsService) Create(
 	}
 	if _, ok := event.Worker.Job(job.Name); ok {
 		return &meta.ErrConflict{
-			Type: JobLabel,
+			Type: JobKind,
 			ID:   job.Name,
 			Reason: fmt.Sprintf(
 				"Event %q already has a job named %q.",
@@ -402,14 +402,14 @@ func (j *jobsService) Start(
 	job, ok := event.Worker.Job(jobName)
 	if !ok {
 		return &meta.ErrNotFound{
-			Type: JobLabel,
+			Type: JobKind,
 			ID:   jobName,
 		}
 	}
 
 	if job.Status.Phase != JobPhasePending {
 		return &meta.ErrConflict{
-			Type: JobLabel,
+			Type: JobKind,
 			ID:   jobName,
 			Reason: fmt.Sprintf(
 				"Event %q job %q has already been started.",
@@ -473,7 +473,7 @@ func (j *jobsService) GetStatus(
 	job, ok := event.Worker.Job(jobName)
 	if !ok {
 		return JobStatus{}, &meta.ErrNotFound{
-			Type: JobLabel,
+			Type: JobKind,
 			ID:   jobName,
 		}
 	}
@@ -497,7 +497,7 @@ func (j *jobsService) WatchStatus(
 	}
 	if _, ok := event.Worker.Job(jobName); !ok {
 		return nil, &meta.ErrNotFound{
-			Type: JobLabel,
+			Type: JobKind,
 			ID:   jobName,
 		}
 	}
@@ -572,7 +572,7 @@ func (j *jobsService) Cleanup(
 	_, ok := event.Worker.Job(jobName)
 	if !ok {
 		return &meta.ErrNotFound{
-			Type: JobLabel,
+			Type: JobKind,
 			ID:   jobName,
 		}
 	}

--- a/v2/apiserver/internal/core/kubernetes/substrate.go
+++ b/v2/apiserver/internal/core/kubernetes/substrate.go
@@ -304,7 +304,7 @@ func (s *substrate) CreateProject(
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "project-secrets",
 				Labels: map[string]string{
-					myk8s.LabelComponent: "project-secrets",
+					myk8s.LabelComponent: myk8s.LabelKeyProjectSecrets,
 					myk8s.LabelProject:   project.ID,
 				},
 			},
@@ -432,7 +432,7 @@ func (s *substrate) ScheduleWorker(
 			ObjectMeta: metav1.ObjectMeta{
 				Name: myk8s.EventSecretName(event.ID),
 				Labels: map[string]string{
-					myk8s.LabelComponent: "event",
+					myk8s.LabelComponent: myk8s.LabelKeyEvent,
 					myk8s.LabelProject:   event.ProjectID,
 					myk8s.LabelEvent:     event.ID,
 				},
@@ -846,7 +846,7 @@ func (s *substrate) createWorkerPod(
 
 	volumes := []corev1.Volume{
 		{
-			Name: "event",
+			Name: myk8s.LabelKeyEvent,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: myk8s.EventSecretName(event.ID),
@@ -870,7 +870,7 @@ func (s *substrate) createWorkerPod(
 
 	volumeMounts := []corev1.VolumeMount{
 		{
-			Name:      "event",
+			Name:      myk8s.LabelKeyEvent,
 			MountPath: "/var/event",
 			ReadOnly:  true,
 		},
@@ -933,7 +933,7 @@ func (s *substrate) createWorkerPod(
 			Name:      myk8s.WorkerPodName(event.ID),
 			Namespace: project.Kubernetes.Namespace,
 			Labels: map[string]string{
-				myk8s.LabelComponent: "worker",
+				myk8s.LabelComponent: myk8s.LabelKeyWorker,
 				myk8s.LabelProject:   event.ProjectID,
 				myk8s.LabelEvent:     event.ID,
 			},
@@ -945,7 +945,7 @@ func (s *substrate) createWorkerPod(
 			InitContainers:     initContainers,
 			Containers: []corev1.Container{
 				{
-					Name:            "worker",
+					Name:            myk8s.LabelKeyWorker,
 					Image:           image,
 					ImagePullPolicy: corev1.PullPolicy(imagePullPolicy),
 					Command:         event.Worker.Spec.Container.Command,
@@ -987,7 +987,7 @@ func (s *substrate) createJobSecret(
 			Name:      myk8s.JobSecretName(eventID, jobName),
 			Namespace: project.Kubernetes.Namespace,
 			Labels: map[string]string{
-				myk8s.LabelComponent: "job",
+				myk8s.LabelComponent: myk8s.LabelKeyJob,
 				myk8s.LabelProject:   project.ID,
 				myk8s.LabelEvent:     eventID,
 				myk8s.LabelJob:       jobName,
@@ -1082,7 +1082,7 @@ func (s *substrate) createJobPod(
 		volumes = append(
 			volumes,
 			corev1.Volume{
-				Name: "event",
+				Name: myk8s.LabelKeyEvent,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						SecretName: myk8s.EventSecretName(event.ID),
@@ -1124,7 +1124,7 @@ func (s *substrate) createJobPod(
 				),
 				VolumeMounts: []corev1.VolumeMount{
 					{
-						Name:      "event",
+						Name:      myk8s.LabelKeyEvent,
 						MountPath: "/var/event",
 						ReadOnly:  true,
 					},
@@ -1166,7 +1166,7 @@ func (s *substrate) createJobPod(
 			Name:      myk8s.JobPodName(event.ID, jobName),
 			Namespace: project.Kubernetes.Namespace,
 			Labels: map[string]string{
-				myk8s.LabelComponent: "job",
+				myk8s.LabelComponent: myk8s.LabelKeyJob,
 				myk8s.LabelProject:   event.ProjectID,
 				myk8s.LabelEvent:     event.ID,
 				myk8s.LabelJob:       jobName,

--- a/v2/apiserver/internal/core/kubernetes/substrate_test.go
+++ b/v2/apiserver/internal/core/kubernetes/substrate_test.go
@@ -42,7 +42,7 @@ func TestSubstrateCountRunningWorkers(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name: "bar",
 				Labels: map[string]string{
-					myk8s.LabelComponent: "job",
+					myk8s.LabelComponent: myk8s.LabelKeyJob,
 				},
 			},
 			Status: corev1.PodStatus{
@@ -59,7 +59,7 @@ func TestSubstrateCountRunningWorkers(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name: "bat",
 				Labels: map[string]string{
-					myk8s.LabelComponent: "worker",
+					myk8s.LabelComponent: myk8s.LabelKeyWorker,
 				},
 			},
 			Status: corev1.PodStatus{
@@ -88,7 +88,7 @@ func TestSubstrateCountRunningJobs(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name: "bar",
 				Labels: map[string]string{
-					myk8s.LabelComponent: "worker",
+					myk8s.LabelComponent: myk8s.LabelKeyWorker,
 				},
 			},
 			Status: corev1.PodStatus{
@@ -105,7 +105,7 @@ func TestSubstrateCountRunningJobs(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name: "bat",
 				Labels: map[string]string{
-					myk8s.LabelComponent: "job",
+					myk8s.LabelComponent: myk8s.LabelKeyJob,
 				},
 			},
 			Status: corev1.PodStatus{

--- a/v2/apiserver/internal/core/logs.go
+++ b/v2/apiserver/internal/core/logs.go
@@ -7,6 +7,7 @@ import (
 
 	libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
+	myk8s "github.com/brigadecore/brigade/v2/internal/kubernetes"
 	"github.com/pkg/errors"
 )
 
@@ -113,10 +114,11 @@ func (l *logsService) Stream(
 	if selector.Job == "" { // If a job isn't specified, then we want worker logs
 		if selector.Container == "" {
 			// If a container isn't specified, we want the one named "worker"
-			selector.Container = "worker"
+			selector.Container = myk8s.LabelKeyWorker
 		}
 		// These are the only legitimate container names for ANY worker
-		if selector.Container != "worker" && selector.Container != "vcs" {
+		if selector.Container != myk8s.LabelKeyWorker &&
+			selector.Container != "vcs" {
 			// Any other container name is an error
 			return nil, &meta.ErrNotFound{
 				Type: "WorkerContainer",
@@ -153,7 +155,7 @@ func (l *logsService) Stream(
 		job, ok := event.Worker.Job(selector.Job)
 		if !ok {
 			return nil, &meta.ErrNotFound{
-				Type: "Job",
+				Type: JobLabel,
 				ID:   selector.Job,
 			}
 		}

--- a/v2/apiserver/internal/core/logs.go
+++ b/v2/apiserver/internal/core/logs.go
@@ -155,7 +155,7 @@ func (l *logsService) Stream(
 		job, ok := event.Worker.Job(selector.Job)
 		if !ok {
 			return nil, &meta.ErrNotFound{
-				Type: JobLabel,
+				Type: JobKind,
 				ID:   selector.Job,
 			}
 		}

--- a/v2/apiserver/internal/core/logs_test.go
+++ b/v2/apiserver/internal/core/logs_test.go
@@ -102,7 +102,7 @@ func TestLogsServiceStream(t *testing.T) {
 			assertions: func(_ <-chan LogEntry, err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, JobLabel, err.(*meta.ErrNotFound).Type)
+				require.Equal(t, JobKind, err.(*meta.ErrNotFound).Type)
 				require.Equal(t, "foo", err.(*meta.ErrNotFound).ID)
 			},
 		},

--- a/v2/apiserver/internal/core/logs_test.go
+++ b/v2/apiserver/internal/core/logs_test.go
@@ -102,7 +102,7 @@ func TestLogsServiceStream(t *testing.T) {
 			assertions: func(_ <-chan LogEntry, err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, "Job", err.(*meta.ErrNotFound).Type)
+				require.Equal(t, JobLabel, err.(*meta.ErrNotFound).Type)
 				require.Equal(t, "foo", err.(*meta.ErrNotFound).ID)
 			},
 		},

--- a/v2/apiserver/internal/core/mongodb/events_store.go
+++ b/v2/apiserver/internal/core/mongodb/events_store.go
@@ -146,7 +146,7 @@ func (e *eventsStore) Get(
 	err := res.Decode(&event)
 	if err == mongo.ErrNoDocuments {
 		return event, &meta.ErrNotFound{
-			Type: "Event",
+			Type: core.EventLabel,
 			ID:   id,
 		}
 	}
@@ -171,7 +171,7 @@ func (e *eventsStore) GetByHashedWorkerToken(
 	err := res.Decode(&event)
 	if res.Err() == mongo.ErrNoDocuments {
 		return event, &meta.ErrNotFound{
-			Type: "Event",
+			Type: core.EventLabel,
 		}
 	}
 	if err != nil {
@@ -245,7 +245,7 @@ func (e *eventsStore) Cancel(ctx context.Context, id string) error {
 
 	if res.MatchedCount == 0 {
 		return &meta.ErrConflict{
-			Type: "Event",
+			Type: core.EventLabel,
 			ID:   id,
 			Reason: fmt.Sprintf(
 				"Event %q was not canceled because it was already in a terminal state.",
@@ -406,7 +406,7 @@ func (e *eventsStore) Delete(ctx context.Context, id string) error {
 	}
 	if res.DeletedCount != 1 {
 		return &meta.ErrNotFound{
-			Type: "Event",
+			Type: core.EventLabel,
 			ID:   id,
 		}
 	}

--- a/v2/apiserver/internal/core/mongodb/events_store.go
+++ b/v2/apiserver/internal/core/mongodb/events_store.go
@@ -146,7 +146,7 @@ func (e *eventsStore) Get(
 	err := res.Decode(&event)
 	if err == mongo.ErrNoDocuments {
 		return event, &meta.ErrNotFound{
-			Type: core.EventLabel,
+			Type: core.EventKind,
 			ID:   id,
 		}
 	}
@@ -171,7 +171,7 @@ func (e *eventsStore) GetByHashedWorkerToken(
 	err := res.Decode(&event)
 	if res.Err() == mongo.ErrNoDocuments {
 		return event, &meta.ErrNotFound{
-			Type: core.EventLabel,
+			Type: core.EventKind,
 		}
 	}
 	if err != nil {
@@ -245,7 +245,7 @@ func (e *eventsStore) Cancel(ctx context.Context, id string) error {
 
 	if res.MatchedCount == 0 {
 		return &meta.ErrConflict{
-			Type: core.EventLabel,
+			Type: core.EventKind,
 			ID:   id,
 			Reason: fmt.Sprintf(
 				"Event %q was not canceled because it was already in a terminal state.",
@@ -406,7 +406,7 @@ func (e *eventsStore) Delete(ctx context.Context, id string) error {
 	}
 	if res.DeletedCount != 1 {
 		return &meta.ErrNotFound{
-			Type: core.EventLabel,
+			Type: core.EventKind,
 			ID:   id,
 		}
 	}

--- a/v2/apiserver/internal/core/mongodb/events_store_test.go
+++ b/v2/apiserver/internal/core/mongodb/events_store_test.go
@@ -238,7 +238,7 @@ func TestEventsStoreGet(t *testing.T) {
 			assertions: func(_ core.Event, err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, core.EventLabel, err.(*meta.ErrNotFound).Type)
+				require.Equal(t, core.EventKind, err.(*meta.ErrNotFound).Type)
 				require.Equal(t, testEventID, err.(*meta.ErrNotFound).ID)
 			},
 		},
@@ -325,7 +325,7 @@ func TestEventsStoreGetByHashedToken(t *testing.T) {
 			assertions: func(_ core.Event, err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, core.EventLabel, err.(*meta.ErrNotFound).Type)
+				require.Equal(t, core.EventKind, err.(*meta.ErrNotFound).Type)
 			},
 		},
 
@@ -739,7 +739,7 @@ func TestEventsStoreDelete(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, core.EventLabel, err.(*meta.ErrNotFound).Type)
+				require.Equal(t, core.EventKind, err.(*meta.ErrNotFound).Type)
 				require.Equal(t, testEventID, err.(*meta.ErrNotFound).ID)
 			},
 		},

--- a/v2/apiserver/internal/core/mongodb/events_store_test.go
+++ b/v2/apiserver/internal/core/mongodb/events_store_test.go
@@ -238,7 +238,7 @@ func TestEventsStoreGet(t *testing.T) {
 			assertions: func(_ core.Event, err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, "Event", err.(*meta.ErrNotFound).Type)
+				require.Equal(t, core.EventLabel, err.(*meta.ErrNotFound).Type)
 				require.Equal(t, testEventID, err.(*meta.ErrNotFound).ID)
 			},
 		},
@@ -325,7 +325,7 @@ func TestEventsStoreGetByHashedToken(t *testing.T) {
 			assertions: func(_ core.Event, err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, "Event", err.(*meta.ErrNotFound).Type)
+				require.Equal(t, core.EventLabel, err.(*meta.ErrNotFound).Type)
 			},
 		},
 
@@ -739,7 +739,7 @@ func TestEventsStoreDelete(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, "Event", err.(*meta.ErrNotFound).Type)
+				require.Equal(t, core.EventLabel, err.(*meta.ErrNotFound).Type)
 				require.Equal(t, testEventID, err.(*meta.ErrNotFound).ID)
 			},
 		},

--- a/v2/apiserver/internal/core/mongodb/jobs_store.go
+++ b/v2/apiserver/internal/core/mongodb/jobs_store.go
@@ -49,7 +49,7 @@ func (j *jobsStore) Create(
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: core.EventLabel,
+			Type: core.EventKind,
 			ID:   eventID,
 		}
 	}
@@ -84,7 +84,7 @@ func (j *jobsStore) UpdateStatus(
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: core.JobLabel,
+			Type: core.JobKind,
 			ID:   fmt.Sprintf("%s:%s", eventID, jobName),
 		}
 	}

--- a/v2/apiserver/internal/core/mongodb/jobs_store.go
+++ b/v2/apiserver/internal/core/mongodb/jobs_store.go
@@ -49,7 +49,7 @@ func (j *jobsStore) Create(
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: "Event",
+			Type: core.EventLabel,
 			ID:   eventID,
 		}
 	}
@@ -84,7 +84,7 @@ func (j *jobsStore) UpdateStatus(
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: "Job",
+			Type: core.JobLabel,
 			ID:   fmt.Sprintf("%s:%s", eventID, jobName),
 		}
 	}

--- a/v2/apiserver/internal/core/mongodb/projects_store.go
+++ b/v2/apiserver/internal/core/mongodb/projects_store.go
@@ -57,7 +57,7 @@ func (p *projectsStore) Create(
 	if _, err := p.collection.InsertOne(ctx, project); err != nil {
 		if mongodb.IsDuplicateKeyError(err) {
 			return &meta.ErrConflict{
-				Type: core.ProjectLabel,
+				Type: core.ProjectKind,
 				ID:   project.ID,
 				Reason: fmt.Sprintf(
 					"A project with the ID %q already exists.",
@@ -165,7 +165,7 @@ func (p *projectsStore) Get(
 	err := res.Decode(&project)
 	if err == mongo.ErrNoDocuments {
 		return project, &meta.ErrNotFound{
-			Type: core.ProjectLabel,
+			Type: core.ProjectKind,
 			ID:   id,
 		}
 	}
@@ -196,7 +196,7 @@ func (p *projectsStore) Update(
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: core.ProjectLabel,
+			Type: core.ProjectKind,
 			ID:   project.ID,
 		}
 	}
@@ -210,7 +210,7 @@ func (p *projectsStore) Delete(ctx context.Context, id string) error {
 	}
 	if res.DeletedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: core.ProjectLabel,
+			Type: core.ProjectKind,
 			ID:   id,
 		}
 	}

--- a/v2/apiserver/internal/core/mongodb/projects_store.go
+++ b/v2/apiserver/internal/core/mongodb/projects_store.go
@@ -57,7 +57,7 @@ func (p *projectsStore) Create(
 	if _, err := p.collection.InsertOne(ctx, project); err != nil {
 		if mongodb.IsDuplicateKeyError(err) {
 			return &meta.ErrConflict{
-				Type: "Project",
+				Type: core.ProjectLabel,
 				ID:   project.ID,
 				Reason: fmt.Sprintf(
 					"A project with the ID %q already exists.",
@@ -165,7 +165,7 @@ func (p *projectsStore) Get(
 	err := res.Decode(&project)
 	if err == mongo.ErrNoDocuments {
 		return project, &meta.ErrNotFound{
-			Type: "Project",
+			Type: core.ProjectLabel,
 			ID:   id,
 		}
 	}
@@ -196,7 +196,7 @@ func (p *projectsStore) Update(
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: "Project",
+			Type: core.ProjectLabel,
 			ID:   project.ID,
 		}
 	}
@@ -210,7 +210,7 @@ func (p *projectsStore) Delete(ctx context.Context, id string) error {
 	}
 	if res.DeletedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: "Project",
+			Type: core.ProjectLabel,
 			ID:   id,
 		}
 	}

--- a/v2/apiserver/internal/core/mongodb/projects_store_test.go
+++ b/v2/apiserver/internal/core/mongodb/projects_store_test.go
@@ -40,7 +40,7 @@ func TestProjectsStoreCreate(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrConflict{}, err)
-				require.Equal(t, core.ProjectLabel, err.(*meta.ErrConflict).Type)
+				require.Equal(t, core.ProjectKind, err.(*meta.ErrConflict).Type)
 				require.Equal(t, testProject.ID, err.(*meta.ErrConflict).ID)
 				require.Contains(t, err.(*meta.ErrConflict).Reason, "already exists")
 			},
@@ -312,7 +312,7 @@ func TestProjectsStoreGet(t *testing.T) {
 			assertions: func(project core.Project, err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, core.ProjectLabel, err.(*meta.ErrNotFound).Type)
+				require.Equal(t, core.ProjectKind, err.(*meta.ErrNotFound).Type)
 				require.Equal(t, testProjectID, err.(*meta.ErrNotFound).ID)
 			},
 		},
@@ -406,7 +406,7 @@ func TestProjectsStoreUpdate(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, core.ProjectLabel, err.(*meta.ErrNotFound).Type)
+				require.Equal(t, core.ProjectKind, err.(*meta.ErrNotFound).Type)
 				require.Equal(t, testProject.ID, err.(*meta.ErrNotFound).ID)
 			},
 		},
@@ -486,7 +486,7 @@ func TestProjectsStoreDelete(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, core.ProjectLabel, err.(*meta.ErrNotFound).Type)
+				require.Equal(t, core.ProjectKind, err.(*meta.ErrNotFound).Type)
 				require.Equal(t, testProjectID, err.(*meta.ErrNotFound).ID)
 			},
 		},

--- a/v2/apiserver/internal/core/mongodb/projects_store_test.go
+++ b/v2/apiserver/internal/core/mongodb/projects_store_test.go
@@ -40,7 +40,7 @@ func TestProjectsStoreCreate(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrConflict{}, err)
-				require.Equal(t, "Project", err.(*meta.ErrConflict).Type)
+				require.Equal(t, core.ProjectLabel, err.(*meta.ErrConflict).Type)
 				require.Equal(t, testProject.ID, err.(*meta.ErrConflict).ID)
 				require.Contains(t, err.(*meta.ErrConflict).Reason, "already exists")
 			},
@@ -312,7 +312,7 @@ func TestProjectsStoreGet(t *testing.T) {
 			assertions: func(project core.Project, err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, "Project", err.(*meta.ErrNotFound).Type)
+				require.Equal(t, core.ProjectLabel, err.(*meta.ErrNotFound).Type)
 				require.Equal(t, testProjectID, err.(*meta.ErrNotFound).ID)
 			},
 		},
@@ -406,7 +406,7 @@ func TestProjectsStoreUpdate(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, "Project", err.(*meta.ErrNotFound).Type)
+				require.Equal(t, core.ProjectLabel, err.(*meta.ErrNotFound).Type)
 				require.Equal(t, testProject.ID, err.(*meta.ErrNotFound).ID)
 			},
 		},
@@ -486,7 +486,7 @@ func TestProjectsStoreDelete(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrNotFound{}, err)
-				require.Equal(t, "Project", err.(*meta.ErrNotFound).Type)
+				require.Equal(t, core.ProjectLabel, err.(*meta.ErrNotFound).Type)
 				require.Equal(t, testProjectID, err.(*meta.ErrNotFound).ID)
 			},
 		},

--- a/v2/apiserver/internal/core/mongodb/workers_store.go
+++ b/v2/apiserver/internal/core/mongodb/workers_store.go
@@ -48,7 +48,7 @@ func (w *workersStore) UpdateStatus(
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: "Event",
+			Type: core.EventLabel,
 			ID:   eventID,
 		}
 	}

--- a/v2/apiserver/internal/core/mongodb/workers_store.go
+++ b/v2/apiserver/internal/core/mongodb/workers_store.go
@@ -48,7 +48,7 @@ func (w *workersStore) UpdateStatus(
 	}
 	if res.MatchedCount == 0 {
 		return &meta.ErrNotFound{
-			Type: core.EventLabel,
+			Type: core.EventKind,
 			ID:   eventID,
 		}
 	}

--- a/v2/apiserver/internal/core/projects.go
+++ b/v2/apiserver/internal/core/projects.go
@@ -14,8 +14,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ProjectLabel represents the canonical Project label string
-const ProjectLabel = "Project"
+// ProjectKind represents the canonical Project kind string
+const ProjectKind = "Project"
 
 // Project is Brigade's fundamental configuration, management, and isolation
 // construct.
@@ -52,7 +52,7 @@ func (p Project) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       ProjectLabel,
+				Kind:       ProjectKind,
 			},
 			Alias: (Alias)(p),
 		},

--- a/v2/apiserver/internal/core/projects.go
+++ b/v2/apiserver/internal/core/projects.go
@@ -14,6 +14,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ProjectLabel represents the canonical Project label string
+const ProjectLabel = "Project"
+
 // Project is Brigade's fundamental configuration, management, and isolation
 // construct.
 // - Configuration: Users define Projects to pair EventSubscriptions with
@@ -49,7 +52,7 @@ func (p Project) MarshalJSON() ([]byte, error) {
 		}{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: meta.APIVersion,
-				Kind:       "Project",
+				Kind:       ProjectLabel,
 			},
 			Alias: (Alias)(p),
 		},

--- a/v2/apiserver/internal/core/projects_test.go
+++ b/v2/apiserver/internal/core/projects_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestProjectMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(t, &Project{}, "Project")
+	metaTesting.RequireAPIVersionAndType(t, &Project{}, ProjectLabel)
 }
 
 func TestProjectListMarshalJSON(t *testing.T) {

--- a/v2/apiserver/internal/core/projects_test.go
+++ b/v2/apiserver/internal/core/projects_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestProjectMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(t, &Project{}, ProjectLabel)
+	metaTesting.RequireAPIVersionAndType(t, &Project{}, ProjectKind)
 }
 
 func TestProjectListMarshalJSON(t *testing.T) {

--- a/v2/apiserver/internal/core/workers.go
+++ b/v2/apiserver/internal/core/workers.go
@@ -12,9 +12,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// WorkerLabel represents the canonical Worker label string
-const WorkerLabel = "Worker"
-
 // LogLevel represents the desired granularity of Worker log output.
 type LogLevel string
 
@@ -285,7 +282,7 @@ func (w *workersService) Start(ctx context.Context, eventID string) error {
 
 	if event.Worker.Status.Phase != WorkerPhasePending {
 		return &meta.ErrConflict{
-			Type: EventLabel,
+			Type: EventKind,
 			ID:   event.ID,
 			Reason: fmt.Sprintf(
 				"Event %q worker has already been started.",

--- a/v2/apiserver/internal/core/workers.go
+++ b/v2/apiserver/internal/core/workers.go
@@ -12,6 +12,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// WorkerLabel represents the canonical Worker label string
+const WorkerLabel = "Worker"
+
 // LogLevel represents the desired granularity of Worker log output.
 type LogLevel string
 
@@ -282,7 +285,7 @@ func (w *workersService) Start(ctx context.Context, eventID string) error {
 
 	if event.Worker.Status.Phase != WorkerPhasePending {
 		return &meta.ErrConflict{
-			Type: "Event",
+			Type: EventLabel,
 			ID:   event.ID,
 			Reason: fmt.Sprintf(
 				"Event %q worker has already been started.",

--- a/v2/internal/kubernetes/common.go
+++ b/v2/internal/kubernetes/common.go
@@ -12,6 +12,12 @@ const (
 	LabelJob       = "brigade.sh/job"
 	LabelProject   = "brigade.sh/project"
 
+	LabelKeyWorker         = "worker"
+	LabelKeyJob            = "job"
+	LabelKeyEvent          = "event"
+	LabelKeyWorkspace      = "workspace"
+	LabelKeyProjectSecrets = "project-secrets"
+
 	SecretTypeProjectSecrets = "brigade.sh/project-secrets"
 	SecretTypeEvent          = "brigade.sh/event"
 	SecretTypeJobSecrets     = "brigade.sh/job"
@@ -32,7 +38,7 @@ func WorkerPodName(eventID string) string {
 func WorkerPodsSelector() string {
 	return labels.Set(
 		map[string]string{
-			LabelComponent: "worker",
+			LabelComponent: LabelKeyWorker,
 		},
 	).AsSelector().String()
 }
@@ -48,7 +54,7 @@ func JobPodName(eventID, jobName string) string {
 func JobPodsSelector() string {
 	return labels.Set(
 		map[string]string{
-			LabelComponent: "job",
+			LabelComponent: LabelKeyJob,
 		},
 	).AsSelector().String()
 }

--- a/v2/observer/jobs_test.go
+++ b/v2/observer/jobs_test.go
@@ -53,7 +53,7 @@ func TestSyncJobPods(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testPodName,
 			Labels: map[string]string{
-				myk8s.LabelComponent: "job",
+				myk8s.LabelComponent: myk8s.LabelKeyJob,
 			},
 		},
 	}

--- a/v2/observer/workers_test.go
+++ b/v2/observer/workers_test.go
@@ -53,7 +53,7 @@ func TestSyncWorkerPods(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testPodName,
 			Labels: map[string]string{
-				myk8s.LabelComponent: "worker",
+				myk8s.LabelComponent: myk8s.LabelKeyWorker,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds consts for commonly used resource names and updates applicable logic to use them

Closes https://github.com/brigadecore/brigade/issues/1174

**Special notes for your reviewer**:

There are still some resources not const-ified (search the repo for all instances of `Kind:` in creating meta.TypeMeta structs)... do we want to update these as well, even though there currently might only be one use of such strings?

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
