### PR TITLE
fix publish-cli target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,6 @@ publish-cli: build-cli
 			-r $(GITHUB_REPO) \
 			-c $$(git rev-parse HEAD) \
 			-t $${GITHUB_TOKEN} \
-			-delete \
 			${VERSION} ./bin \
 	'
 


### PR DESCRIPTION
This is fixes a _different_ problem than #1346...

By using the `-delete` option here, if the release exists, it is deleted and re-created. (And often the release _does_ already exist, because that's often how I create the tag that triggers the delivery pipeline.) Deleting and re-creating the release seems to include deleting and re-creating the tag itself. That's bad news because it puts us into an infinite loop here the release triggers the delivery pipeline, which triggers a new release, which...

`-delete`'s gotta go.