### PR TITLE
Refactor authz

### DIFF
--- a/sdk/v2/authn/principals.go
+++ b/sdk/v2/authn/principals.go
@@ -1,0 +1,26 @@
+package authn
+
+// PrincipalType is a type whose values can be used to disambiguate one type of
+// principal from another. For instance, when assigning a Role to a principal
+// via a RoleAssignment, a PrincipalType field is used to indicate whether the
+// value of the PrincipalID field reflects a User ID or a ServiceAccount ID.
+type PrincipalType string
+
+const (
+	// PrincipalTypeServiceAccount represents a principal that is a
+	// ServiceAccount.
+	PrincipalTypeServiceAccount PrincipalType = "SERVICE_ACCOUNT"
+	// PrincipalTypeUser represents a principal that is a User.
+	PrincipalTypeUser PrincipalType = "USER"
+)
+
+// PrincipalReference is a reference to any sort of security principal (human
+// user, service account, etc.)
+type PrincipalReference struct {
+	// Type qualifies what kind of principal is referenced by the ID field-- for
+	// instance, a User or a ServiceAccount.
+	Type PrincipalType `json:"type,omitempty"`
+	// ID references a principal. The Type qualifies what type of principal that
+	// is-- for instance, a User or a ServiceAccount.
+	ID string `json:"id,omitempty"`
+}

--- a/sdk/v2/authz/role_assignments.go
+++ b/sdk/v2/authz/role_assignments.go
@@ -5,36 +5,12 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/brigadecore/brigade/sdk/v2/authn"
 	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
 	libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
 	"github.com/brigadecore/brigade/sdk/v2/meta"
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
-
-// PrincipalType is a type whose values can be used to disambiguate one type of
-// principal from another. For instance, when assigning a Role to a principal
-// via a RoleAssignment, a PrincipalType field is used to indicate whether the
-// value of the PrincipalID field reflects a User ID or a ServiceAccount ID.
-type PrincipalType string
-
-const (
-	// PrincipalTypeServiceAccount represents a principal that is a
-	// ServiceAccount.
-	PrincipalTypeServiceAccount PrincipalType = "SERVICE_ACCOUNT"
-	// PrincipalTypeUser represents a principal that is a User.
-	PrincipalTypeUser PrincipalType = "USER"
-)
-
-// PrincipalReference is a reference to any sort of security principal (human
-// user, service account, etc.)
-type PrincipalReference struct {
-	// Type qualifies what kind of principal is referenced by the ID field-- for
-	// instance, a User or a ServiceAccount.
-	Type PrincipalType `json:"type,omitempty"`
-	// ID references a principal. The Type qualifies what type of principal that
-	// is-- for instance, a User or a ServiceAccount.
-	ID string `json:"id,omitempty"`
-}
 
 // RoleAssignment represents the assignment of a Role to a principal such as a
 // User or ServiceAccount.
@@ -42,7 +18,7 @@ type RoleAssignment struct {
 	// Role assigns a Role to the specified principal.
 	Role libAuthz.Role `json:"role"`
 	// Principal specifies the principal to whom the Role is assigned.
-	Principal PrincipalReference `json:"principal"`
+	Principal authn.PrincipalReference `json:"principal"`
 }
 
 // MarshalJSON amends RoleAssignment instances with type metadata so that
