### PR TITLE
feat(ci): add schema and example validation

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -98,6 +98,20 @@ const testIntegrationJob = (e, p) => {
 }
 jobs[testIntegrationJobName] = testIntegrationJob;
 
+// Schema validation:
+
+const validateSchemasJobName = "validate-schemas";
+const validateSchemasJob = (e, p) => {
+  return new MakeTargetJob(validateSchemasJobName, jsImg, e);
+}
+jobs[validateSchemasJobName] = validateSchemasJob;
+
+const validateExamplesJobName = "validate-examples";
+const validateExamplesJob = (e, p) => {
+  return new MakeTargetJob(validateExamplesJobName, jsImg, e);
+}
+jobs[validateExamplesJobName] = validateExamplesJob;
+
 // Brigadier:
 
 const buildBrigadierJobName = "build-brigadier";
@@ -242,6 +256,9 @@ function runSuite(e, p) {
     run(e, p, testUnitJSJob(e, p)).catch((err) => { return err }),
     run(e, p, lintJSJob(e, p)).catch((err) => { return err }),
     run(e, p, testIntegrationJob(e, p)).catch((err) => { return err }),
+    // Schema validation:
+    run(e, p, validateSchemasJob(e, p)).catch((err) => { return err }),
+    run(e, p, validateExamplesJob(e, p)).catch((err) => { return err }),
     // Brigadier:
     run(e, p, buildBrigadierJob(e, p)).catch((err) => { return err }),
     // Docker images:

--- a/v2/apiserver/schemas/common.json
+++ b/v2/apiserver/schemas/common.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "github.com/brigadecore/brigade/common.schema.json",
+	"$id": "common.json",
 	"description": "A common set of schema definitions shared by other Brigade schemas",
 
 	"definitions": {

--- a/v2/apiserver/schemas/event.json
+++ b/v2/apiserver/schemas/event.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "github.com/brigadecore/brigade/event.schema.json",
+	"$id": "event.json",
 
 	"definitions": {
 
@@ -24,7 +24,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
+			"$ref": "common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"
@@ -34,13 +34,13 @@
 		},
 		"projectID": {
 			"oneOf": [
-				{ "$ref": "file:///brigade/schemas/common.json#/definitions/empty" },
-				{ "$ref": "file:///brigade/schemas/common.json#/definitions/identifier" }
+				{ "$ref": "common.json#/definitions/empty" },
+				{ "$ref": "common.json#/definitions/identifier" }
 			],
 			"description": "The ID of the project the event is for"
 		},
 		"source": {
-			"allOf": [{ "$ref": "file:///brigade/schemas/common.json#/definitions/url" }],
+			"allOf": [{ "$ref": "common.json#/definitions/url" }],
 			"description": "The name of the source that is sending the event"
 		},
 		"sourceState": {
@@ -48,19 +48,19 @@
 			"additionalProperties": false,
 			"properties": {
 				"apiVersion": {
-					"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
+					"$ref": "common.json#/definitions/apiVersion"
 				},
 				"kind": {
-					"$ref": "file:///brigade/schemas/source-state.json#/definitions/kind"
+					"$ref": "source-state.json#/definitions/kind"
 				},
 				"state": {
-					"$ref": "file:///brigade/schemas/source-state.json#/definitions/stateMap"
+					"$ref": "source-state.json#/definitions/stateMap"
 				}
 			},
 			"description": "Source-specific (e.g. gateway-specific) state"
 		},
 		"type": {
-			"allOf": [{ "$ref": "file:///brigade/schemas/common.json#/definitions/label" }],
+			"allOf": [{ "$ref": "common.json#/definitions/label" }],
 			"description": "The type of the event"
 		},
 		"labels": {
@@ -71,7 +71,7 @@
 			"additionalProperties": true,
 			"patternProperties": {
 				"^[\\w:/\\-\\.\\?=\\*]*$": {
-					"$ref": "file:///brigade/schemas/common.json#/definitions/label"
+					"$ref": "common.json#/definitions/label"
 				}
 			},
 			"description": "Labels to help Brigade route the event to subscribed projects"
@@ -87,7 +87,7 @@
 			"maxLength": 100
 		},
 		"git": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig",
+			"allOf": [{ "$ref": "common.json#/definitions/gitConfig" }],
 			"additionalProperties": false
 		},
 		"payload": {

--- a/v2/apiserver/schemas/job-status.json
+++ b/v2/apiserver/schemas/job-status.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "github.com/brigadecore/brigade/v2/job-status.schema.json",
+	"$id": "job-status.json",
 
 	"definitions": {
 
@@ -18,7 +18,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
+			"$ref": "common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"

--- a/v2/apiserver/schemas/job.json
+++ b/v2/apiserver/schemas/job.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "github.com/brigadecore/brigade/v2/job.schema.json",
+	"$id": "job.json",
 
 	"definitions": {
 
@@ -138,7 +138,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
+			"$ref": "common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"
@@ -146,7 +146,7 @@
 		"name": {
 			"allOf": [
 				{
-					"$ref": "file:///brigade/schemas/common.json#/definitions/identifier"
+					"$ref": "common.json#/definitions/identifier"
 				}
 			],
 			"description": "The job's name; must be unique per worker"

--- a/v2/apiserver/schemas/project-role-assignment.json
+++ b/v2/apiserver/schemas/project-role-assignment.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "github.com/brigadecore/brigade/v2/project-role-assignment.schema.json",
+	"$id": "project-role-assignment.json",
 
 	"definitions": {
 
@@ -18,13 +18,13 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
+			"$ref": "common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"
 		},
 		"principal": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/principalReference"
+			"$ref": "common.json#/definitions/principalReference"
 		},
 		"role": {
 			"type": "object",

--- a/v2/apiserver/schemas/project.json
+++ b/v2/apiserver/schemas/project.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "github.com/brigadecore/brigade/v2/project.schema.json",
+	"$id": "project.json",
 
 	"definitions": {
 
@@ -57,7 +57,7 @@
 				"source": {
 					"allOf": [
 						{
-							"$ref": "file:///brigade/schemas/common.json#/definitions/url"
+							"$ref": "common.json#/definitions/url"
 						}
 					],
 					"description": "The name of the event source"
@@ -67,7 +67,7 @@
 					"description": "Types of events from the source",
 					"minItems": 1,
 					"items": {
-						"$ref": "file:///brigade/schemas/common.json#/definitions/label"
+						"$ref": "common.json#/definitions/label"
 					}
 				},
 				"labels": {
@@ -78,7 +78,7 @@
 					"additionalProperties": true,
 					"patternProperties": {
 						"^[\\w:/\\-\\.\\?=\\*]*$": {
-							"$ref": "file:///brigade/schemas/common.json#/definitions/label"
+							"$ref": "common.json#/definitions/label"
 						}
 					}
 				}
@@ -161,7 +161,7 @@
 					],
 					"description": "Kubernetes secrets that can be used as image pull secrets for job images",
 					"items": {
-						"$ref": "file:///brigade/schemas/common.json#/definitions/identifier"
+						"$ref": "common.json#/definitions/identifier"
 					}
 				}
 			}
@@ -179,7 +179,7 @@
 					],
 					"description": "Kubernetes secrets that can be used as image pull secrets for the worker's images",
 					"items": {
-						"$ref": "file:///brigade/schemas/common.json#/definitions/identifier"
+						"$ref": "common.json#/definitions/identifier"
 					}
 				}
 			}
