### PR TITLE
move the PrincipalReference type

### DIFF
--- a/sdk/v2/authz/role_assignments.go
+++ b/sdk/v2/authz/role_assignments.go
@@ -11,30 +11,13 @@ import (
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
-// PrincipalType is a type whose values can be used to disambiguate one type of
-// principal from another. For instance, when assigning a Role to a principal
-// via a RoleAssignment, a PrincipalType field is used to indicate whether the
-// value of the PrincipalID field reflects a User ID or a ServiceAccount ID.
-type PrincipalType string
-
 const (
 	// PrincipalTypeServiceAccount represents a principal that is a
 	// ServiceAccount.
-	PrincipalTypeServiceAccount PrincipalType = "SERVICE_ACCOUNT"
+	PrincipalTypeServiceAccount libAuthz.PrincipalType = "SERVICE_ACCOUNT"
 	// PrincipalTypeUser represents a principal that is a User.
-	PrincipalTypeUser PrincipalType = "USER"
+	PrincipalTypeUser libAuthz.PrincipalType = "USER"
 )
-
-// PrincipalReference is a reference to any sort of security principal (human
-// user, service account, etc.)
-type PrincipalReference struct {
-	// Type qualifies what kind of principal is referenced by the ID field-- for
-	// instance, a User or a ServiceAccount.
-	Type PrincipalType `json:"type,omitempty"`
-	// ID references a principal. The Type qualifies what type of principal that
-	// is-- for instance, a User or a ServiceAccount.
-	ID string `json:"id,omitempty"`
-}
 
 // RoleAssignment represents the assignment of a Role to a principal such as a
 // User or ServiceAccount.
@@ -42,7 +25,7 @@ type RoleAssignment struct {
 	// Role assigns a Role to the specified principal.
 	Role libAuthz.Role `json:"role"`
 	// Principal specifies the principal to whom the Role is assigned.
-	Principal PrincipalReference `json:"principal"`
+	Principal libAuthz.PrincipalReference `json:"principal"`
 }
 
 // MarshalJSON amends RoleAssignment instances with type metadata so that

--- a/sdk/v2/authz/role_assignments_test.go
+++ b/sdk/v2/authz/role_assignments_test.go
@@ -35,7 +35,7 @@ func TestRoleAssignmentsClientGrant(t *testing.T) {
 			Type: system.RoleTypeSystem,
 			Name: libAuthz.RoleName("ceo"),
 		},
-		Principal: PrincipalReference{
+		Principal: libAuthz.PrincipalReference{
 			Type: PrincipalTypeUser,
 			ID:   "tony@starkindustries.com",
 		},
@@ -68,7 +68,7 @@ func TestRoleAssignmentsClientRevoke(t *testing.T) {
 			Type: system.RoleTypeSystem,
 			Name: libAuthz.RoleName("ceo"),
 		},
-		Principal: PrincipalReference{
+		Principal: libAuthz.PrincipalReference{
 			Type: PrincipalTypeUser,
 			ID:   "tony@starkindustries.com",
 		},
@@ -91,7 +91,7 @@ func TestRoleAssignmentsClientRevoke(t *testing.T) {
 				require.Equal(
 					t,
 					testRoleAssignment.Principal.Type,
-					PrincipalType(r.URL.Query().Get("principalType")),
+					libAuthz.PrincipalType(r.URL.Query().Get("principalType")),
 				)
 				require.Equal(
 					t,

--- a/sdk/v2/core/project_roles_assignments_test.go
+++ b/sdk/v2/core/project_roles_assignments_test.go
@@ -34,7 +34,7 @@ func TestProjectRoleAssignmentsClientGrant(t *testing.T) {
 			Name:  libAuthz.RoleName("ceo"),
 			Scope: "bluebook",
 		},
-		Principal: authz.PrincipalReference{
+		Principal: libAuthz.PrincipalReference{
 			Type: authz.PrincipalTypeUser,
 			ID:   "tony@starkindustries.com",
 		},
@@ -72,7 +72,7 @@ func TestProjectRoleAssignmentsClientRevoke(t *testing.T) {
 			Name:  libAuthz.RoleName("ceo"),
 			Scope: "bluebook",
 		},
-		Principal: authz.PrincipalReference{
+		Principal: libAuthz.PrincipalReference{
 			Type: authz.PrincipalTypeUser,
 			ID:   "tony@starkindustries.com",
 		},
@@ -95,7 +95,7 @@ func TestProjectRoleAssignmentsClientRevoke(t *testing.T) {
 				require.Equal(
 					t,
 					testRoleAssignment.Principal.Type,
-					authz.PrincipalType(r.URL.Query().Get("principalType")),
+					libAuthz.PrincipalType(r.URL.Query().Get("principalType")),
 				)
 				require.Equal(
 					t,

--- a/sdk/v2/lib/authz/principals.go
+++ b/sdk/v2/lib/authz/principals.go
@@ -1,0 +1,18 @@
+package authz
+
+// PrincipalType is a type whose values can be used to disambiguate one type of
+// principal from another. For instance, when assigning a Role to a principal
+// via a RoleAssignment, a PrincipalType field is used to indicate whether the
+// value of the PrincipalID field reflects a User ID or a ServiceAccount ID.
+type PrincipalType string
+
+// PrincipalReference is a reference to any sort of security principal (human
+// user, service account, etc.)
+type PrincipalReference struct {
+	// Type qualifies what kind of principal is referenced by the ID field-- for
+	// instance, a User or a ServiceAccount.
+	Type PrincipalType `json:"type,omitempty"`
+	// ID references a principal. The Type qualifies what type of principal that
+	// is-- for instance, a User or a ServiceAccount.
+	ID string `json:"id,omitempty"`
+}

--- a/v2/apiserver/internal/authz/rest/role_assignments_endpoints.go
+++ b/v2/apiserver/internal/authz/rest/role_assignments_endpoints.go
@@ -62,8 +62,8 @@ func (r *RoleAssignmentsEndpoints) revoke(
 			Name:  libAuthz.RoleName(req.URL.Query().Get("roleName")),
 			Scope: req.URL.Query().Get("roleScope"),
 		},
-		Principal: authz.PrincipalReference{
-			Type: authz.PrincipalType(req.URL.Query().Get("principalType")),
+		Principal: libAuthz.PrincipalReference{
+			Type: libAuthz.PrincipalType(req.URL.Query().Get("principalType")),
 			ID:   req.URL.Query().Get("principalID"),
 		},
 	}

--- a/v2/apiserver/internal/authz/role_assignments.go
+++ b/v2/apiserver/internal/authz/role_assignments.go
@@ -9,30 +9,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PrincipalType is a type whose values can be used to disambiguate one type of
-// principal from another. For instance, when assigning a Role to a principal
-// via a RoleAssignment, a PrincipalType field is used to indicate whether the
-// value of the PrincipalID field reflects a User ID or a ServiceAccount ID.
-type PrincipalType string
-
 const (
 	// PrincipalTypeServiceAccount represents a principal that is a
 	// ServiceAccount.
-	PrincipalTypeServiceAccount PrincipalType = "SERVICE_ACCOUNT"
+	PrincipalTypeServiceAccount libAuthz.PrincipalType = "SERVICE_ACCOUNT"
 	// PrincipalTypeUser represents a principal that is a User.
-	PrincipalTypeUser PrincipalType = "USER"
+	PrincipalTypeUser libAuthz.PrincipalType = "USER"
 )
-
-// PrincipalReference is a reference to any sort of security principal (human
-// user, service account, etc.)
-type PrincipalReference struct {
-	// Type qualifies what kind of principal is referenced by the ID field-- for
-	// instance, a User or a ServiceAccount.
-	Type PrincipalType `json:"type,omitempty" bson:"type,omitempty"`
-	// ID references a principal. The Type qualifies what type of principal that
-	// is-- for instance, a User or a ServiceAccount.
-	ID string `json:"id,omitempty" bson:"id,omitempty"`
-}
 
 // RoleAssignment represents the assignment of a Role to a principal such as a
 // User or ServiceAccount.
@@ -40,7 +23,7 @@ type RoleAssignment struct {
 	// Role assigns a Role to the specified principal.
 	Role libAuthz.Role `json:"role" bson:"role"`
 	// Principal specifies the principal to whom the Role is assigned.
-	Principal PrincipalReference `json:"principal" bson:"principal"`
+	Principal libAuthz.PrincipalReference `json:"principal" bson:"principal"`
 }
 
 // RoleAssignmentsService is the specialized interface for managing

--- a/v2/apiserver/internal/authz/role_assignments_test.go
+++ b/v2/apiserver/internal/authz/role_assignments_test.go
@@ -55,7 +55,7 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 		{
 			name: "error retrieving user from store",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeUser,
 					ID:   "foo",
 				},
@@ -77,7 +77,7 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 		{
 			name: "error retrieving service account from store",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
@@ -99,7 +99,7 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 		{
 			name: "error granting the role",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
@@ -126,7 +126,7 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 		{
 			name: "success",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
@@ -180,7 +180,7 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 		{
 			name: "error retrieving user from store",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeUser,
 					ID:   "foo",
 				},
@@ -202,7 +202,7 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 		{
 			name: "error retrieving service account from store",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
@@ -224,7 +224,7 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 		{
 			name: "error revoking the role",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
@@ -251,7 +251,7 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 		{
 			name: "success",
 			roleAssignment: RoleAssignment{
-				Principal: PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},

--- a/v2/apiserver/internal/core/project_role_assignments_test.go
+++ b/v2/apiserver/internal/core/project_role_assignments_test.go
@@ -63,7 +63,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		{
 			name: "error retrieving project from store",
 			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeUser,
 					ID:   "foo",
 				},
@@ -85,7 +85,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		{
 			name: "error retrieving user from store",
 			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeUser,
 					ID:   "foo",
 				},
@@ -112,7 +112,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		{
 			name: "error retrieving service account from store",
 			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
@@ -139,7 +139,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		{
 			name: "error granting the role",
 			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
@@ -171,7 +171,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		{
 			name: "success",
 			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
@@ -230,7 +230,7 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		{
 			name: "error retrieving project from store",
 			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeUser,
 					ID:   "foo",
 				},
@@ -252,7 +252,7 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		{
 			name: "error retrieving user from store",
 			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeUser,
 					ID:   "foo",
 				},
@@ -279,7 +279,7 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		{
 			name: "error retrieving service account from store",
 			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
@@ -306,7 +306,7 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		{
 			name: "error revoking the role",
 			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},
@@ -338,7 +338,7 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		{
 			name: "success",
 			roleAssignment: authz.RoleAssignment{
-				Principal: authz.PrincipalReference{
+				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeServiceAccount,
 					ID:   "foo",
 				},

--- a/v2/apiserver/internal/core/projects.go
+++ b/v2/apiserver/internal/core/projects.go
@@ -232,15 +232,15 @@ func (p *projectsService) Create(
 	// Make the current user an admin, developer, and user of the project
 	principal := libAuthn.PrincipalFromContext(ctx)
 
-	var principalRef authz.PrincipalReference
+	var principalRef libAuthz.PrincipalReference
 	switch prin := principal.(type) {
 	case *authn.User:
-		principalRef = authz.PrincipalReference{
+		principalRef = libAuthz.PrincipalReference{
 			Type: authz.PrincipalTypeUser,
 			ID:   prin.ID,
 		}
 	case *authn.ServiceAccount:
-		principalRef = authz.PrincipalReference{
+		principalRef = libAuthz.PrincipalReference{
 			Type: authz.PrincipalTypeServiceAccount,
 			ID:   prin.ID,
 		}

--- a/v2/apiserver/internal/core/rest/project_role_assignments_endpoints.go
+++ b/v2/apiserver/internal/core/rest/project_role_assignments_endpoints.go
@@ -63,8 +63,8 @@ func (p *ProjectRoleAssignmentsEndpoints) revoke(
 			Name:  libAuthz.RoleName(r.URL.Query().Get("roleName")),
 			Scope: r.URL.Query().Get("roleScope"),
 		},
-		Principal: authz.PrincipalReference{
-			Type: authz.PrincipalType(r.URL.Query().Get("principalType")),
+		Principal: libAuthz.PrincipalReference{
+			Type: libAuthz.PrincipalType(r.URL.Query().Get("principalType")),
 			ID:   r.URL.Query().Get("principalID"),
 		},
 	}

--- a/v2/apiserver/internal/lib/authz/principals.go
+++ b/v2/apiserver/internal/lib/authz/principals.go
@@ -1,0 +1,18 @@
+package authz
+
+// PrincipalType is a type whose values can be used to disambiguate one type of
+// principal from another. For instance, when assigning a Role to a principal
+// via a RoleAssignment, a PrincipalType field is used to indicate whether the
+// value of the PrincipalID field reflects a User ID or a ServiceAccount ID.
+type PrincipalType string
+
+// PrincipalReference is a reference to any sort of security principal (human
+// user, service account, etc.)
+type PrincipalReference struct {
+	// Type qualifies what kind of principal is referenced by the ID field-- for
+	// instance, a User or a ServiceAccount.
+	Type PrincipalType `json:"type,omitempty"`
+	// ID references a principal. The Type qualifies what type of principal that
+	// is-- for instance, a User or a ServiceAccount.
+	ID string `json:"id,omitempty"`
+}

--- a/v2/apiserver/internal/system/authz/authorizers.go
+++ b/v2/apiserver/internal/system/authz/authorizers.go
@@ -59,12 +59,12 @@ func (a *authorizer) Authorize(
 		}
 		return &meta.ErrAuthorization{}
 	case *authn.User:
-		roleAssignment.Principal = authz.PrincipalReference{
+		roleAssignment.Principal = libAuthz.PrincipalReference{
 			Type: authz.PrincipalTypeUser,
 			ID:   p.ID,
 		}
 	case *authn.ServiceAccount:
-		roleAssignment.Principal = authz.PrincipalReference{
+		roleAssignment.Principal = libAuthz.PrincipalReference{
 			Type: authz.PrincipalTypeServiceAccount,
 			ID:   p.ID,
 		}


### PR DESCRIPTION
There is some moderately extensive refactoring that is in order to address #1257. (Alpha is the time for this sort of stuff!) So this is the first of several related PRs-- I'm trying hard to keep them bite-sied.

This PR just moves the `PrincipalReference` type (on both the server side and client side) to a different package. It does this as a prelude to the next step in the refactor wherein I'll need `PrincipalReference` to exist in a package that has no significant dependencies of its own so that I can avoid dependency cycles-- and that was exactly the point of this `libAuthz` package to begin with.

To be clear-- there are no functional changes at all in this PR.

