### PR TITLE
add script and make target for standing up a customized kind cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,10 @@ publish-cli: build-cli
 # Targets to facilitate hacking on Brigade.                                    #
 ################################################################################
 
+.PHONY: hack-new-kind-cluster
+hack-new-kind-cluster:
+	hack/kind/new-cluster.sh
+
 .PHONY: hack-build-images
 hack-build-images: hack-build-apiserver hack-build-scheduler hack-build-observer hack-build-logger-linux hack-build-git-initializer hack-build-worker
 

--- a/hack/kind/new-cluster.sh
+++ b/hack/kind/new-cluster.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+
+set -o errexit
+
+# Create a local Docker image registry that we'll hook up to kind
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+# Create a kind cluster with the local Docker image registry enabled
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: brigadecore/kind-node:v1.20.2
+  extraPortMappings:
+  - containerPort: 31600
+    hostPort: 31600
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_name}:${reg_port}"]
+EOF
+
+# Make sure the local Docker image registry is connected to the same network
+# as the kind cluster
+docker network connect "kind" "${reg_name}" || true
+
+# Tell each node to use the local Docker image registry
+for node in $(kind get nodes); do
+  kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${reg_port}";
+done
+
+# Set up NFS
+helm repo ls | grep https://charts.helm.sh/stable || helm repo add stable https://charts.helm.sh/stable
+kubectl create namespace nfs
+helm install nfs stable/nfs-server-provisioner -n nfs


### PR DESCRIPTION
As the number of contributors to v2 starts to grow, I figure it might be useful to start sharing some of the little hacks that I've kept to myself until now.

This PR adds a make target for standing up a new customized kind cluster that:

* Is integrated with a local Docker registry
* Forwards localhost:31600 to the API server
* Has NFS support pre-installed to support Brigade's "shared workspaces" feature

End-user documentation will obviously have to address what the prerequisites within a cluster are, in general, for running Brigade 2. This contribution is not aimed at end-users. It's aimed at contributors who want to rapidly set up a suitable, local environment to facilitate development.

A comprehensive guide to hacking on v2 will follow in another PR.