### PR TITLE
feat(*): add unversioned ping endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,9 +177,11 @@ lint-chart:
 
 .PHONY: test-integration
 test-integration: hack-expose-apiserver
-	@cd v2 && \
+	@export VERSION=${VERSION} && \
+		cd v2 && \
 		go test \
 			-v \
+			--count=1 \
 			-timeout=10m \
 			-tags=integration \
 			./tests/... || (cd - && $(MAKE) hack-unexpose-apiserver && exit 1)

--- a/sdk/v2/system/api_client.go
+++ b/sdk/v2/system/api_client.go
@@ -64,13 +64,14 @@ func (a *apiClient) UnversionedPing(ctx context.Context) ([]byte, error) {
 			SuccessCode: http.StatusOK,
 		},
 	)
+	defer resp.Body.Close()
 	if err != nil {
-		return []byte{}, errors.Wrap(err, "error submitting request")
+		return nil, errors.Wrap(err, "error submitting request")
 	}
 
 	respBodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return []byte{}, errors.Wrap(err, "error reading response body")
+		return nil, errors.Wrap(err, "error reading response body")
 	}
 	return respBodyBytes, nil
 }

--- a/sdk/v2/system/api_client.go
+++ b/sdk/v2/system/api_client.go
@@ -16,8 +16,11 @@ type PingResponse struct {
 
 // APIClient is the client for system checks involving the Brigade API.
 type APIClient interface {
-	// Ping pings the API Server
+	// Ping sends a GET request to the API Server's versioned ping endpoint
 	Ping(ctx context.Context) (PingResponse, error)
+
+	// PingRaw sends a GET request to the API Server's unversioned ping endpoint
+	PingRaw(ctx context.Context) (string, error)
 }
 
 type apiClient struct {
@@ -43,6 +46,19 @@ func (a *apiClient) Ping(ctx context.Context) (PingResponse, error) {
 		rm.OutboundRequest{
 			Method:      http.MethodGet,
 			Path:        "v2/ping",
+			SuccessCode: http.StatusOK,
+			RespObj:     &pingResponse,
+		},
+	)
+}
+
+func (a *apiClient) PingRaw(ctx context.Context) (string, error) {
+	var pingResponse string
+	return pingResponse, a.ExecuteRequest(
+		ctx,
+		rm.OutboundRequest{
+			Method:      http.MethodGet,
+			Path:        "ping",
 			SuccessCode: http.StatusOK,
 			RespObj:     &pingResponse,
 		},

--- a/v2/apiserver/internal/system/rest/system_endpoints.go
+++ b/v2/apiserver/internal/system/rest/system_endpoints.go
@@ -40,7 +40,7 @@ func (h *SystemEndpoints) Register(router *mux.Router) {
 	// Get /ping (unversioned)
 	router.HandleFunc(
 		"/ping",
-		h.pingRaw,
+		h.unversionedPing,
 	).Methods(http.MethodGet)
 }
 
@@ -83,15 +83,18 @@ func (h *SystemEndpoints) healthz(w http.ResponseWriter, r *http.Request) {
 	)
 }
 
-// pingRaw returns the api server version in raw string form and http.StatusOK.
+// unversionedPing returns the api server version and http.StatusOK.
 // This is handy for auxiliary components to verify their connectivity.
-func (h *SystemEndpoints) pingRaw(w http.ResponseWriter, r *http.Request) {
+func (h *SystemEndpoints) unversionedPing(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
 	restmachinery.ServeRequest(
 		restmachinery.InboundRequest{
 			W: w,
 			R: r,
 			EndpointLogic: func() (interface{}, error) {
-				return h.APIServerVersion, nil
+				return []byte(h.APIServerVersion), nil
 			},
 			SuccessCode: http.StatusOK,
 		},

--- a/v2/apiserver/internal/system/rest/system_endpoints.go
+++ b/v2/apiserver/internal/system/rest/system_endpoints.go
@@ -84,7 +84,9 @@ func (h *SystemEndpoints) healthz(w http.ResponseWriter, r *http.Request) {
 }
 
 // unversionedPing returns the api server version and http.StatusOK.
-// This is handy for auxiliary components to verify their connectivity.
+// This exists for auxiliary components to verify their connectivity
+// and get version information without needing to know the version
+// beforehand (as they would via the standard ping endpoint).
 func (h *SystemEndpoints) unversionedPing(
 	w http.ResponseWriter,
 	r *http.Request,

--- a/v2/apiserver/internal/system/rest/system_endpoints.go
+++ b/v2/apiserver/internal/system/rest/system_endpoints.go
@@ -36,6 +36,12 @@ func (h *SystemEndpoints) Register(router *mux.Router) {
 		"/v2/ping",
 		h.ping,
 	).Methods(http.MethodGet)
+
+	// Get /ping (unversioned)
+	router.HandleFunc(
+		"/ping",
+		h.pingRaw,
+	).Methods(http.MethodGet)
 }
 
 // healthz is the main healthcheck endpoint for the api server.  The endpoint
@@ -77,6 +83,21 @@ func (h *SystemEndpoints) healthz(w http.ResponseWriter, r *http.Request) {
 	)
 }
 
+// pingRaw returns the api server version in raw string form and http.StatusOK.
+// This is handy for auxiliary components to verify their connectivity.
+func (h *SystemEndpoints) pingRaw(w http.ResponseWriter, r *http.Request) {
+	restmachinery.ServeRequest(
+		restmachinery.InboundRequest{
+			W: w,
+			R: r,
+			EndpointLogic: func() (interface{}, error) {
+				return h.APIServerVersion, nil
+			},
+			SuccessCode: http.StatusOK,
+		},
+	)
+}
+
 // ping returns the api server version and http.StatusOK.  This is handy for
 // auxiliary components to verify their connectivity.
 func (h *SystemEndpoints) ping(w http.ResponseWriter, r *http.Request) {
@@ -87,7 +108,6 @@ func (h *SystemEndpoints) ping(w http.ResponseWriter, r *http.Request) {
 			EndpointLogic: func() (interface{}, error) {
 				return PingResponse{Version: h.APIServerVersion}, nil
 			},
-
 			SuccessCode: http.StatusOK,
 		},
 	)

--- a/v2/tests/integration_test.go
+++ b/v2/tests/integration_test.go
@@ -260,7 +260,7 @@ func TestMain(t *testing.T) {
 	require.NoError(t, err, "error creating root session")
 	tokenStr := token.Value
 
-	// Check pingRaw endpoint for expected version
+	// Check unversionedPing endpoint for expected version
 	wantResp := os.Getenv("VERSION")
 	require.NotEmpty(t, wantResp, "expected the VERSION env var to be non-empty")
 
@@ -269,9 +269,9 @@ func TestMain(t *testing.T) {
 		tokenStr,
 		apiClientOpts,
 	)
-	resp, err := systemClient.PingRaw(ctx)
+	resp, err := systemClient.UnversionedPing(ctx)
 	require.NoError(t, err)
-	require.Equal(t, wantResp, resp, "ping response did not match expected")
+	require.Equal(t, wantResp, string(resp), "ping response did not match expected")
 
 	// Create the api client for use in tests below
 	client := sdk.NewAPIClient(


### PR DESCRIPTION
**What this PR does / why we need it**:

* adds an unversioned ping endpoint to return a raw api server version string
* re-orgs the integration tests to set up the api clients first/once (and issue a ping check) before running all of the scenarios

**Special notes for your reviewer**:

Closes https://github.com/brigadecore/brigade/issues/1352

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
