### PR TITLE
export Event from brigadier and worker's brigadier polyfill

### DIFF
--- a/v2/brigadier/src/index.ts
+++ b/v2/brigadier/src/index.ts
@@ -1,4 +1,4 @@
-export { events } from "./events"
-export { SerialGroup, ConcurrentGroup } from "./groups"
-export { Job, Container, JobHost } from "./jobs"
+export { Event, events } from "./events"
+export { ConcurrentGroup, SerialGroup } from "./groups"
+export { Container, Job, JobHost } from "./jobs"
 export { logger } from "./logger"

--- a/v2/brigadier/test/index.ts
+++ b/v2/brigadier/test/index.ts
@@ -6,11 +6,13 @@ import * as brigadier from "../src"
 describe("brigadier", () => {
   it("has expected exports", () => {
     assert.property(brigadier, "Container")
-    assert.property(brigadier, "events")
-    assert.property(brigadier, "SerialGroup")
     assert.property(brigadier, "ConcurrentGroup")
+    // TODO: Figure out how to assert that an interface was exported.
+    // assert.property(brigadier, "Event")
+    assert.property(brigadier, "events")
     assert.property(brigadier, "Job")    
     assert.property(brigadier, "JobHost")
     assert.property(brigadier, "logger")
+    assert.property(brigadier, "SerialGroup")
   })
 })

--- a/v2/worker/src/brigadier.ts
+++ b/v2/worker/src/brigadier.ts
@@ -5,7 +5,7 @@
 // Brigade API server.
 
 // Export these things directly from Brigadier
-export { Container, SerialGroup, ConcurrentGroup, JobHost }  from "../../brigadier/src"
+export { Container, ConcurrentGroup, Event, JobHost, SerialGroup }  from "../../brigadier/src"
 
 // These are custom implementations of resources ordinarily found in Brigadier
 export { events } from "./events"

--- a/v2/worker/test/brigadier.ts
+++ b/v2/worker/test/brigadier.ts
@@ -6,11 +6,13 @@ import * as brigadier from "../src/brigadier"
 describe("brigadier", () => {
   it("has expected exports", () => {
     assert.property(brigadier, "Container")
-    assert.property(brigadier, "events")
-    assert.property(brigadier, "SerialGroup")
     assert.property(brigadier, "ConcurrentGroup")
+    // TODO: Figure out how to assert that an interface was exported.
+    // assert.property(brigadier, "Event")
+    assert.property(brigadier, "events")
     assert.property(brigadier, "Job")    
     assert.property(brigadier, "JobHost")
     assert.property(brigadier, "logger")
+    assert.property(brigadier, "SerialGroup")
   })
 })


### PR DESCRIPTION
Fixes #1317

While touching these files anyway, I also organized exports alphabetically, which seems cleaner and more consistent.

Note that there are two new TODOs here that I do not intend to resolve at this time. It seems that approach we used for validating something is exported as expected, which works beautifully for constants, variables, and classes, simply does NOT work for interfaces. I'm not clear on why.

I have, however, manually verified that these changes address #1317.