### PR TITLE
API version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ To install Brigade 2 with _default_ configuration:
 
 ```console
 $ export HELM_EXPERIMENTAL_OCI=1
-$ helm chart pull ghcr.io/brigadecore/brigade:v2.0.0-alpha.1
-$ helm chart export ghcr.io/brigadecore/brigade:v2.0.0-alpha.1 -d ~/charts
+$ helm chart pull ghcr.io/brigadecore/brigade:v2.0.0-alpha.2
+$ helm chart export ghcr.io/brigadecore/brigade:v2.0.0-alpha.2 -d ~/charts
 $ kubectl create namespace brigade2
 $ helm install brigade2 ~/charts/brigade --namespace brigade2
 ```

--- a/examples/01-hello-world/project.yaml
+++ b/examples/01-hello-world/project.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-alpha.1
+apiVersion: brigade.sh/v2-alpha.2
 kind: Project
 metadata:
   id: hello-world

--- a/examples/02-first-event/project.yaml
+++ b/examples/02-first-event/project.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-alpha.1
+apiVersion: brigade.sh/v2-alpha.2
 kind: Project
 metadata:
   id: first-event

--- a/examples/03-first-job/project.yaml
+++ b/examples/03-first-job/project.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-alpha.1
+apiVersion: brigade.sh/v2-alpha.2
 kind: Project
 metadata:
   id: first-job

--- a/examples/04-simple-pipeline/project.yaml
+++ b/examples/04-simple-pipeline/project.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-alpha.1
+apiVersion: brigade.sh/v2-alpha.2
 kind: Project
 metadata:
   id: simple-pipeline

--- a/examples/05-groups/project.yaml
+++ b/examples/05-groups/project.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-alpha.1
+apiVersion: brigade.sh/v2-alpha.2
 kind: Project
 metadata:
   id: groups

--- a/examples/06-git/project.yaml
+++ b/examples/06-git/project.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-alpha.1
+apiVersion: brigade.sh/v2-alpha.2
 kind: Project
 metadata:
   id: git

--- a/examples/07-npm/project.yaml
+++ b/examples/07-npm/project.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-alpha.1
+apiVersion: brigade.sh/v2-alpha.2
 kind: Project
 metadata:
   id: npm

--- a/examples/08-yarn/project.yaml
+++ b/examples/08-yarn/project.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-alpha.1
+apiVersion: brigade.sh/v2-alpha.2
 kind: Project
 metadata:
   id: yarn

--- a/examples/09-typescript/project.yaml
+++ b/examples/09-typescript/project.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-alpha.1
+apiVersion: brigade.sh/v2-alpha.2
 kind: Project
 metadata:
   id: hello-typescript

--- a/examples/10-kitchen-sink/project.yaml
+++ b/examples/10-kitchen-sink/project.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-alpha.1
+apiVersion: brigade.sh/v2-alpha.2
 kind: Project
 metadata:
   id: kitchen-sink

--- a/sdk/v2/meta/meta.go
+++ b/sdk/v2/meta/meta.go
@@ -4,7 +4,7 @@ import "time"
 
 // APIVersion represents the API and major version thereof with which this
 // version of the Brigade SDK is compatible.
-const APIVersion = "brigade.sh/v2-alpha.1"
+const APIVersion = "brigade.sh/v2-alpha.2"
 
 // TypeMeta represents metadata about a resource type to help clients and
 // servers mutually head off potential confusion over types (and versions

--- a/v2/apiserver/internal/meta/meta.go
+++ b/v2/apiserver/internal/meta/meta.go
@@ -4,7 +4,7 @@ import "time"
 
 // APIVersion represents the API and major version thereof with which this
 // version of the Brigade API server is compatible.
-const APIVersion = "brigade.sh/v2-alpha.1"
+const APIVersion = "brigade.sh/v2-alpha.2"
 
 // TypeMeta represents metadata about a resource type to help clients and
 // servers mutually head off potential confusion over types (and versions of

--- a/v2/apiserver/internal/meta/testing/meta.go
+++ b/v2/apiserver/internal/meta/testing/meta.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const apiVersion = "brigade.sh/v2-alpha.1"
+const apiVersion = "brigade.sh/v2-alpha.2"
 
 func RequireAPIVersionAndType(
 	t *testing.T,

--- a/v2/apiserver/schemas/common.json
+++ b/v2/apiserver/schemas/common.json
@@ -8,7 +8,7 @@
 		"apiVersion": {
 			"type": "string",
 			"description": "The major version of the Brigade API with which this object conforms",
-			"enum": ["brigade.sh/v2-alpha.1"]
+			"enum": ["brigade.sh/v2-alpha.2"]
 		},
 
 		"description": {

--- a/v2/brigadier-polyfill/src/jobs.ts
+++ b/v2/brigadier-polyfill/src/jobs.ts
@@ -33,7 +33,7 @@ export class Job extends BrigadierJob {
           Authorization: `Bearer ${this.event.worker.apiToken}`
         },
         data: {
-          apiVersion: "brigade.sh/v2-alpha.1",
+          apiVersion: "brigade.sh/v2-alpha.2",
           kind: "Job",
           name: this.name,
           spec: {


### PR DESCRIPTION
@vdice and I previously agreed that we'd just assume breaking changes occur between _alpha_ releases, so this PR bumps everything from v2.0.0-alpha.1 to v2.0.0-alpha.2.

_By design_, this will make v2.0.0-alpha.1 clients incompatible with the v2.0.0-alpha.2 server.

I think this PR should actually just end up being the last thing we merge before we cut v2.0.0-alpha.2.