@@ -110,7 +86,6 @@ func (r *roleAssignmentsClient) Revoke(
 	roleAssignment RoleAssignment,
 ) error {
 	queryParams := map[string]string{
-		"roleType":      string(roleAssignment.Role.Type),
 		"roleName":      string(roleAssignment.Role.Name),
 		"principalType": string(roleAssignment.Principal.Type),
 		"principalID":   roleAssignment.Principal.ID,

--- a/sdk/v2/authz/role_assignments_test.go
+++ b/sdk/v2/authz/role_assignments_test.go
@@ -8,10 +8,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/brigadecore/brigade/sdk/v2/authn"
 	rmTesting "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery/testing" // nolint: lll
 	libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
 	metaTesting "github.com/brigadecore/brigade/sdk/v2/meta/testing"
-	"github.com/brigadecore/brigade/sdk/v2/system"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,11 +32,10 @@ func TestNewRoleAssignmentsClient(t *testing.T) {
 func TestRoleAssignmentsClientGrant(t *testing.T) {
 	testRoleAssignment := RoleAssignment{
 		Role: libAuthz.Role{
-			Type: system.RoleTypeSystem,
 			Name: libAuthz.RoleName("ceo"),
 		},
-		Principal: PrincipalReference{
-			Type: PrincipalTypeUser,
+		Principal: authn.PrincipalReference{
+			Type: authn.PrincipalTypeUser,
 			ID:   "tony@starkindustries.com",
 		},
 	}
@@ -65,11 +64,10 @@ func TestRoleAssignmentsClientGrant(t *testing.T) {
 func TestRoleAssignmentsClientRevoke(t *testing.T) {
 	testRoleAssignment := RoleAssignment{
 		Role: libAuthz.Role{
-			Type: system.RoleTypeSystem,
 			Name: libAuthz.RoleName("ceo"),
 		},
-		Principal: PrincipalReference{
-			Type: PrincipalTypeUser,
+		Principal: authn.PrincipalReference{
+			Type: authn.PrincipalTypeUser,
 			ID:   "tony@starkindustries.com",
 		},
 	}
@@ -80,18 +78,13 @@ func TestRoleAssignmentsClientRevoke(t *testing.T) {
 				require.Equal(t, "/v2/role-assignments", r.URL.Path)
 				require.Equal(
 					t,
-					testRoleAssignment.Role.Type,
-					libAuthz.RoleType(r.URL.Query().Get("roleType")),
-				)
-				require.Equal(
-					t,
 					testRoleAssignment.Role.Name,
 					libAuthz.RoleName(r.URL.Query().Get("roleName")),
 				)
 				require.Equal(
 					t,
 					testRoleAssignment.Principal.Type,
-					PrincipalType(r.URL.Query().Get("principalType")),
+					authn.PrincipalType(r.URL.Query().Get("principalType")),
 				)
 				require.Equal(
 					t,

--- a/sdk/v2/core/authz.go
+++ b/sdk/v2/core/authz.go
@@ -1,22 +1,21 @@
 package core
 
 import (
-	"github.com/brigadecore/brigade/sdk/v2/authz"
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
 // AuthzClient is the specialized client for managing project-level
 // authorization concerns with the Brigade API.
 type AuthzClient interface {
-	// RoleAssignments returns a specialized client for managing project-level
-	// RoleAssignments.
-	RoleAssignments() authz.RoleAssignmentsClient
+	// ProjectRoleAssignments returns a specialized client for managing
+	// ProjectRoleAssignments.
+	ProjectRoleAssignments() ProjectRoleAssignmentsClient
 }
 
 type authzClient struct {
-	// roleAssignmentsClient is a specialized client for managing project-level
-	// RoleAssignments.
-	roleAssignmentsClient authz.RoleAssignmentsClient
+	// projectRoleAssignmentsClient is a specialized client for managing
+	// ProjectRoleAssignments.
+	projectRoleAssignmentsClient ProjectRoleAssignmentsClient
 }
 
 // NewAuthzClient returns a specialized client for managing project-level
@@ -27,7 +26,7 @@ func NewAuthzClient(
 	opts *restmachinery.APIClientOptions,
 ) AuthzClient {
 	return &authzClient{
-		roleAssignmentsClient: NewProjectRoleAssignmentsClient(
+		projectRoleAssignmentsClient: NewProjectRoleAssignmentsClient(
 			apiAddress,
 			apiToken,
 			opts,
@@ -35,6 +34,6 @@ func NewAuthzClient(
 	}
 }
 
-func (a *authzClient) RoleAssignments() authz.RoleAssignmentsClient {
-	return a.roleAssignmentsClient
+func (a *authzClient) ProjectRoleAssignments() ProjectRoleAssignmentsClient {
+	return a.projectRoleAssignmentsClient
 }

--- a/sdk/v2/core/authz_test.go
+++ b/sdk/v2/core/authz_test.go
@@ -14,10 +14,10 @@ func TestNewAuthzClient(t *testing.T) {
 		nil,
 	)
 	require.IsType(t, &authzClient{}, client)
-	require.NotNil(t, client.(*authzClient).roleAssignmentsClient)
+	require.NotNil(t, client.(*authzClient).projectRoleAssignmentsClient)
 	require.Equal(
 		t,
-		client.(*authzClient).roleAssignmentsClient,
-		client.RoleAssignments(),
+		client.(*authzClient).projectRoleAssignmentsClient,
+		client.ProjectRoleAssignments(),
 	)
 }

--- a/sdk/v2/core/named_roles.go
+++ b/sdk/v2/core/named_roles.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
-	"github.com/brigadecore/brigade/sdk/v2/system"
 )
 
 const (
@@ -43,7 +42,6 @@ const (
 // Projects, but should NOT be able to impersonate other gateways.
 func RoleEventCreator(eventSource string) libAuthz.Role {
 	return libAuthz.Role{
-		Type:  system.RoleTypeSystem,
 		Name:  RoleNameEventCreator,
 		Scope: eventSource,
 	}
@@ -53,46 +51,42 @@ func RoleEventCreator(eventSource string) libAuthz.Role {
 // create new Projects.
 func RoleProjectCreator() libAuthz.Role {
 	return libAuthz.Role{
-		Type: system.RoleTypeSystem,
 		Name: RoleNameProjectCreator,
 	}
 }
 
 // Core-specific, project-level roles...
 
-// RoleProjectAdmin returns a project-level Role that enables a principal to
-// manage the Project whose ID matches the value of the Scope field. If the
-// value of the Scope field is RoleScopeGlobal ("*"), then the Role is unbounded
-// and enables a principal to manage all Projects.
-func RoleProjectAdmin(projectID string) libAuthz.Role {
-	return libAuthz.Role{
-		Type:  RoleTypeProject,
-		Name:  RoleNameProjectAdmin,
-		Scope: projectID,
+// RoleProjectAdmin returns a ProjectRole that enables a principal to manage the
+// Project whose ID matches the value of the Scope field. If the value of the
+// Scope field is RoleScopeGlobal ("*"), then the Role is unbounded and enables
+// a principal to manage all Projects.
+func RoleProjectAdmin(projectID string) ProjectRole {
+	return ProjectRole{
+		Name:      RoleNameProjectAdmin,
+		ProjectID: projectID,
 	}
 }
 
-// RoleProjectDeveloper returns a project-level Role that enables a principal to
-// update the Project whose ID matches the value of the Scope field. If the
-// value of the Scope field is RoleScopeGlobal ("*"), then the Role is unbounded
-// and enables a principal to update all Projects.
-func RoleProjectDeveloper(projectID string) libAuthz.Role {
-	return libAuthz.Role{
-		Type:  RoleTypeProject,
-		Name:  RoleNameProjectDeveloper,
-		Scope: projectID,
+// RoleProjectDeveloper returns a ProjectRole that enables a principal to update
+// the Project whose ID matches the value of the Scope field. If the value of
+// the Scope field is RoleScopeGlobal ("*"), then the Role is unbounded and
+// enables a principal to update all Projects.
+func RoleProjectDeveloper(projectID string) ProjectRole {
+	return ProjectRole{
+		Name:      RoleNameProjectDeveloper,
+		ProjectID: projectID,
 	}
 }
 
-// RoleProjectUser returns a project-level Role that enables a principal to
-// create and manage Events for the Project whose ID matches the value of the
-// Scope field. If the value of the Scope field is RoleScopeGlobal ("*"), then
-// the Role is unbounded and enables a principal to create and manage Events for
-// all Projects.
-func RoleProjectUser(projectID string) libAuthz.Role {
-	return libAuthz.Role{
-		Type:  RoleTypeProject,
-		Name:  RoleNameProjectUser,
-		Scope: projectID,
+// RoleProjectUser returns a ProjectRole that enables a principal to create and
+// manage Events for the Project whose ID matches the value of the Scope field.
+// If the value of the Scope field is RoleScopeGlobal ("*"), then the Role is
+// unbounded and enables a principal to create and manage Events for all
+// Projects.
+func RoleProjectUser(projectID string) ProjectRole {
+	return ProjectRole{
+		Name:      RoleNameProjectUser,
+		ProjectID: projectID,
 	}
 }

--- a/sdk/v2/core/project_role.go
+++ b/sdk/v2/core/project_role.go
@@ -1,0 +1,11 @@
+package core
+
+import libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
+
+// ProjectRole represents a set of project-level permissions.
+type ProjectRole struct {
+	// Name is the name of a ProjectRole and has domain-specific meaning.
+	Name libAuthz.RoleName `json:"name,omitempty"`
+	// ProjectID qualifies the scope of the ProjectRole.
+	ProjectID string `json:"projectID,omitempty"`
+}

--- a/sdk/v2/core/project_role_assignments.go
+++ b/sdk/v2/core/project_role_assignments.go
@@ -2,12 +2,52 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
-	"github.com/brigadecore/brigade/sdk/v2/authz"
+	"github.com/brigadecore/brigade/sdk/v2/authn"
 	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	"github.com/brigadecore/brigade/sdk/v2/meta"
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
+
+// RoleAssignment represents the assignment of a ProjectRole to a principal such
+// as a User or ServiceAccount.
+type ProjectRoleAssignment struct {
+	// Role assigns a ProjectRole to the specified principal.
+	Role ProjectRole `json:"role"`
+	// Principal specifies the principal to whom the ProjectRole is assigned.
+	Principal authn.PrincipalReference `json:"principal"`
+}
+
+// MarshalJSON amends ProjectRoleAssignment instances with type metadata so that
+// clients do not need to be concerned with the tedium of doing so.
+func (p ProjectRoleAssignment) MarshalJSON() ([]byte, error) {
+	type Alias ProjectRoleAssignment
+	return json.Marshal(
+		struct {
+			meta.TypeMeta `json:",inline"`
+			Alias         `json:",inline"`
+		}{
+			TypeMeta: meta.TypeMeta{
+				APIVersion: meta.APIVersion,
+				Kind:       "ProjectRoleAssignment",
+			},
+			Alias: (Alias)(p),
+		},
+	)
+}
+
+// ProjectRoleAssignmentsClient is the specialized client for managing
+// ProjectRoleAssignments with the Brigade API.
+type ProjectRoleAssignmentsClient interface {
+	// Grant grants the ProjectRole specified by the ProjectRoleAssignment to the
+	// principal also specified by the ProjectRoleAssignment.
+	Grant(context.Context, ProjectRoleAssignment) error
+	// Revoke revokes the ProjectRole specified by the ProjectRoleAssignment for
+	// the principal also specified by the ProjectRoleAssignment.
+	Revoke(context.Context, ProjectRoleAssignment) error
+}
 
 type projectRoleAssignmentsClient struct {
 	*rm.BaseClient
@@ -19,7 +59,7 @@ func NewProjectRoleAssignmentsClient(
 	apiAddress string,
 	apiToken string,
 	opts *restmachinery.APIClientOptions,
-) authz.RoleAssignmentsClient {
+) ProjectRoleAssignmentsClient {
 	return &projectRoleAssignmentsClient{
 		BaseClient: rm.NewBaseClient(apiAddress, apiToken, opts),
 	}
@@ -27,14 +67,14 @@ func NewProjectRoleAssignmentsClient(
 
 func (p *projectRoleAssignmentsClient) Grant(
 	ctx context.Context,
-	roleAssignment authz.RoleAssignment,
+	projectRoleAssignment ProjectRoleAssignment,
 ) error {
 	return p.ExecuteRequest(
 		ctx,
 		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/project-role-assignments",
-			ReqBodyObj:  roleAssignment,
+			ReqBodyObj:  projectRoleAssignment,
 			SuccessCode: http.StatusOK,
 		},
 	)
@@ -42,13 +82,13 @@ func (p *projectRoleAssignmentsClient) Grant(
 
 func (p *projectRoleAssignmentsClient) Revoke(
 	ctx context.Context,
-	roleAssignment authz.RoleAssignment,
+	projectRoleAssignment ProjectRoleAssignment,
 ) error {
 	queryParams := map[string]string{
-		"roleName":      string(roleAssignment.Role.Name),
-		"roleScope":     roleAssignment.Role.Scope,
-		"principalType": string(roleAssignment.Principal.Type),
-		"principalID":   roleAssignment.Principal.ID,
+		"roleName":      string(projectRoleAssignment.Role.Name),
+		"projectID":     projectRoleAssignment.Role.ProjectID,
+		"principalType": string(projectRoleAssignment.Principal.Type),
+		"principalID":   projectRoleAssignment.Principal.ID,
 	}
 	return p.ExecuteRequest(
 		ctx,

--- a/sdk/v2/core/roles.go
+++ b/sdk/v2/core/roles.go
@@ -1,6 +1,0 @@
-package core
-
-import libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
-
-// RoleTypeProject represents a project-level Role.
-const RoleTypeProject libAuthz.RoleType = "PROJECT"

--- a/sdk/v2/lib/authz/roles.go
+++ b/sdk/v2/lib/authz/roles.go
@@ -1,9 +1,5 @@
 package authz
 
-// RoleType is a type whose values can be used to disambiguate one type of Role
-// from another.
-type RoleType string
-
 // RoleName is a type whose value maps to a well-defined Brigade Role.
 type RoleName string
 
@@ -13,9 +9,6 @@ const RoleScopeGlobal = "*"
 // Role represents a set of permissions, with domain-specific meaning, held by a
 // principal, such as a User or ServiceAccount via a RoleAssignment.
 type Role struct {
-	// Type indicates the Role's type, for instance, system-level or
-	// project-level.
-	Type RoleType `json:"type,omitempty"`
 	// Name is the name of a Role and has domain-specific meaning.
 	Name RoleName `json:"name,omitempty"`
 	// Scope qualifies the scope of the Role. The value is opaque and has meaning

--- a/sdk/v2/system/named_roles.go
+++ b/sdk/v2/system/named_roles.go
@@ -18,7 +18,6 @@ const (
 // ServiceAccounts.
 func RoleAdmin() libAuthz.Role {
 	return libAuthz.Role{
-		Type: RoleTypeSystem,
 		Name: RoleNameAdmin,
 	}
 }
@@ -26,7 +25,6 @@ func RoleAdmin() libAuthz.Role {
 // RoleReader returns a system-level Role that enables global read access.
 func RoleReader() libAuthz.Role {
 	return libAuthz.Role{
-		Type: RoleTypeSystem,
 		Name: RoleNameReader,
 	}
 }

--- a/sdk/v2/system/roles.go
+++ b/sdk/v2/system/roles.go
@@ -1,6 +1,0 @@
-package system
-
-import libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
-
-// RoleTypeSystem represents a system-level Role.
-const RoleTypeSystem libAuthz.RoleType = "SYSTEM"

--- a/v2/apiserver/internal/authn/principals.go
+++ b/v2/apiserver/internal/authn/principals.go
@@ -1,0 +1,26 @@
+package authn
+
+// PrincipalType is a type whose values can be used to disambiguate one type of
+// principal from another. For instance, when assigning a Role to a principal
+// via a RoleAssignment, a PrincipalType field is used to indicate whether the
+// value of the PrincipalID field reflects a User ID or a ServiceAccount ID.
+type PrincipalType string
+
+const (
+	// PrincipalTypeServiceAccount represents a principal that is a
+	// ServiceAccount.
+	PrincipalTypeServiceAccount PrincipalType = "SERVICE_ACCOUNT"
+	// PrincipalTypeUser represents a principal that is a User.
+	PrincipalTypeUser PrincipalType = "USER"
+)
+
+// PrincipalReference is a reference to any sort of security principal (human
+// user, service account, etc.)
+type PrincipalReference struct {
+	// Type qualifies what kind of principal is referenced by the ID field-- for
+	// instance, a User or a ServiceAccount.
+	Type PrincipalType `json:"type,omitempty" bson:"type,omitempty"`
+	// ID references a principal. The Type qualifies what type of principal that
+	// is-- for instance, a User or a ServiceAccount.
+	ID string `json:"id,omitempty" bson:"id,omitempty"`
+}

--- a/v2/apiserver/internal/authz/mock_roles_assignments_store.go
+++ b/v2/apiserver/internal/authz/mock_roles_assignments_store.go
@@ -3,10 +3,9 @@ package authz
 import "context"
 
 type MockRoleAssignmentsStore struct {
-	GrantFn      func(context.Context, RoleAssignment) error
-	RevokeFn     func(context.Context, RoleAssignment) error
-	RevokeManyFn func(context.Context, RoleAssignment) error
-	ExistsFn     func(context.Context, RoleAssignment) (bool, error)
+	GrantFn  func(context.Context, RoleAssignment) error
+	RevokeFn func(context.Context, RoleAssignment) error
+	ExistsFn func(context.Context, RoleAssignment) (bool, error)
 }
 
 func (m *MockRoleAssignmentsStore) Grant(
@@ -21,13 +20,6 @@ func (m *MockRoleAssignmentsStore) Revoke(
 	roleAssignment RoleAssignment,
 ) error {
 	return m.RevokeFn(ctx, roleAssignment)
-}
-
-func (m *MockRoleAssignmentsStore) RevokeMany(
-	ctx context.Context,
-	roleAssignment RoleAssignment,
-) error {
-	return m.RevokeManyFn(ctx, roleAssignment)
 }
 
 func (m *MockRoleAssignmentsStore) Exists(

--- a/v2/apiserver/internal/authz/mongodb/role_assignments_store.go
+++ b/v2/apiserver/internal/authz/mongodb/role_assignments_store.go
@@ -64,38 +64,11 @@ func (r *roleAssignmentsStore) Revoke(
 	return nil
 }
 
-func (r *roleAssignmentsStore) RevokeMany(
-	ctx context.Context,
-	roleAssignment authz.RoleAssignment,
-) error {
-	criteria := bson.M{}
-	if roleAssignment.Role.Type != "" {
-		criteria["role.type"] = roleAssignment.Role.Type
-	}
-	if roleAssignment.Role.Name != "" {
-		criteria["role.name"] = roleAssignment.Role.Name
-	}
-	if roleAssignment.Role.Scope != "" {
-		criteria["role.scope"] = roleAssignment.Role.Scope
-	}
-	if roleAssignment.Principal.Type != "" {
-		criteria["principal.type"] = roleAssignment.Principal.Type
-	}
-	if roleAssignment.Principal.ID != "" {
-		criteria["principal.id"] = roleAssignment.Principal.ID
-	}
-	if _, err := r.collection.DeleteMany(ctx, criteria); err != nil {
-		return errors.Wrap(err, "error deleting role assignments")
-	}
-	return nil
-}
-
 func (r *roleAssignmentsStore) Exists(
 	ctx context.Context,
 	roleAssignment authz.RoleAssignment,
 ) (bool, error) {
 	criteria := bson.M{
-		"role.type":      roleAssignment.Role.Type,
 		"role.name":      roleAssignment.Role.Name,
 		"principal.type": roleAssignment.Principal.Type,
 		"principal.id":   roleAssignment.Principal.ID,

--- a/v2/apiserver/internal/authz/rest/role_assignments_endpoints.go
+++ b/v2/apiserver/internal/authz/rest/role_assignments_endpoints.go
@@ -3,10 +3,10 @@ package rest
 import (
 	"net/http"
 
+	"github.com/brigadecore/brigade/v2/apiserver/internal/authn"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/authz"
 	libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/restmachinery"
-	"github.com/brigadecore/brigade/v2/apiserver/internal/system"
 	"github.com/gorilla/mux"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -58,12 +58,11 @@ func (r *RoleAssignmentsEndpoints) revoke(
 ) {
 	roleAssignment := authz.RoleAssignment{
 		Role: libAuthz.Role{
-			Type:  system.RoleTypeSystem,
 			Name:  libAuthz.RoleName(req.URL.Query().Get("roleName")),
 			Scope: req.URL.Query().Get("roleScope"),
 		},
-		Principal: authz.PrincipalReference{
-			Type: authz.PrincipalType(req.URL.Query().Get("principalType")),
+		Principal: authn.PrincipalReference{
+			Type: authn.PrincipalType(req.URL.Query().Get("principalType")),
 			ID:   req.URL.Query().Get("principalID"),
 		},
 	}

--- a/v2/apiserver/internal/authz/role_assignments.go
+++ b/v2/apiserver/internal/authz/role_assignments.go
@@ -9,38 +9,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PrincipalType is a type whose values can be used to disambiguate one type of
-// principal from another. For instance, when assigning a Role to a principal
-// via a RoleAssignment, a PrincipalType field is used to indicate whether the
-// value of the PrincipalID field reflects a User ID or a ServiceAccount ID.
-type PrincipalType string
-
-const (
-	// PrincipalTypeServiceAccount represents a principal that is a
-	// ServiceAccount.
-	PrincipalTypeServiceAccount PrincipalType = "SERVICE_ACCOUNT"
-	// PrincipalTypeUser represents a principal that is a User.
-	PrincipalTypeUser PrincipalType = "USER"
-)
-
-// PrincipalReference is a reference to any sort of security principal (human
-// user, service account, etc.)
-type PrincipalReference struct {
-	// Type qualifies what kind of principal is referenced by the ID field-- for
-	// instance, a User or a ServiceAccount.
-	Type PrincipalType `json:"type,omitempty" bson:"type,omitempty"`
-	// ID references a principal. The Type qualifies what type of principal that
-	// is-- for instance, a User or a ServiceAccount.
-	ID string `json:"id,omitempty" bson:"id,omitempty"`
-}
-
 // RoleAssignment represents the assignment of a Role to a principal such as a
 // User or ServiceAccount.
 type RoleAssignment struct {
 	// Role assigns a Role to the specified principal.
 	Role libAuthz.Role `json:"role" bson:"role"`
 	// Principal specifies the principal to whom the Role is assigned.
-	Principal PrincipalReference `json:"principal" bson:"principal"`
+	Principal authn.PrincipalReference `json:"principal" bson:"principal"`
 }
 
 // RoleAssignmentsService is the specialized interface for managing
@@ -52,7 +27,6 @@ type RoleAssignmentsService interface {
 	// specified by the RoleAssignment. If the specified principal does not exist,
 	// implementations must return a *meta.ErrNotFound error.
 	Grant(ctx context.Context, roleAssignment RoleAssignment) error
-
 	// Revoke revokes the Role specified by the RoleAssignment for the principal
 	// also specified by the RoleAssignment. If the specified principal does not
 	// exist, implementations must return a *meta.ErrNotFound error.
@@ -91,7 +65,7 @@ func (r *roleAssignmentsService) Grant(
 	}
 
 	switch roleAssignment.Principal.Type {
-	case PrincipalTypeUser:
+	case authn.PrincipalTypeUser:
 		// Make sure the User exists
 		user, err := r.usersStore.Get(ctx, roleAssignment.Principal.ID)
 		if err != nil {
@@ -107,7 +81,7 @@ func (r *roleAssignmentsService) Grant(
 		// Instead we replace it with the ID (with correct case) from the User we
 		// found.
 		roleAssignment.Principal.ID = user.ID
-	case PrincipalTypeServiceAccount:
+	case authn.PrincipalTypeServiceAccount:
 		// Make sure the ServiceAccount exists
 		if _, err :=
 			r.serviceAccountsStore.Get(ctx, roleAssignment.Principal.ID); err != nil {
@@ -145,7 +119,7 @@ func (r *roleAssignmentsService) Revoke(
 	}
 
 	switch roleAssignment.Principal.Type {
-	case PrincipalTypeUser:
+	case authn.PrincipalTypeUser:
 		// Make sure the User exists
 		user, err := r.usersStore.Get(ctx, roleAssignment.Principal.ID)
 		if err != nil {
@@ -161,7 +135,7 @@ func (r *roleAssignmentsService) Revoke(
 		// Instead we replace it with the ID (with correct case) from the User we
 		// found.
 		roleAssignment.Principal.ID = user.ID
-	case PrincipalTypeServiceAccount:
+	case authn.PrincipalTypeServiceAccount:
 		// Make sure the ServiceAccount exists
 		if _, err :=
 			r.serviceAccountsStore.Get(ctx, roleAssignment.Principal.ID); err != nil {
@@ -198,23 +172,6 @@ type RoleAssignmentsStore interface {
 	// Revoke the role specified by the RoleAssignment for the principal specified
 	// by the RoleAssignment.
 	Revoke(context.Context, RoleAssignment) error
-	// RevokeMany revokes all RoleAssignments that share ALL properties of the
-	// specified RoleAssignment. Properties left unspecified are ignored, i.e.
-	// not factored into the match.
-	//
-	// Example -- revoking all project-level RoleAssignments for a given Project:
-	//
-	//   err := p.roleAssignmentsStore.RevokeMany(
-	// 	  ctx,
-	// 	  authz.RoleAssignment{
-	// 		  Role: libAuthz.Role{
-	// 			  Type:  RoleTypeProject,
-	// 			  Scope: projectID,
-	// 		  },
-	// 	  },
-	//   )
-	RevokeMany(ctx context.Context, roleAssignment RoleAssignment) error
-
 	// Exists returns a bool indicating whether the specified RoleAssignment
 	// exists within the store. Implementations MUST also return true if a
 	// RoleAssignment exists in the store that logically "overlaps" the specified

--- a/v2/apiserver/internal/authz/role_assignments_test.go
+++ b/v2/apiserver/internal/authz/role_assignments_test.go
@@ -55,8 +55,8 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 		{
 			name: "error retrieving user from store",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
-					Type: PrincipalTypeUser,
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeUser,
 					ID:   "foo",
 				},
 			},
@@ -77,8 +77,8 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 		{
 			name: "error retrieving service account from store",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
-					Type: PrincipalTypeServiceAccount,
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
 			},
@@ -99,8 +99,8 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 		{
 			name: "error granting the role",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
-					Type: PrincipalTypeServiceAccount,
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
 			},
@@ -126,8 +126,8 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 		{
 			name: "success",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
-					Type: PrincipalTypeServiceAccount,
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
 			},
@@ -180,8 +180,8 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 		{
 			name: "error retrieving user from store",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
-					Type: PrincipalTypeUser,
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeUser,
 					ID:   "foo",
 				},
 			},
@@ -202,8 +202,8 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 		{
 			name: "error retrieving service account from store",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
-					Type: PrincipalTypeServiceAccount,
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
 			},
@@ -224,8 +224,8 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 		{
 			name: "error revoking the role",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
-					Type: PrincipalTypeServiceAccount,
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
 			},
@@ -251,8 +251,8 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 		{
 			name: "success",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
-					Type: PrincipalTypeServiceAccount,
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
 			},

--- a/v2/apiserver/internal/core/logs.go
+++ b/v2/apiserver/internal/core/logs.go
@@ -80,27 +80,30 @@ type LogsService interface {
 }
 
 type logsService struct {
-	authorize     libAuthz.AuthorizeFn
-	projectsStore ProjectsStore
-	eventsStore   EventsStore
-	warmLogsStore LogsStore
-	coolLogsStore LogsStore
+	authorize        libAuthz.AuthorizeFn
+	projectAuthorize ProjectAuthorizeFn
+	projectsStore    ProjectsStore
+	eventsStore      EventsStore
+	warmLogsStore    LogsStore
+	coolLogsStore    LogsStore
 }
 
 // NewLogsService returns a specialized interface for accessing logs.
 func NewLogsService(
 	authorizeFn libAuthz.AuthorizeFn,
+	projectAuthorize ProjectAuthorizeFn,
 	projectsStore ProjectsStore,
 	eventsStore EventsStore,
 	warmLogsStore LogsStore,
 	coolLogsStore LogsStore,
 ) LogsService {
 	return &logsService{
-		authorize:     authorizeFn,
-		projectsStore: projectsStore,
-		eventsStore:   eventsStore,
-		warmLogsStore: warmLogsStore,
-		coolLogsStore: coolLogsStore,
+		authorize:        authorizeFn,
+		projectAuthorize: projectAuthorize,
+		projectsStore:    projectsStore,
+		eventsStore:      eventsStore,
+		warmLogsStore:    warmLogsStore,
+		coolLogsStore:    coolLogsStore,
 	}
 }
 
@@ -146,7 +149,8 @@ func (l *logsService) Stream(
 	// misstep. So, out of an abundance of caution, we raise the bar a little on
 	// this one read-only operation and require the principal to be a project user
 	// in order to stream logs.
-	if err = l.authorize(ctx, RoleProjectUser(event.ProjectID)); err != nil {
+	if err =
+		l.projectAuthorize(ctx, RoleProjectUser(event.ProjectID)); err != nil {
 		return nil, err
 	}
 

--- a/v2/apiserver/internal/core/logs_test.go
+++ b/v2/apiserver/internal/core/logs_test.go
@@ -22,12 +22,14 @@ func TestLogsService(t *testing.T) {
 	coolLogsStore := &mockLogsStore{}
 	svc := NewLogsService(
 		libAuthz.AlwaysAuthorize,
+		alwaysAuthorize,
 		projectsStore,
 		eventsStore,
 		warmLogsStore,
 		coolLogsStore,
 	)
 	require.NotNil(t, svc.(*logsService).authorize)
+	require.NotNil(t, svc.(*logsService).projectAuthorize)
 	require.Same(t, projectsStore, svc.(*logsService).projectsStore)
 	require.Same(t, eventsStore, svc.(*logsService).eventsStore)
 	require.Same(t, warmLogsStore, svc.(*logsService).warmLogsStore)
@@ -74,7 +76,7 @@ func TestLogsServiceStream(t *testing.T) {
 		{
 			name: "unauthorized",
 			service: &logsService{
-				authorize: libAuthz.NeverAuthorize,
+				projectAuthorize: neverAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -92,7 +94,7 @@ func TestLogsServiceStream(t *testing.T) {
 				Job: "foo",
 			},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -113,7 +115,7 @@ func TestLogsServiceStream(t *testing.T) {
 				Container: "bar",
 			},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
@@ -139,7 +141,7 @@ func TestLogsServiceStream(t *testing.T) {
 			name:     "error retrieving project from store",
 			selector: LogsSelector{},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -161,7 +163,7 @@ func TestLogsServiceStream(t *testing.T) {
 			name:     "warm logs succeed",
 			selector: LogsSelector{},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -205,7 +207,7 @@ func TestLogsServiceStream(t *testing.T) {
 			name:     "warm logs store has unexpected error",
 			selector: LogsSelector{},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -237,7 +239,7 @@ func TestLogsServiceStream(t *testing.T) {
 			name:     "cool logs succeed",
 			selector: LogsSelector{},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -281,7 +283,7 @@ func TestLogsServiceStream(t *testing.T) {
 			name:     "warm and cool logs both fail",
 			selector: LogsSelector{},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil

--- a/v2/apiserver/internal/core/mongodb/project_role_assignments_store.go
+++ b/v2/apiserver/internal/core/mongodb/project_role_assignments_store.go
@@ -1,0 +1,103 @@
+package mongodb
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/v2/apiserver/internal/core"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/mongodb"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// projectRoleAssignmentsStore is a MongoDB-based implementation of the
+// core.ProjectRoleAssignmentsStore interface.
+type projectRoleAssignmentsStore struct {
+	collection mongodb.Collection
+}
+
+// NewProjectRoleAssignmentsStore returns a MongoDB-based implementation of the
+// core.ProjectRoleAssignmentsStore interface.
+func NewProjectRoleAssignmentsStore(
+	database *mongo.Database,
+) core.ProjectRoleAssignmentsStore {
+	// TODO: Add indices
+	return &projectRoleAssignmentsStore{
+		collection: database.Collection("project-role-assignments"),
+	}
+}
+
+func (p *projectRoleAssignmentsStore) Grant(
+	ctx context.Context,
+	projectRoleAssignment core.ProjectRoleAssignment,
+) error {
+	tru := true
+	if res := p.collection.FindOneAndReplace(
+		ctx,
+		projectRoleAssignment,
+		projectRoleAssignment,
+		&options.FindOneAndReplaceOptions{
+			Upsert: &tru,
+		},
+	); res.Err() != nil && res.Err() != mongo.ErrNoDocuments {
+		return errors.Wrapf(
+			res.Err(),
+			"error upserting project role assignment %v",
+			projectRoleAssignment,
+		)
+	}
+	return nil
+}
+
+func (p *projectRoleAssignmentsStore) Revoke(
+	ctx context.Context,
+	roleAssignment core.ProjectRoleAssignment,
+) error {
+	if _, err := p.collection.DeleteOne(ctx, roleAssignment); err != nil {
+		return errors.Wrapf(
+			err,
+			"error deleting project role assignment %v",
+			roleAssignment,
+		)
+	}
+	return nil
+}
+
+func (p *projectRoleAssignmentsStore) RevokeMany(
+	ctx context.Context,
+	projectID string,
+) error {
+	criteria := bson.M{
+		"role.projectID": projectID,
+	}
+	if _, err := p.collection.DeleteMany(ctx, criteria); err != nil {
+		return errors.Wrap(err, "error deleting project role assignments")
+	}
+	return nil
+}
+
+func (p *projectRoleAssignmentsStore) Exists(
+	ctx context.Context,
+	roleAssignment core.ProjectRoleAssignment,
+) (bool, error) {
+	criteria := bson.M{
+		"role.name": roleAssignment.Role.Name,
+		"role.projectID": bson.M{
+			"$in": []string{
+				roleAssignment.Role.ProjectID,
+				core.ProjectIDGlobal,
+			},
+		},
+		"principal.type": roleAssignment.Principal.Type,
+		"principal.id":   roleAssignment.Principal.ID,
+	}
+	err := p.collection.FindOne(ctx, criteria).Err()
+	if err == mongo.ErrNoDocuments {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.Wrap(err, "error finding role assignment")
+	}
+	return true, nil
+}

--- a/v2/apiserver/internal/core/mongodb/project_role_assignments_store_test.go
+++ b/v2/apiserver/internal/core/mongodb/project_role_assignments_store_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/brigadecore/brigade/v2/apiserver/internal/authz"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/core"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/mongodb"
 	mongoTesting "github.com/brigadecore/brigade/v2/apiserver/internal/lib/mongodb/testing" // nolint: lll
 	"github.com/stretchr/testify/require"
@@ -14,7 +14,7 @@ import (
 )
 
 func TestGrant(t *testing.T) {
-	testRoleAssignment := authz.RoleAssignment{}
+	testProjectRoleAssignment := core.ProjectRoleAssignment{}
 	testCases := []struct {
 		name       string
 		collection mongodb.Collection
@@ -39,7 +39,11 @@ func TestGrant(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error upserting role assignment")
+				require.Contains(
+					t,
+					err.Error(),
+					"error upserting project role assignment",
+				)
 			},
 		},
 		{
@@ -51,7 +55,7 @@ func TestGrant(t *testing.T) {
 					interface{},
 					...*options.FindOneAndReplaceOptions,
 				) *mongo.SingleResult {
-					res, err := mongoTesting.MockSingleResult(testRoleAssignment)
+					res, err := mongoTesting.MockSingleResult(testProjectRoleAssignment)
 					require.NoError(t, err)
 					return res
 				},
@@ -63,17 +67,17 @@ func TestGrant(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			store := &roleAssignmentsStore{
+			store := &projectRoleAssignmentsStore{
 				collection: testCase.collection,
 			}
-			err := store.Grant(context.Background(), testRoleAssignment)
+			err := store.Grant(context.Background(), testProjectRoleAssignment)
 			testCase.assertions(err)
 		})
 	}
 }
 
 func TestRevoke(t *testing.T) {
-	testRoleAssignment := authz.RoleAssignment{}
+	testProjectRoleAssignment := core.ProjectRoleAssignment{}
 	testCases := []struct {
 		name       string
 		collection mongodb.Collection
@@ -93,7 +97,11 @@ func TestRevoke(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "something went wrong")
-				require.Contains(t, err.Error(), "error deleting role assignment")
+				require.Contains(
+					t,
+					err.Error(),
+					"error deleting project role assignment",
+				)
 			},
 		},
 		{
@@ -116,17 +124,74 @@ func TestRevoke(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			store := &roleAssignmentsStore{
+			store := &projectRoleAssignmentsStore{
 				collection: testCase.collection,
 			}
-			err := store.Revoke(context.Background(), testRoleAssignment)
+			err := store.Revoke(context.Background(), testProjectRoleAssignment)
+			testCase.assertions(err)
+		})
+	}
+}
+
+func TestRevokeMany(t *testing.T) {
+	const testProjectID = "foo"
+	testCases := []struct {
+		name       string
+		collection mongodb.Collection
+		assertions func(error)
+	}{
+		{
+			name: "error",
+			collection: &mongoTesting.MockCollection{
+				DeleteManyFn: func(
+					context.Context,
+					interface{},
+					...*options.DeleteOptions,
+				) (*mongo.DeleteResult, error) {
+					return nil, errors.New("something went wrong")
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(
+					t,
+					err.Error(),
+					"error deleting project role assignments",
+				)
+			},
+		},
+		{
+			name: "success",
+			collection: &mongoTesting.MockCollection{
+				DeleteManyFn: func(
+					context.Context,
+					interface{},
+					...*options.DeleteOptions,
+				) (*mongo.DeleteResult, error) {
+					return &mongo.DeleteResult{
+						DeletedCount: 1,
+					}, nil
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := &projectRoleAssignmentsStore{
+				collection: testCase.collection,
+			}
+			err := store.RevokeMany(context.Background(), testProjectID)
 			testCase.assertions(err)
 		})
 	}
 }
 
 func TestExists(t *testing.T) {
-	testRoleAssignment := authz.RoleAssignment{}
+	testProjectRoleAssignment := core.ProjectRoleAssignment{}
 	testCases := []struct {
 		name       string
 		collection mongodb.Collection
@@ -179,7 +244,7 @@ func TestExists(t *testing.T) {
 					filter interface{},
 					opts ...*options.FindOneOptions,
 				) *mongo.SingleResult {
-					res, err := mongoTesting.MockSingleResult(testRoleAssignment)
+					res, err := mongoTesting.MockSingleResult(testProjectRoleAssignment)
 					require.NoError(t, err)
 					return res
 				},
@@ -192,10 +257,11 @@ func TestExists(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			store := &roleAssignmentsStore{
+			store := &projectRoleAssignmentsStore{
 				collection: testCase.collection,
 			}
-			exists, err := store.Exists(context.Background(), testRoleAssignment)
+			exists, err :=
+				store.Exists(context.Background(), testProjectRoleAssignment)
 			testCase.assertions(exists, err)
 		})
 	}

--- a/v2/apiserver/internal/core/named_roles.go
+++ b/v2/apiserver/internal/core/named_roles.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
-	"github.com/brigadecore/brigade/v2/apiserver/internal/system"
 )
 
 // Core-specific, system-level roles...
@@ -14,7 +13,6 @@ import (
 // Projects, but should NOT be able to impersonate other gateways.
 func RoleEventCreator(eventSource string) libAuthz.Role {
 	return libAuthz.Role{
-		Type:  system.RoleTypeSystem,
 		Name:  "EVENT_CREATOR",
 		Scope: eventSource,
 	}
@@ -24,7 +22,6 @@ func RoleEventCreator(eventSource string) libAuthz.Role {
 // create new Projects.
 func RoleProjectCreator() libAuthz.Role {
 	return libAuthz.Role{
-		Type: system.RoleTypeSystem,
 		Name: "PROJECT_CREATOR",
 	}
 }
@@ -35,11 +32,10 @@ func RoleProjectCreator() libAuthz.Role {
 // manage the Project whose ID matches the value of the Scope field. If the
 // value of the Scope field is RoleScopeGlobal ("*"), then the Role is unbounded
 // and enables a principal to manage all Projects.
-func RoleProjectAdmin(projectID string) libAuthz.Role {
-	return libAuthz.Role{
-		Type:  RoleTypeProject,
-		Name:  "ADMIN",
-		Scope: projectID,
+func RoleProjectAdmin(projectID string) ProjectRole {
+	return ProjectRole{
+		Name:      "ADMIN",
+		ProjectID: projectID,
 	}
 }
 
@@ -47,11 +43,10 @@ func RoleProjectAdmin(projectID string) libAuthz.Role {
 // update the Project whose ID matches the value of the Scope field. If the
 // value of the Scope field is RoleScopeGlobal ("*"), then the Role is unbounded
 // and enables a principal to update all Projects.
-func RoleProjectDeveloper(projectID string) libAuthz.Role {
-	return libAuthz.Role{
-		Type:  RoleTypeProject,
-		Name:  "DEVELOPER",
-		Scope: projectID,
+func RoleProjectDeveloper(projectID string) ProjectRole {
+	return ProjectRole{
+		Name:      "DEVELOPER",
+		ProjectID: projectID,
 	}
 }
 
@@ -60,11 +55,10 @@ func RoleProjectDeveloper(projectID string) libAuthz.Role {
 // Scope field. If the value of the Scope field is RoleScopeGlobal ("*"), then
 // the Role is unbounded and enables a principal to create and manage Events for
 // all Projects.
-func RoleProjectUser(projectID string) libAuthz.Role {
-	return libAuthz.Role{
-		Type:  RoleTypeProject,
-		Name:  "USER",
-		Scope: projectID,
+func RoleProjectUser(projectID string) ProjectRole {
+	return ProjectRole{
+		Name:      "USER",
+		ProjectID: projectID,
 	}
 }
 
@@ -79,7 +73,6 @@ func RoleProjectUser(projectID string) libAuthz.Role {
 // Observer component.
 func RoleObserver() libAuthz.Role {
 	return libAuthz.Role{
-		Type: system.RoleTypeSystem,
 		Name: "OBSERVER",
 	}
 }
@@ -89,7 +82,6 @@ func RoleObserver() libAuthz.Role {
 // This Role exists exclusively for use by Brigade's Scheduler component.
 func RoleScheduler() libAuthz.Role {
 	return libAuthz.Role{
-		Type: system.RoleTypeSystem,
 		Name: "SCHEDULER",
 	}
 }
@@ -99,7 +91,6 @@ func RoleScheduler() libAuthz.Role {
 // exclusively for the use of Brigade Workers.
 func RoleWorker(eventID string) libAuthz.Role {
 	return libAuthz.Role{
-		Type:  system.RoleTypeSystem,
 		Name:  "WORKER",
 		Scope: eventID,
 	}

--- a/v2/apiserver/internal/core/project_authorizers.go
+++ b/v2/apiserver/internal/core/project_authorizers.go
@@ -1,0 +1,99 @@
+package core
+
+import (
+	"context"
+	"log"
+
+	"github.com/brigadecore/brigade/v2/apiserver/internal/authn"
+	libAuthn "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authn"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
+)
+
+// ProjectAuthorizeFn is the signature for any function that can, presumably,
+// retrieve a principal from the provided Context and make an access control
+// decision based on the principal having (or not having) at least one of the
+// provided ProjectRoles. Implementations MUST return a *meta.ErrAuthorization
+// error if the principal is not authorized.
+type ProjectAuthorizeFn func(context.Context, ...ProjectRole) error
+
+// projectRoleHolder is an interface for any sort of security principal that can
+// directly return its own ProjectRoles from a function call without making a
+// database call.
+type projectRoleHolder interface {
+	ProjectRoles() []ProjectRole
+}
+
+// ProjectRoleAuthorizer is the public interface for the component returned by
+// the NewAuthorizer function.
+type ProjectRoleAuthorizer interface {
+	// Authorize retrieves a principal from the provided Context and asserts that
+	// it has at least one of the allowed ProjectRoles. If it does not,
+	// implementations MUST return a *meta.ErrAuthorization error.
+	Authorize(ctx context.Context, allowedRoles ...ProjectRole) error
+}
+
+// projectRoleAuthorizer is a component that can authorize a request based on
+// ProjectRoles.
+type projectRoleAuthorizer struct {
+	projectRoleAssignmentsStore ProjectRoleAssignmentsStore
+}
+
+// NewProjectRoleAuthorizer returns a component that can authorize a request
+// based on ProjectRoles.
+func NewProjectRoleAuthorizer(
+	projectRoleAssignmentsStore ProjectRoleAssignmentsStore,
+) ProjectRoleAuthorizer {
+	return &projectRoleAuthorizer{
+		projectRoleAssignmentsStore: projectRoleAssignmentsStore,
+	}
+}
+
+func (p *projectRoleAuthorizer) Authorize(
+	ctx context.Context,
+	allowedRoles ...ProjectRole,
+) error {
+	principal := libAuthn.PrincipalFromContext(ctx)
+	if principal == nil {
+		return &meta.ErrAuthorization{}
+	}
+	roleAssignment := ProjectRoleAssignment{}
+	switch p := principal.(type) {
+	case projectRoleHolder: // Any principal with hard-coded ProjectRoles
+		for _, allowedRole := range allowedRoles {
+			for _, principalRole := range p.ProjectRoles() {
+				if principalRole.Matches(allowedRole) {
+					return nil
+				}
+			}
+		}
+		return &meta.ErrAuthorization{}
+	case *authn.User:
+		roleAssignment.Principal = authn.PrincipalReference{
+			Type: authn.PrincipalTypeUser,
+			ID:   p.ID,
+		}
+	case *authn.ServiceAccount:
+		roleAssignment.Principal = authn.PrincipalReference{
+			Type: authn.PrincipalTypeServiceAccount,
+			ID:   p.ID,
+		}
+	default: // What kind of principal is this??? This shouldn't happen.
+		return &meta.ErrAuthorization{}
+	}
+	// We only get here if the principal was a User or ServiceAccount
+	for _, roleAssignment.Role = range allowedRoles {
+		if exists, err := p.projectRoleAssignmentsStore.Exists(
+			ctx,
+			roleAssignment,
+		); err != nil {
+			// We encountered an unexpected error when looking for a RoleAssignment
+			// in the store. We're going to treat this as an authz failure, but we're
+			// also going to log it for good measure.
+			log.Println(err)
+			return &meta.ErrAuthorization{}
+		} else if exists {
+			return nil
+		}
+	}
+	return &meta.ErrAuthorization{}
+}

--- a/v2/apiserver/internal/core/project_authorizers_test.go
+++ b/v2/apiserver/internal/core/project_authorizers_test.go
@@ -1,0 +1,228 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/brigadecore/brigade/v2/apiserver/internal/authn"
+	libAuthn "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authn"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
+	"github.com/stretchr/testify/require"
+)
+
+type principal struct {
+	projectRoles []ProjectRole
+}
+
+func (p *principal) ProjectRoles() []ProjectRole {
+	return p.projectRoles
+}
+
+func TestNewProjectRoleAuthorizer(t *testing.T) {
+	roleAssignmentsStore := &mockProjectRoleAssignmentsStore{}
+	svc := NewProjectRoleAuthorizer(roleAssignmentsStore)
+	require.Same(
+		t,
+		roleAssignmentsStore,
+		svc.(*projectRoleAuthorizer).projectRoleAssignmentsStore,
+	)
+}
+
+func TestProjectRoleAuthorizerAuthorize(t *testing.T) {
+	testRequiredRole := ProjectRole{
+		Name:      "foo",
+		ProjectID: "foo",
+	}
+	testCases := []struct {
+		name                  string
+		principal             interface{}
+		projectRoleAuthorizer ProjectRoleAuthorizer
+		assertions            func(error)
+	}{
+		{
+			name:                  "principal is nil",
+			principal:             nil,
+			projectRoleAuthorizer: &projectRoleAuthorizer{},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrAuthorization{}, err)
+			},
+		},
+		{
+			name:                  "roleHolder does not have role",
+			principal:             &principal{},
+			projectRoleAuthorizer: &projectRoleAuthorizer{},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrAuthorization{}, err)
+			},
+		},
+		{
+			name: "roleHolder has role",
+			principal: &principal{
+				projectRoles: []ProjectRole{
+					testRequiredRole,
+				},
+			},
+			projectRoleAuthorizer: &projectRoleAuthorizer{},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:      "error looking up user role assignment",
+			principal: &authn.User{},
+			projectRoleAuthorizer: &projectRoleAuthorizer{
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					ExistsFn: func(context.Context, ProjectRoleAssignment) (bool, error) {
+						return false, errors.New("something went wrong")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrAuthorization{}, err)
+			},
+		},
+		{
+			name:      "user does not have role",
+			principal: &authn.User{},
+			projectRoleAuthorizer: &projectRoleAuthorizer{
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					ExistsFn: func(context.Context, ProjectRoleAssignment) (bool, error) {
+						return false, nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrAuthorization{}, err)
+			},
+		},
+		{
+			name:      "user has role",
+			principal: &authn.User{},
+			projectRoleAuthorizer: &projectRoleAuthorizer{
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					ExistsFn: func(context.Context, ProjectRoleAssignment) (bool, error) {
+						return true, nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:      "error looking up service account role assignment",
+			principal: &authn.ServiceAccount{},
+			projectRoleAuthorizer: &projectRoleAuthorizer{
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					ExistsFn: func(context.Context, ProjectRoleAssignment) (bool, error) {
+						return false, errors.New("something went wrong")
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrAuthorization{}, err)
+			},
+		},
+		{
+			name:      "service account does not have role",
+			principal: &authn.ServiceAccount{},
+			projectRoleAuthorizer: &projectRoleAuthorizer{
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					ExistsFn: func(context.Context, ProjectRoleAssignment) (bool, error) {
+						return false, nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrAuthorization{}, err)
+			},
+		},
+		{
+			name:      "service account has role",
+			principal: &authn.ServiceAccount{},
+			projectRoleAuthorizer: &projectRoleAuthorizer{
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					ExistsFn: func(context.Context, ProjectRoleAssignment) (bool, error) {
+						return true, nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:                  "principal is an unknown type",
+			principal:             struct{}{},
+			projectRoleAuthorizer: &projectRoleAuthorizer{},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrAuthorization{}, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = libAuthn.ContextWithPrincipal(ctx, testCase.principal)
+			err := testCase.projectRoleAuthorizer.Authorize(ctx, testRequiredRole)
+			testCase.assertions(err)
+		})
+	}
+}
+
+type mockProjectRoleAssignmentsStore struct {
+	GrantFn      func(context.Context, ProjectRoleAssignment) error
+	RevokeFn     func(context.Context, ProjectRoleAssignment) error
+	RevokeManyFn func(context.Context, string) error
+	ExistsFn     func(context.Context, ProjectRoleAssignment) (bool, error)
+}
+
+func (m *mockProjectRoleAssignmentsStore) Grant(
+	ctx context.Context,
+	roleAssignment ProjectRoleAssignment,
+) error {
+	return m.GrantFn(ctx, roleAssignment)
+}
+
+func (m *mockProjectRoleAssignmentsStore) Revoke(
+	ctx context.Context,
+	roleAssignment ProjectRoleAssignment,
+) error {
+	return m.RevokeFn(ctx, roleAssignment)
+}
+
+func (m *mockProjectRoleAssignmentsStore) RevokeMany(
+	ctx context.Context,
+	projectID string,
+) error {
+	return m.RevokeManyFn(ctx, projectID)
+}
+
+func (m *mockProjectRoleAssignmentsStore) Exists(
+	ctx context.Context,
+	roleAssignment ProjectRoleAssignment,
+) (bool, error) {
+	return m.ExistsFn(ctx, roleAssignment)
+}
+
+// alwaysAuthorize is an implementation of the ProjectAuthorizeFn function
+// signature that unconditionally passes authorization requests by returning
+// nil. This is used only for testing purposes.
+func alwaysAuthorize(context.Context, ...ProjectRole) error {
+	return nil
+}
+
+// neverAuthorize is an implementation of the ProjectAuthorizeFn function
+// signature that unconditionally fails authorization requests by returning a
+// *meta.ErrAuthorization error. This is used only for testing purposes.
+func neverAuthorize(context.Context, ...ProjectRole) error {
+	return &meta.ErrAuthorization{}
+}

--- a/v2/apiserver/internal/core/project_role_assignments_test.go
+++ b/v2/apiserver/internal/core/project_role_assignments_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/brigadecore/brigade/v2/apiserver/internal/authn"
-	"github.com/brigadecore/brigade/v2/apiserver/internal/authz"
-	libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
 	"github.com/stretchr/testify/require"
 )
@@ -16,15 +14,15 @@ func TestNewProjectRoleAssignmentsService(t *testing.T) {
 	projectsStore := &mockProjectsStore{}
 	usersStore := &authn.MockUsersStore{}
 	serviceAccountsStore := &authn.MockServiceAccountStore{}
-	roleAssignmentsStore := &authz.MockRoleAssignmentsStore{}
+	projectRoleAssignmentsStore := &mockProjectRoleAssignmentsStore{}
 	svc := NewProjectRoleAssignmentsService(
-		libAuthz.AlwaysAuthorize,
+		alwaysAuthorize,
 		projectsStore,
 		usersStore,
 		serviceAccountsStore,
-		roleAssignmentsStore,
+		projectRoleAssignmentsStore,
 	)
-	require.NotNil(t, svc.(*projectRoleAssignmentsService).authorize)
+	require.NotNil(t, svc.(*projectRoleAssignmentsService).projectAuthorize)
 	require.Same(
 		t,
 		projectsStore,
@@ -38,22 +36,22 @@ func TestNewProjectRoleAssignmentsService(t *testing.T) {
 	)
 	require.Same(
 		t,
-		roleAssignmentsStore,
-		svc.(*projectRoleAssignmentsService).roleAssignmentsStore,
+		projectRoleAssignmentsStore,
+		svc.(*projectRoleAssignmentsService).projectRoleAssignmentsStore,
 	)
 }
 
 func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 	testCases := []struct {
-		name           string
-		roleAssignment authz.RoleAssignment
-		service        authz.RoleAssignmentsService
-		assertions     func(error)
+		name                  string
+		projectRoleAssignment ProjectRoleAssignment
+		service               ProjectRoleAssignmentsService
+		assertions            func(error)
 	}{
 		{
 			name: "unauthorized",
 			service: &projectRoleAssignmentsService{
-				authorize: libAuthz.NeverAuthorize,
+				projectAuthorize: neverAuthorize,
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
@@ -62,14 +60,14 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "error retrieving project from store",
-			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
-					Type: authz.PrincipalTypeUser,
+			projectRoleAssignment: ProjectRoleAssignment{
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeUser,
 					ID:   "foo",
 				},
 			},
 			service: &projectRoleAssignmentsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, errors.New("something went wrong")
@@ -84,14 +82,14 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "error retrieving user from store",
-			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
-					Type: authz.PrincipalTypeUser,
+			projectRoleAssignment: ProjectRoleAssignment{
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeUser,
 					ID:   "foo",
 				},
 			},
 			service: &projectRoleAssignmentsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -111,14 +109,14 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "error retrieving service account from store",
-			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
-					Type: authz.PrincipalTypeServiceAccount,
+			projectRoleAssignment: ProjectRoleAssignment{
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
 			},
 			service: &projectRoleAssignmentsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -138,14 +136,14 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "error granting the role",
-			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
-					Type: authz.PrincipalTypeServiceAccount,
+			projectRoleAssignment: ProjectRoleAssignment{
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
 			},
 			service: &projectRoleAssignmentsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -156,8 +154,8 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 						return authn.ServiceAccount{}, nil
 					},
 				},
-				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					GrantFn: func(context.Context, authz.RoleAssignment) error {
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					GrantFn: func(context.Context, ProjectRoleAssignment) error {
 						return errors.New("something went wrong")
 					},
 				},
@@ -170,14 +168,14 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "success",
-			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
-					Type: authz.PrincipalTypeServiceAccount,
+			projectRoleAssignment: ProjectRoleAssignment{
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
 			},
 			service: &projectRoleAssignmentsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -188,8 +186,8 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 						return authn.ServiceAccount{}, nil
 					},
 				},
-				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					GrantFn: func(context.Context, authz.RoleAssignment) error {
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					GrantFn: func(context.Context, ProjectRoleAssignment) error {
 						return nil
 					},
 				},
@@ -203,7 +201,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			err := testCase.service.Grant(
 				context.Background(),
-				testCase.roleAssignment,
+				testCase.projectRoleAssignment,
 			)
 			testCase.assertions(err)
 		})
@@ -212,15 +210,15 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 
 func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 	testCases := []struct {
-		name           string
-		roleAssignment authz.RoleAssignment
-		service        authz.RoleAssignmentsService
-		assertions     func(error)
+		name                  string
+		projectRoleAssignment ProjectRoleAssignment
+		service               ProjectRoleAssignmentsService
+		assertions            func(error)
 	}{
 		{
 			name: "unauthorized",
 			service: &projectRoleAssignmentsService{
-				authorize: libAuthz.NeverAuthorize,
+				projectAuthorize: neverAuthorize,
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
@@ -229,14 +227,14 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "error retrieving project from store",
-			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
-					Type: authz.PrincipalTypeUser,
+			projectRoleAssignment: ProjectRoleAssignment{
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeUser,
 					ID:   "foo",
 				},
 			},
 			service: &projectRoleAssignmentsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, errors.New("something went wrong")
@@ -251,14 +249,14 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "error retrieving user from store",
-			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
-					Type: authz.PrincipalTypeUser,
+			projectRoleAssignment: ProjectRoleAssignment{
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeUser,
 					ID:   "foo",
 				},
 			},
 			service: &projectRoleAssignmentsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -278,14 +276,14 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "error retrieving service account from store",
-			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
-					Type: authz.PrincipalTypeServiceAccount,
+			projectRoleAssignment: ProjectRoleAssignment{
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
 			},
 			service: &projectRoleAssignmentsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -305,14 +303,14 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "error revoking the role",
-			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
-					Type: authz.PrincipalTypeServiceAccount,
+			projectRoleAssignment: ProjectRoleAssignment{
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
 			},
 			service: &projectRoleAssignmentsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -323,8 +321,8 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 						return authn.ServiceAccount{}, nil
 					},
 				},
-				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeFn: func(context.Context, authz.RoleAssignment) error {
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					RevokeFn: func(context.Context, ProjectRoleAssignment) error {
 						return errors.New("something went wrong")
 					},
 				},
@@ -337,14 +335,14 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "success",
-			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
-					Type: authz.PrincipalTypeServiceAccount,
+			projectRoleAssignment: ProjectRoleAssignment{
+				Principal: authn.PrincipalReference{
+					Type: authn.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
 			},
 			service: &projectRoleAssignmentsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -355,8 +353,8 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 						return authn.ServiceAccount{}, nil
 					},
 				},
-				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeFn: func(context.Context, authz.RoleAssignment) error {
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					RevokeFn: func(context.Context, ProjectRoleAssignment) error {
 						return nil
 					},
 				},
@@ -370,7 +368,7 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			err := testCase.service.Revoke(
 				context.Background(),
-				testCase.roleAssignment,
+				testCase.projectRoleAssignment,
 			)
 			testCase.assertions(err)
 		})

--- a/v2/apiserver/internal/core/project_roles.go
+++ b/v2/apiserver/internal/core/project_roles.go
@@ -1,0 +1,26 @@
+package core
+
+import libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
+
+// ProjectIDGlobal represents an unbounded scope.
+const ProjectIDGlobal = "*"
+
+// ProjectRole represents a set of project-level permissions.
+type ProjectRole struct {
+	// Name is the name of a ProjectRole and has domain-specific meaning.
+	Name libAuthz.RoleName `json:"name,omitempty" bson:"name,omitempty"`
+	// ProjectID qualifies the scope of the ProjectRole.
+	ProjectID string `json:"projectID,omitempty" bson:"projectID,omitempty"`
+}
+
+// Matches determines if this ProjectRole matches the requiredRole argument.
+// This ProjectRole is a match for the required one if the Name fields have the
+// same values in both AND if the value of this ProjectRole's ProjectID field is
+// either the same as that of the required ProjectRole's ProjectID field OR is
+// unbounded ("*").
+//
+// Note that order is important. A.Matches(B) does not guarantee B.Matches(A).
+func (p ProjectRole) Matches(requiredRole ProjectRole) bool {
+	return p.Name == requiredRole.Name &&
+		(p.ProjectID == requiredRole.ProjectID || p.ProjectID == ProjectIDGlobal)
+}

--- a/v2/apiserver/internal/core/project_roles_test.go
+++ b/v2/apiserver/internal/core/project_roles_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatches(t *testing.T) {
+	testCases := []struct {
+		name    string
+		a       ProjectRole
+		b       ProjectRole
+		matches bool
+	}{
+		{
+			name: "names do not match",
+			a: ProjectRole{
+				Name:      "foo",
+				ProjectID: "foo",
+			},
+			b: ProjectRole{
+				Name:      "bar",
+				ProjectID: "foo",
+			},
+			matches: false,
+		},
+		{
+			name: "projectIDs do not match",
+			a: ProjectRole{
+				Name:      "foo",
+				ProjectID: "foo",
+			},
+			b: ProjectRole{
+				Name:      "foo",
+				ProjectID: "bar",
+			},
+			matches: false,
+		},
+		{
+			name: "projectIDs are an exact match",
+			a: ProjectRole{
+				Name:      "foo",
+				ProjectID: "foo",
+			},
+			b: ProjectRole{
+				Name:      "foo",
+				ProjectID: "foo",
+			},
+			matches: true,
+		},
+		{
+			name: "a global projectID matches b projectID",
+			a: ProjectRole{
+				Name:      "foo",
+				ProjectID: ProjectIDGlobal,
+			},
+			b: ProjectRole{
+				Name:      "foo",
+				ProjectID: "foo",
+			},
+			matches: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.matches, testCase.a.Matches(testCase.b))
+		})
+	}
+}

--- a/v2/apiserver/internal/core/roles.go
+++ b/v2/apiserver/internal/core/roles.go
@@ -1,6 +1,0 @@
-package core
-
-import libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
-
-// RoleTypeProject represents a project-level Role.
-const RoleTypeProject libAuthz.RoleType = "PROJECT"

--- a/v2/apiserver/internal/core/secrets.go
+++ b/v2/apiserver/internal/core/secrets.go
@@ -109,21 +109,24 @@ type SecretsService interface {
 }
 
 type secretsService struct {
-	authorize     libAuthz.AuthorizeFn
-	projectsStore ProjectsStore
-	secretsStore  SecretsStore
+	authorize        libAuthz.AuthorizeFn
+	projectAuthorize ProjectAuthorizeFn
+	projectsStore    ProjectsStore
+	secretsStore     SecretsStore
 }
 
 // NewSecretsService returns a specialized interface for managing Secrets.
 func NewSecretsService(
 	authorizeFn libAuthz.AuthorizeFn,
+	projectAuthorize ProjectAuthorizeFn,
 	projectsStore ProjectsStore,
 	secretsStore SecretsStore,
 ) SecretsService {
 	return &secretsService{
-		authorize:     authorizeFn,
-		projectsStore: projectsStore,
-		secretsStore:  secretsStore,
+		authorize:        authorizeFn,
+		projectAuthorize: projectAuthorize,
+		projectsStore:    projectsStore,
+		secretsStore:     secretsStore,
 	}
 }
 
@@ -164,7 +167,7 @@ func (s *secretsService) Set(
 	projectID string,
 	secret Secret,
 ) error {
-	if err := s.authorize(ctx, RoleProjectAdmin(projectID)); err != nil {
+	if err := s.projectAuthorize(ctx, RoleProjectAdmin(projectID)); err != nil {
 		return err
 	}
 
@@ -191,7 +194,7 @@ func (s *secretsService) Unset(
 	projectID string,
 	key string,
 ) error {
-	if err := s.authorize(ctx, RoleProjectAdmin(projectID)); err != nil {
+	if err := s.projectAuthorize(ctx, RoleProjectAdmin(projectID)); err != nil {
 		return err
 	}
 

--- a/v2/apiserver/internal/lib/authz/roles.go
+++ b/v2/apiserver/internal/lib/authz/roles.go
@@ -1,9 +1,5 @@
 package authz
 
-// RoleType is a type whose values can be used to disambiguate one type of Role
-// from another.
-type RoleType string
-
 // RoleName is a type whose value maps to a well-defined Brigade Role.
 type RoleName string
 
@@ -12,9 +8,6 @@ const RoleScopeGlobal = "*"
 
 // Role represents a set of permissions.
 type Role struct {
-	// Type indicates the Role's type, for instance, system-level or
-	// project-level.
-	Type RoleType `json:"type,omitempty" bson:"type,omitempty"`
 	// Name is the name of a Role and has domain-specific meaning.
 	Name RoleName `json:"name,omitempty" bson:"name,omitempty"`
 	// Scope qualifies the scope of the Role. The value is opaque and has meaning
@@ -23,13 +16,12 @@ type Role struct {
 }
 
 // Matches determines if this Role matches the requiredRole argument. This Role
-// is a match for the required one if the Type and Name fields have the same
-// values in both AND if the value of this Role's Scope field is either the same
-// as that of the required Role's Scope field OR is unbounded ("*").
+// is a match for the required one if the Name fields have the same values in
+// both AND if the value of this Role's Scope field is either the same as that
+// of the required Role's Scope field OR is unbounded ("*").
 //
 // Note that order is important. A.Matches(B) does not guarantee B.Matches(A).
 func (r Role) Matches(requiredRole Role) bool {
-	return r.Type == requiredRole.Type &&
-		r.Name == requiredRole.Name &&
+	return r.Name == requiredRole.Name &&
 		(r.Scope == requiredRole.Scope || r.Scope == RoleScopeGlobal)
 }

--- a/v2/apiserver/internal/lib/authz/roles_test.go
+++ b/v2/apiserver/internal/lib/authz/roles_test.go
@@ -14,28 +14,12 @@ func TestMatches(t *testing.T) {
 		matches bool
 	}{
 		{
-			name: "types do not match",
-			a: Role{
-				Type:  "foo",
-				Name:  "foo",
-				Scope: "foo",
-			},
-			b: Role{
-				Type:  "bar",
-				Name:  "foo",
-				Scope: "foo",
-			},
-			matches: false,
-		},
-		{
 			name: "names do not match",
 			a: Role{
-				Type:  "foo",
 				Name:  "foo",
 				Scope: "foo",
 			},
 			b: Role{
-				Type:  "foo",
 				Name:  "bar",
 				Scope: "foo",
 			},
@@ -44,12 +28,10 @@ func TestMatches(t *testing.T) {
 		{
 			name: "scopes do not match",
 			a: Role{
-				Type:  "foo",
 				Name:  "foo",
 				Scope: "foo",
 			},
 			b: Role{
-				Type:  "foo",
 				Name:  "foo",
 				Scope: "bar",
 			},
@@ -58,12 +40,10 @@ func TestMatches(t *testing.T) {
 		{
 			name: "scopes are an exact match",
 			a: Role{
-				Type:  "foo",
 				Name:  "foo",
 				Scope: "foo",
 			},
 			b: Role{
-				Type:  "foo",
 				Name:  "foo",
 				Scope: "foo",
 			},
@@ -72,12 +52,10 @@ func TestMatches(t *testing.T) {
 		{
 			name: "a global scope matches b scope",
 			a: Role{
-				Type:  "foo",
 				Name:  "foo",
 				Scope: RoleScopeGlobal,
 			},
 			b: Role{
-				Type:  "foo",
 				Name:  "foo",
 				Scope: "foo",
 			},

--- a/v2/apiserver/internal/system/authn/named_principals.go
+++ b/v2/apiserver/internal/system/authn/named_principals.go
@@ -24,10 +24,16 @@ func (r *rootPrincipal) Roles() []libAuthz.Role {
 		system.RoleAdmin(),
 		system.RoleReader(),
 		core.RoleEventCreator(libAuthz.RoleScopeGlobal),
-		core.RoleProjectAdmin(libAuthz.RoleScopeGlobal),
 		core.RoleProjectCreator(),
-		core.RoleProjectDeveloper(libAuthz.RoleScopeGlobal),
-		core.RoleProjectUser(libAuthz.RoleScopeGlobal),
+	}
+}
+
+// TODO: THIS ISN'T RIGHT
+func (r *rootPrincipal) ProjectRoles() []core.ProjectRole {
+	return []core.ProjectRole{
+		core.RoleProjectAdmin(core.ProjectIDGlobal),
+		core.RoleProjectDeveloper(core.ProjectIDGlobal),
+		core.RoleProjectUser(core.ProjectIDGlobal),
 	}
 }
 

--- a/v2/apiserver/internal/system/named_roles.go
+++ b/v2/apiserver/internal/system/named_roles.go
@@ -7,7 +7,6 @@ import libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
 // ServiceAccounts.
 func RoleAdmin() libAuthz.Role {
 	return libAuthz.Role{
-		Type: RoleTypeSystem,
 		Name: "ADMIN",
 	}
 }
@@ -15,7 +14,6 @@ func RoleAdmin() libAuthz.Role {
 // RoleReader returns a system-level Role that enables global read access.
 func RoleReader() libAuthz.Role {
 	return libAuthz.Role{
-		Type: RoleTypeSystem,
 		Name: "READER",
 	}
 }

--- a/v2/apiserver/internal/system/roles.go
+++ b/v2/apiserver/internal/system/roles.go
@@ -1,6 +1,0 @@
-package system
-
-import libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
-
-// RoleTypeSystem represents a system-level Role.
-const RoleTypeSystem libAuthz.RoleType = "SYSTEM"

--- a/v2/apiserver/schemas/project-role-assignment.json
+++ b/v2/apiserver/schemas/project-role-assignment.json
@@ -7,7 +7,7 @@
 		"kind": {
 			"type": "string",
 			"description": "The type of object represented by the document",
-			"enum": ["RoleAssignment"]
+			"enum": ["ProjectRoleAssignment"]
 		}
 
 	},
@@ -28,14 +28,9 @@
 		},
 		"role": {
 			"type": "object",
-			"required": ["type", "name", "scope"],
+			"required": ["name", "projectID"],
 			"additionalProperties": false,
 			"properties": {
-				"type": {
-					"type": "string",
-					"description": "The type of role being assigned-- must be PROJECT",
-					"enum": ["PROJECT"]
-				},
 				"name": {
 					"type": "string",
 					"description": "A role name",
@@ -45,12 +40,11 @@
 						"USER"
 					]
 				},
-				"scope": {
-					"type": "string",
-					"description": "The project this role should be scoped to",
-					"pattern": "^[a-z][a-z\\d-]*[a-z\\d]$",
-					"minLength": 3,
-					"maxLength": 18
+				"projectID": {
+					"oneOf": [
+						{ "$ref": "common.json#/definitions/identifier" }
+					],
+					"description": "The project this role should be scoped to"
 				}
 			}
 		}

--- a/v2/apiserver/schemas/role-assignment.json
+++ b/v2/apiserver/schemas/role-assignment.json
@@ -12,14 +12,9 @@
 
 		"role": {
 			"type": "object",
-			"required": ["type", "name"],
+			"required": ["name"],
 			"additionalProperties": false,
 			"properties": {
-				"type": {
-					"type": "string",
-					"description": "The type of role being assigned-- must be SYSTEM",
-					"enum": ["SYSTEM"]
-				},
 				"name": {
 					"type": "string",
 					"description": "A role name",
@@ -34,14 +29,9 @@
 
 		"eventCreatorRole": {
 			"type": "object",
-			"required": ["type", "name"],
+			"required": ["name", "scope"],
 			"additionalProperties": false,
 			"properties": {
-				"type": {
-					"type": "string",
-					"description": "The type of role being assigned-- must be SYSTEM",
-					"enum": ["SYSTEM"]
-				},
 				"name": {
 					"type": "string",
 					"description": "A role name",

--- a/v2/cli/project_role_commands.go
+++ b/v2/cli/project_role_commands.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/brigadecore/brigade/sdk/v2/authz"
+	"github.com/brigadecore/brigade/sdk/v2/authn"
 	"github.com/brigadecore/brigade/sdk/v2/core"
 	libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
 	"github.com/pkg/errors"
@@ -156,26 +156,25 @@ func grantProjectRole(
 			return err
 		}
 
-		roleAssignment := authz.RoleAssignment{
-			Role: libAuthz.Role{
-				Type:  core.RoleTypeProject,
-				Name:  roleName,
-				Scope: projectID,
+		roleAssignment := core.ProjectRoleAssignment{
+			Role: core.ProjectRole{
+				Name:      roleName,
+				ProjectID: projectID,
 			},
 		}
 
-		roleAssignment.Principal.Type = authz.PrincipalTypeUser
+		roleAssignment.Principal.Type = authn.PrincipalTypeUser
 		for _, roleAssignment.Principal.ID = range userIDs {
-			if err = client.Core().Projects().Authz().RoleAssignments().Grant(
+			if err = client.Core().Projects().Authz().ProjectRoleAssignments().Grant(
 				c.Context,
 				roleAssignment,
 			); err != nil {
 				return err
 			}
 		}
-		roleAssignment.Principal.Type = authz.PrincipalTypeServiceAccount
+		roleAssignment.Principal.Type = authn.PrincipalTypeServiceAccount
 		for _, roleAssignment.Principal.ID = range serviceAccountIDs {
-			if err = client.Core().Projects().Authz().RoleAssignments().Grant(
+			if err = client.Core().Projects().Authz().ProjectRoleAssignments().Grant(
 				c.Context,
 				roleAssignment,
 			); err != nil {
@@ -206,26 +205,25 @@ func revokeProjectRole(
 			return err
 		}
 
-		roleAssignment := authz.RoleAssignment{
-			Role: libAuthz.Role{
-				Type:  core.RoleTypeProject,
-				Name:  roleName,
-				Scope: projectID,
+		roleAssignment := core.ProjectRoleAssignment{
+			Role: core.ProjectRole{
+				Name:      roleName,
+				ProjectID: projectID,
 			},
 		}
 
-		roleAssignment.Principal.Type = authz.PrincipalTypeUser
+		roleAssignment.Principal.Type = authn.PrincipalTypeUser
 		for _, roleAssignment.Principal.ID = range userIDs {
-			if err = client.Core().Projects().Authz().RoleAssignments().Revoke(
+			if err = client.Core().Projects().Authz().ProjectRoleAssignments().Revoke(
 				c.Context,
 				roleAssignment,
 			); err != nil {
 				return err
 			}
 		}
-		roleAssignment.Principal.Type = authz.PrincipalTypeServiceAccount
+		roleAssignment.Principal.Type = authn.PrincipalTypeServiceAccount
 		for _, roleAssignment.Principal.ID = range serviceAccountIDs {
-			if err = client.Core().Projects().Authz().RoleAssignments().Revoke(
+			if err = client.Core().Projects().Authz().ProjectRoleAssignments().Revoke(
 				c.Context,
 				roleAssignment,
 			); err != nil {

--- a/v2/cli/role_commands.go
+++ b/v2/cli/role_commands.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/brigadecore/brigade/sdk/v2/authn"
 	"github.com/brigadecore/brigade/sdk/v2/authz"
 	"github.com/brigadecore/brigade/sdk/v2/core"
 	libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
@@ -165,7 +166,6 @@ func grantSystemRole(roleName libAuthz.RoleName) func(c *cli.Context) error {
 
 		roleAssignment := authz.RoleAssignment{
 			Role: libAuthz.Role{
-				Type: system.RoleTypeSystem,
 				Name: roleName,
 			},
 		}
@@ -180,7 +180,7 @@ func grantSystemRole(roleName libAuthz.RoleName) func(c *cli.Context) error {
 			return err
 		}
 
-		roleAssignment.Principal.Type = authz.PrincipalTypeUser
+		roleAssignment.Principal.Type = authn.PrincipalTypeUser
 		for _, roleAssignment.Principal.ID = range userIDs {
 			if err = client.Authz().RoleAssignments().Grant(
 				c.Context,
@@ -189,7 +189,7 @@ func grantSystemRole(roleName libAuthz.RoleName) func(c *cli.Context) error {
 				return err
 			}
 		}
-		roleAssignment.Principal.Type = authz.PrincipalTypeServiceAccount
+		roleAssignment.Principal.Type = authn.PrincipalTypeServiceAccount
 		for _, roleAssignment.Principal.ID = range serviceAccountIDs {
 			if err = client.Authz().RoleAssignments().Grant(
 				c.Context,
@@ -218,7 +218,6 @@ func revokeSystemRole(
 
 		roleAssignment := authz.RoleAssignment{
 			Role: libAuthz.Role{
-				Type: system.RoleTypeSystem,
 				Name: roleName,
 			},
 		}
@@ -233,7 +232,7 @@ func revokeSystemRole(
 			return err
 		}
 
-		roleAssignment.Principal.Type = authz.PrincipalTypeUser
+		roleAssignment.Principal.Type = authn.PrincipalTypeUser
 		for _, roleAssignment.Principal.ID = range userIDs {
 			if err = client.Authz().RoleAssignments().Revoke(
 				c.Context,
@@ -242,7 +241,7 @@ func revokeSystemRole(
 				return err
 			}
 		}
-		roleAssignment.Principal.Type = authz.PrincipalTypeServiceAccount
+		roleAssignment.Principal.Type = authn.PrincipalTypeServiceAccount
 		for _, roleAssignment.Principal.ID = range serviceAccountIDs {
 			if err = client.Authz().RoleAssignments().Revoke(
 				c.Context,


### PR DESCRIPTION
This is related to #1257, which I've been working on, on-and-off, for some time.

https://github.com/brigadecore/brigade/pull/1241 introduced endpoints, services, and stores having to do with role assignments (the association between a principal and a role).

In a (perhaps overzealous) effort to be DRY, a lot of the code that was committed was common to two different _types_ of roles-- these being system-level roles like `ADMIN` and project-level roles, like `PROJECT_ADMIN`, which are, necessarily, scoped to a given project.

As my work on #1257 continue, I'm finding it increasingly difficult to account for behavioral differences between these two types of roles while keeping things DRY. I've finally concluded that #1257 is exposing the fact that the differences between the two types of roles outweigh their rather superficial similarities by a wide margin.

I'm invoking "clear is better than clever" and unDRYing some things in this PR.

There are no functional changes in this PR, but it leaves me with two _distinct_ sets of components for dealing with the two types of roles so that I can mutate each of those independently from the other as work on #1257 continues.

I'm leaving this as a draft for right now because I want to start rebuilding my solution for #1257 on top of this to prove to myself that it really does improve the state of affairs.