### PR TITLE
fix(worker/job services): disallow transition of workers/jobs from terminal status

### DIFF
--- a/v2/apiserver/internal/core/jobs_test.go
+++ b/v2/apiserver/internal/core/jobs_test.go
@@ -1001,7 +1001,12 @@ func TestJobsServiceUpdateStatus(t *testing.T) {
 				},
 			},
 			assertions: func(err error) {
-				require.NoError(t, err)
+				require.Error(t, err)
+				require.Contains(
+					t,
+					err.Error(),
+					`job "italian" has already reached a terminal phase`,
+				)
 			},
 		},
 		{
@@ -1016,7 +1021,7 @@ func TestJobsServiceUpdateStatus(t *testing.T) {
 									{
 										Name: testJobName,
 										Status: &JobStatus{
-											Phase: JobPhaseSucceeded,
+											Phase: JobPhaseRunning,
 										},
 									},
 								},

--- a/v2/apiserver/internal/core/workers_test.go
+++ b/v2/apiserver/internal/core/workers_test.go
@@ -444,7 +444,12 @@ func TestWorkersServiceUpdateStatus(t *testing.T) {
 				},
 			},
 			assertions: func(err error) {
-				require.NoError(t, err)
+				require.Error(t, err)
+				require.Contains(
+					t,
+					err.Error(),
+					"worker has already reached a terminal phase",
+				)
 			},
 		},
 		{

--- a/v2/apiserver/internal/core/workers_test.go
+++ b/v2/apiserver/internal/core/workers_test.go
@@ -382,9 +382,30 @@ func TestWorkersServiceUpdateStatus(t *testing.T) {
 			},
 		},
 		{
+			name: "error retrieving event from store",
+			service: &workersService{
+				authorize: libAuthz.AlwaysAuthorize,
+				eventsStore: &mockEventsStore{
+					GetFn: func(context.Context, string) (Event, error) {
+						return Event{}, errors.New("something went wrong")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error retrieving event")
+			},
+		},
+		{
 			name: "error updating worker in store",
 			service: &workersService{
 				authorize: libAuthz.AlwaysAuthorize,
+				eventsStore: &mockEventsStore{
+					GetFn: func(context.Context, string) (Event, error) {
+						return Event{}, nil
+					},
+				},
 				workersStore: &mockWorkersStore{
 					UpdateStatusFn: func(context.Context, string, WorkerStatus) error {
 						return errors.New("something went wrong")
@@ -398,9 +419,43 @@ func TestWorkersServiceUpdateStatus(t *testing.T) {
 			},
 		},
 		{
+			name: "worker's phase already terminal",
+			service: &workersService{
+				authorize: libAuthz.AlwaysAuthorize,
+				eventsStore: &mockEventsStore{
+					GetFn: func(context.Context, string) (Event, error) {
+						return Event{
+							Worker: Worker{
+								Status: WorkerStatus{
+									Phase: WorkerPhaseCanceled,
+								},
+							},
+						}, nil
+					},
+				},
+				workersStore: &mockWorkersStore{
+					UpdateStatusFn: func(context.Context, string, WorkerStatus) error {
+						require.Fail(
+							t,
+							"UpdateStatusFn should not have been called, but was",
+						)
+						return nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
 			name: "success",
 			service: &workersService{
 				authorize: libAuthz.AlwaysAuthorize,
+				eventsStore: &mockEventsStore{
+					GetFn: func(context.Context, string) (Event, error) {
+						return Event{}, nil
+					},
+				},
 				workersStore: &mockWorkersStore{
 					UpdateStatusFn: func(context.Context, string, WorkerStatus) error {
 						return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

* Disallows updating a worker's or job's status if their phase is already terminal

Closes https://github.com/brigadecore/brigade/issues/1276

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
