### PR TITLE
expose worker git details to brigadier-based scripts

### DIFF
--- a/v2/brigadier/src/workers.ts
+++ b/v2/brigadier/src/workers.ts
@@ -25,4 +25,33 @@ export interface Worker {
    * configuration.
    */
   logLevel?: string
+  /**
+   * If applicable, contains git-specific Worker details.
+   */
+  git?: GitConfig
+}
+
+/**
+ * Represents git-specific Worker details.
+ */
+export interface GitConfig {
+  /**
+   * Specifies the remote repository where, if applicable, the Worker will have
+   * obtained source code from.
+   */
+  cloneURL: string
+  /**
+   * Specifies the exact commit where, if applicable, the Worker will have
+   * obtained source code from.
+   */
+  commit?: string
+  /**
+   * Specifies a symbolic reference to the commit where, if applicable, the
+   * Worker will have obtained source code from.
+   *
+   * It is sometimes useful for Brigade scripts (e.g. brigade.js or brigade.ts)
+   * to examine the value of this field to determine, for instance, the name of
+   * a branch or tag related to the Event the Worker is handling.
+   */
+  ref?: string
 }


### PR DESCRIPTION
When working on #1316 I discovered that scripts had no way of getting to commit/ref info.

This PR fixes that.

The API server already includes this information when it creates the k8s secret for an Event. The only issue was that we weren't exposing it neatly via Brigadier.