### PR TITLE
a more elegant way of managing CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file is described here:  https://help.github.com/en/articles/about-code-owners
 
 # Global Owners: These members are Core Maintainers of Brigade
-* @technosophos @adamreese @mumoshu @vdice @radu-matei @lukepatrick @krancour
+* @brigadecore/maintainers


### PR DESCRIPTION
If we agree this is an improvement, I have PRs ready to to rip for most other repos in this org.