@@ -208,7 +208,7 @@
 				},
 				"git": {
 					"allOf": [
-						{ "$ref": "file:///brigade/schemas/common.json#/definitions/gitConfig" },
+						{ "$ref": "common.json#/definitions/gitConfig" },
 						{
 							"additionalProperties": {
 								"initSubmodules": {
@@ -261,7 +261,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
+			"$ref": "common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"
@@ -272,10 +272,10 @@
 		"description": {
 			"oneOf": [
 				{
-					"$ref": "file:///brigade/schemas/common.json#/definitions/empty"
+					"$ref": "common.json#/definitions/empty"
 				},
 				{
-					"$ref": "file:///brigade/schemas/common.json#/definitions/description"
+					"$ref": "common.json#/definitions/description"
 				}
 			],
 			"description": "A brief description of the project"

--- a/v2/apiserver/schemas/role-assignment.json
+++ b/v2/apiserver/schemas/role-assignment.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "github.com/brigadecore/brigade/v2/role-assignment.schema.json",
+	"$id": "role-assignment.json",
 
 	"definitions": {
 
@@ -65,13 +65,13 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
+			"$ref": "common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"
 		},
 		"principal": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/principalReference"
+			"$ref": "common.json#/definitions/principalReference"
 		},
 		"role": {
 			"anyOf": [

--- a/v2/apiserver/schemas/secret.json
+++ b/v2/apiserver/schemas/secret.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "github.com/brigadecore/brigade/v2/secret.schema.json",
+	"$id": "secret.json",
 
 	"definitions": {
 
@@ -18,7 +18,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
+			"$ref": "common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"

--- a/v2/apiserver/schemas/service-account.json
+++ b/v2/apiserver/schemas/service-account.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "github.com/brigadecore/brigade/v2/service-account.schema.json",
+	"$id": "service-account.json",
 
 	"definitions": {
 
@@ -19,7 +19,7 @@
 				"id": {
 					"allOf": [
 						{
-							"$ref": "file:///brigade/schemas/common.json#/definitions/identifier"
+							"$ref": "common.json#/definitions/identifier"
 						}
 					],
 					"description": "A meaningful identifier for the service account"
@@ -34,7 +34,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
+			"$ref": "common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"
@@ -45,7 +45,7 @@
 		"description": {
 			"allOf": [
 				{
-					"$ref": "file:///brigade/schemas/common.json#/definitions/description"
+					"$ref": "common.json#/definitions/description"
 				}
 			],
 			"description": "A brief description of the service account"

--- a/v2/apiserver/schemas/source-state.json
+++ b/v2/apiserver/schemas/source-state.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "github.com/brigadecore/brigade/v2/source-state.schema.json",
+	"$id": "source-state.json",
 
 	"definitions": {
 
@@ -29,7 +29,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
+			"$ref": "common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"

--- a/v2/apiserver/schemas/worker-status.json
+++ b/v2/apiserver/schemas/worker-status.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "github.com/brigadecore/brigade/v2/worker-status.schema.json",
+	"$id": "worker-status.json",
 
 	"definitions": {
 
@@ -18,7 +18,7 @@
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
-			"$ref": "file:///brigade/schemas/common.json#/definitions/apiVersion"
+			"$ref": "common.json#/definitions/apiVersion"
 		},
 		"kind": {
 			"$ref": "#/definitions/kind"


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds CI for validating schema compilation and examples against these schemas

I couldn't figure out how to keep the namespaced `$id`'s (e.g. `github.com/brigadecore/brigade/v2/job.schema.json`) for each schema and have that work with both ajv (it did not like the `file://` approach we had) and runtime validation by the api server.  So, I simplified the `$id` fields, which also simplifies the `$ref`'s for accessing common definitions.  Thoughts/concerns?

Closes https://github.com/brigadecore/brigade/issues/1247

**Special notes for your reviewer**:

* Not sure if this helps or hurts the VS Code syntax highlighting; I recall there may have been an issue in this realm cc @krancour 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
