### PR TITLE
fix publish cli job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,7 @@ publish-cli: build-cli
 		ghr \
 			-u $(GITHUB_ORG) \
 			-r $(GITHUB_REPO) \
+			-c $$(git rev-parse HEAD) \
 			-t $${GITHUB_TOKEN} \
 			-delete \
 			${VERSION} ./bin \


### PR DESCRIPTION
We need to specify a commit when we do this or else we end up with a tag that points to the head of master-- even if it originally pointed elsewhere (it is deleted and re-created).