### PR TITLE
a more elegant way of managing CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # This file is described here:  https://help.github.com/en/articles/about-code-owners
 
 # Global Owners: These members are Core Maintainers of Brigade
-* @technosophos @adamreese @mumoshu @vdice @radu-matei @lukepatrick @krancour
+* @brigadecore/maintainers
 
 # Specific responsibilities
 brigade-controller/ @adamreese


### PR DESCRIPTION
Like #1318 but for the master branch... necessary since it's still going to be some time before `v2` is merged into `master`.