### PR TITLE
move RoleAssignment type

### DIFF
--- a/sdk/v2/authz/role_assignments.go
+++ b/sdk/v2/authz/role_assignments.go
@@ -2,12 +2,10 @@ package authz
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 
 	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
 	libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
-	"github.com/brigadecore/brigade/sdk/v2/meta"
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
@@ -19,42 +17,15 @@ const (
 	PrincipalTypeUser libAuthz.PrincipalType = "USER"
 )
 
-// RoleAssignment represents the assignment of a Role to a principal such as a
-// User or ServiceAccount.
-type RoleAssignment struct {
-	// Role assigns a Role to the specified principal.
-	Role libAuthz.Role `json:"role"`
-	// Principal specifies the principal to whom the Role is assigned.
-	Principal libAuthz.PrincipalReference `json:"principal"`
-}
-
-// MarshalJSON amends RoleAssignment instances with type metadata so that
-// clients do not need to be concerned with the tedium of doing so.
-func (r RoleAssignment) MarshalJSON() ([]byte, error) {
-	type Alias RoleAssignment
-	return json.Marshal(
-		struct {
-			meta.TypeMeta `json:",inline"`
-			Alias         `json:",inline"`
-		}{
-			TypeMeta: meta.TypeMeta{
-				APIVersion: meta.APIVersion,
-				Kind:       "RoleAssignment",
-			},
-			Alias: (Alias)(r),
-		},
-	)
-}
-
 // RoleAssignmentsClient is the specialized client for managing RoleAssignments
 // with the Brigade API.
 type RoleAssignmentsClient interface {
 	// Grant grants the system-level Role specified by the RoleAssignment to the
 	// principal also specified by the RoleAssignment.
-	Grant(context.Context, RoleAssignment) error
+	Grant(context.Context, libAuthz.RoleAssignment) error
 	// Revoke revokes the system-level Role specified by the RoleAssignment for
 	// the principal also specified by the RoleAssignment.
-	Revoke(context.Context, RoleAssignment) error
+	Revoke(context.Context, libAuthz.RoleAssignment) error
 }
 
 type roleAssignmentsClient struct {
@@ -75,7 +46,7 @@ func NewRoleAssignmentsClient(
 
 func (r *roleAssignmentsClient) Grant(
 	ctx context.Context,
-	roleAssignment RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	return r.ExecuteRequest(
 		ctx,
@@ -90,7 +61,7 @@ func (r *roleAssignmentsClient) Grant(
 
 func (r *roleAssignmentsClient) Revoke(
 	ctx context.Context,
-	roleAssignment RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	queryParams := map[string]string{
 		"roleType":      string(roleAssignment.Role.Type),

--- a/sdk/v2/authz/role_assignments_test.go
+++ b/sdk/v2/authz/role_assignments_test.go
@@ -16,7 +16,11 @@ import (
 )
 
 func TestRoleAssignmentMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(t, RoleAssignment{}, "RoleAssignment")
+	metaTesting.RequireAPIVersionAndType(
+		t,
+		libAuthz.RoleAssignment{},
+		"RoleAssignment",
+	)
 }
 
 func TestNewRoleAssignmentsClient(t *testing.T) {
@@ -30,7 +34,7 @@ func TestNewRoleAssignmentsClient(t *testing.T) {
 }
 
 func TestRoleAssignmentsClientGrant(t *testing.T) {
-	testRoleAssignment := RoleAssignment{
+	testRoleAssignment := libAuthz.RoleAssignment{
 		Role: libAuthz.Role{
 			Type: system.RoleTypeSystem,
 			Name: libAuthz.RoleName("ceo"),
@@ -48,7 +52,7 @@ func TestRoleAssignmentsClientGrant(t *testing.T) {
 				require.Equal(t, "/v2/role-assignments", r.URL.Path)
 				bodyBytes, err := ioutil.ReadAll(r.Body)
 				require.NoError(t, err)
-				roleAssignment := RoleAssignment{}
+				roleAssignment := libAuthz.RoleAssignment{}
 				err = json.Unmarshal(bodyBytes, &roleAssignment)
 				require.NoError(t, err)
 				require.Equal(t, testRoleAssignment, roleAssignment)
@@ -63,7 +67,7 @@ func TestRoleAssignmentsClientGrant(t *testing.T) {
 }
 
 func TestRoleAssignmentsClientRevoke(t *testing.T) {
-	testRoleAssignment := RoleAssignment{
+	testRoleAssignment := libAuthz.RoleAssignment{
 		Role: libAuthz.Role{
 			Type: system.RoleTypeSystem,
 			Name: libAuthz.RoleName("ceo"),

--- a/sdk/v2/core/project_role_assignments.go
+++ b/sdk/v2/core/project_role_assignments.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/brigadecore/brigade/sdk/v2/authz"
 	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
+	libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
@@ -27,7 +28,7 @@ func NewProjectRoleAssignmentsClient(
 
 func (p *projectRoleAssignmentsClient) Grant(
 	ctx context.Context,
-	roleAssignment authz.RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	return p.ExecuteRequest(
 		ctx,
@@ -42,7 +43,7 @@ func (p *projectRoleAssignmentsClient) Grant(
 
 func (p *projectRoleAssignmentsClient) Revoke(
 	ctx context.Context,
-	roleAssignment authz.RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	queryParams := map[string]string{
 		"roleName":      string(roleAssignment.Role.Name),

--- a/sdk/v2/core/project_roles_assignments_test.go
+++ b/sdk/v2/core/project_roles_assignments_test.go
@@ -28,7 +28,7 @@ func TestNewProjectRoleAssignmentsClient(t *testing.T) {
 }
 
 func TestProjectRoleAssignmentsClientGrant(t *testing.T) {
-	testRoleAssignment := authz.RoleAssignment{
+	testRoleAssignment := libAuthz.RoleAssignment{
 		Role: libAuthz.Role{
 			Type:  RoleTypeProject,
 			Name:  libAuthz.RoleName("ceo"),
@@ -47,7 +47,7 @@ func TestProjectRoleAssignmentsClientGrant(t *testing.T) {
 				require.Equal(t, "/v2/project-role-assignments", r.URL.Path)
 				bodyBytes, err := ioutil.ReadAll(r.Body)
 				require.NoError(t, err)
-				roleAssignment := authz.RoleAssignment{}
+				roleAssignment := libAuthz.RoleAssignment{}
 				err = json.Unmarshal(bodyBytes, &roleAssignment)
 				require.NoError(t, err)
 				require.Equal(t, testRoleAssignment, roleAssignment)
@@ -66,7 +66,7 @@ func TestProjectRoleAssignmentsClientGrant(t *testing.T) {
 }
 
 func TestProjectRoleAssignmentsClientRevoke(t *testing.T) {
-	testRoleAssignment := authz.RoleAssignment{
+	testRoleAssignment := libAuthz.RoleAssignment{
 		Role: libAuthz.Role{
 			Type:  RoleTypeProject,
 			Name:  libAuthz.RoleName("ceo"),

--- a/sdk/v2/lib/authz/role_assignments.go
+++ b/sdk/v2/lib/authz/role_assignments.go
@@ -1,0 +1,34 @@
+package authz
+
+import (
+	"encoding/json"
+
+	"github.com/brigadecore/brigade/sdk/v2/meta"
+)
+
+// RoleAssignment represents the assignment of a Role to a principal such as a
+// User or ServiceAccount.
+type RoleAssignment struct {
+	// Role assigns a Role to the specified principal.
+	Role Role `json:"role"`
+	// Principal specifies the principal to whom the Role is assigned.
+	Principal PrincipalReference `json:"principal"`
+}
+
+// MarshalJSON amends RoleAssignment instances with type metadata so that
+// clients do not need to be concerned with the tedium of doing so.
+func (r RoleAssignment) MarshalJSON() ([]byte, error) {
+	type Alias RoleAssignment
+	return json.Marshal(
+		struct {
+			meta.TypeMeta `json:",inline"`
+			Alias         `json:",inline"`
+		}{
+			TypeMeta: meta.TypeMeta{
+				APIVersion: meta.APIVersion,
+				Kind:       "RoleAssignment",
+			},
+			Alias: (Alias)(r),
+		},
+	)
+}

--- a/v2/apiserver/internal/authz/mock_roles_assignments_store.go
+++ b/v2/apiserver/internal/authz/mock_roles_assignments_store.go
@@ -1,38 +1,42 @@
 package authz
 
-import "context"
+import (
+	"context"
+
+	libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
+)
 
 type MockRoleAssignmentsStore struct {
-	GrantFn      func(context.Context, RoleAssignment) error
-	RevokeFn     func(context.Context, RoleAssignment) error
-	RevokeManyFn func(context.Context, RoleAssignment) error
-	ExistsFn     func(context.Context, RoleAssignment) (bool, error)
+	GrantFn      func(context.Context, libAuthz.RoleAssignment) error
+	RevokeFn     func(context.Context, libAuthz.RoleAssignment) error
+	RevokeManyFn func(context.Context, libAuthz.RoleAssignment) error
+	ExistsFn     func(context.Context, libAuthz.RoleAssignment) (bool, error)
 }
 
 func (m *MockRoleAssignmentsStore) Grant(
 	ctx context.Context,
-	roleAssignment RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	return m.GrantFn(ctx, roleAssignment)
 }
 
 func (m *MockRoleAssignmentsStore) Revoke(
 	ctx context.Context,
-	roleAssignment RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	return m.RevokeFn(ctx, roleAssignment)
 }
 
 func (m *MockRoleAssignmentsStore) RevokeMany(
 	ctx context.Context,
-	roleAssignment RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	return m.RevokeManyFn(ctx, roleAssignment)
 }
 
 func (m *MockRoleAssignmentsStore) Exists(
 	ctx context.Context,
-	roleAssignment RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) (bool, error) {
 	return m.ExistsFn(ctx, roleAssignment)
 }

--- a/v2/apiserver/internal/authz/mongodb/role_assignments_store.go
+++ b/v2/apiserver/internal/authz/mongodb/role_assignments_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/brigadecore/brigade/v2/apiserver/internal/authz"
+	libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/mongodb"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
@@ -30,7 +31,7 @@ func NewRoleAssignmentsStore(
 
 func (r *roleAssignmentsStore) Grant(
 	ctx context.Context,
-	roleAssignment authz.RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	tru := true
 	if res := r.collection.FindOneAndReplace(
@@ -52,7 +53,7 @@ func (r *roleAssignmentsStore) Grant(
 
 func (r *roleAssignmentsStore) Revoke(
 	ctx context.Context,
-	roleAssignment authz.RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	if _, err := r.collection.DeleteOne(ctx, roleAssignment); err != nil {
 		return errors.Wrapf(
@@ -66,7 +67,7 @@ func (r *roleAssignmentsStore) Revoke(
 
 func (r *roleAssignmentsStore) RevokeMany(
 	ctx context.Context,
-	roleAssignment authz.RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	criteria := bson.M{}
 	if roleAssignment.Role.Type != "" {
@@ -92,7 +93,7 @@ func (r *roleAssignmentsStore) RevokeMany(
 
 func (r *roleAssignmentsStore) Exists(
 	ctx context.Context,
-	roleAssignment authz.RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) (bool, error) {
 	criteria := bson.M{
 		"role.type":      roleAssignment.Role.Type,

--- a/v2/apiserver/internal/authz/mongodb/role_assignments_store_test.go
+++ b/v2/apiserver/internal/authz/mongodb/role_assignments_store_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/brigadecore/brigade/v2/apiserver/internal/authz"
+	libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/mongodb"
 	mongoTesting "github.com/brigadecore/brigade/v2/apiserver/internal/lib/mongodb/testing" // nolint: lll
 	"github.com/stretchr/testify/require"
@@ -14,7 +14,7 @@ import (
 )
 
 func TestGrant(t *testing.T) {
-	testRoleAssignment := authz.RoleAssignment{}
+	testRoleAssignment := libAuthz.RoleAssignment{}
 	testCases := []struct {
 		name       string
 		collection mongodb.Collection
@@ -73,7 +73,7 @@ func TestGrant(t *testing.T) {
 }
 
 func TestRevoke(t *testing.T) {
-	testRoleAssignment := authz.RoleAssignment{}
+	testRoleAssignment := libAuthz.RoleAssignment{}
 	testCases := []struct {
 		name       string
 		collection mongodb.Collection
@@ -126,7 +126,7 @@ func TestRevoke(t *testing.T) {
 }
 
 func TestRevokeMany(t *testing.T) {
-	testRoleAssignment := authz.RoleAssignment{}
+	testRoleAssignment := libAuthz.RoleAssignment{}
 	testCases := []struct {
 		name       string
 		collection mongodb.Collection
@@ -179,7 +179,7 @@ func TestRevokeMany(t *testing.T) {
 }
 
 func TestExists(t *testing.T) {
-	testRoleAssignment := authz.RoleAssignment{}
+	testRoleAssignment := libAuthz.RoleAssignment{}
 	testCases := []struct {
 		name       string
 		collection mongodb.Collection

--- a/v2/apiserver/internal/authz/rest/role_assignments_endpoints.go
+++ b/v2/apiserver/internal/authz/rest/role_assignments_endpoints.go
@@ -37,7 +37,7 @@ func (r *RoleAssignmentsEndpoints) grant(
 	w http.ResponseWriter,
 	req *http.Request,
 ) {
-	roleAssignment := authz.RoleAssignment{}
+	roleAssignment := libAuthz.RoleAssignment{}
 	restmachinery.ServeRequest(
 		restmachinery.InboundRequest{
 			W:                   w,
@@ -56,7 +56,7 @@ func (r *RoleAssignmentsEndpoints) revoke(
 	w http.ResponseWriter,
 	req *http.Request,
 ) {
-	roleAssignment := authz.RoleAssignment{
+	roleAssignment := libAuthz.RoleAssignment{
 		Role: libAuthz.Role{
 			Type:  system.RoleTypeSystem,
 			Name:  libAuthz.RoleName(req.URL.Query().Get("roleName")),

--- a/v2/apiserver/internal/authz/role_assignments.go
+++ b/v2/apiserver/internal/authz/role_assignments.go
@@ -17,15 +17,6 @@ const (
 	PrincipalTypeUser libAuthz.PrincipalType = "USER"
 )
 
-// RoleAssignment represents the assignment of a Role to a principal such as a
-// User or ServiceAccount.
-type RoleAssignment struct {
-	// Role assigns a Role to the specified principal.
-	Role libAuthz.Role `json:"role" bson:"role"`
-	// Principal specifies the principal to whom the Role is assigned.
-	Principal libAuthz.PrincipalReference `json:"principal" bson:"principal"`
-}
-
 // RoleAssignmentsService is the specialized interface for managing
 // RoleAssignments. It's decoupled from underlying technology choices (e.g. data
 // store, message bus, etc.) to keep business logic reusable and consistent
@@ -34,12 +25,12 @@ type RoleAssignmentsService interface {
 	// Grant grants the Role specified by the RoleAssignment to the principal also
 	// specified by the RoleAssignment. If the specified principal does not exist,
 	// implementations must return a *meta.ErrNotFound error.
-	Grant(ctx context.Context, roleAssignment RoleAssignment) error
+	Grant(ctx context.Context, roleAssignment libAuthz.RoleAssignment) error
 
 	// Revoke revokes the Role specified by the RoleAssignment for the principal
 	// also specified by the RoleAssignment. If the specified principal does not
 	// exist, implementations must return a *meta.ErrNotFound error.
-	Revoke(ctx context.Context, roleAssignment RoleAssignment) error
+	Revoke(ctx context.Context, roleAssignment libAuthz.RoleAssignment) error
 }
 
 type roleAssignmentsService struct {
@@ -67,7 +58,7 @@ func NewRoleAssignmentsService(
 
 func (r *roleAssignmentsService) Grant(
 	ctx context.Context,
-	roleAssignment RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	if err := r.authorize(ctx, system.RoleAdmin()); err != nil {
 		return err
@@ -121,7 +112,7 @@ func (r *roleAssignmentsService) Grant(
 
 func (r *roleAssignmentsService) Revoke(
 	ctx context.Context,
-	roleAssignment RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	if err := r.authorize(ctx, system.RoleAdmin()); err != nil {
 		return err
@@ -177,10 +168,10 @@ func (r *roleAssignmentsService) Revoke(
 type RoleAssignmentsStore interface {
 	// Grant the role specified by the RoleAssignment to the principal specified
 	// by the RoleAssignment.
-	Grant(context.Context, RoleAssignment) error
+	Grant(context.Context, libAuthz.RoleAssignment) error
 	// Revoke the role specified by the RoleAssignment for the principal specified
 	// by the RoleAssignment.
-	Revoke(context.Context, RoleAssignment) error
+	Revoke(context.Context, libAuthz.RoleAssignment) error
 	// RevokeMany revokes all RoleAssignments that share ALL properties of the
 	// specified RoleAssignment. Properties left unspecified are ignored, i.e.
 	// not factored into the match.
@@ -196,7 +187,7 @@ type RoleAssignmentsStore interface {
 	// 		  },
 	// 	  },
 	//   )
-	RevokeMany(ctx context.Context, roleAssignment RoleAssignment) error
+	RevokeMany(ctx context.Context, roleAssignment libAuthz.RoleAssignment) error
 
 	// Exists returns a bool indicating whether the specified RoleAssignment
 	// exists within the store. Implementations MUST also return true if a
@@ -209,5 +200,5 @@ type RoleAssignmentsStore interface {
 	// goes wrong. i.e. Errors are never used to communicate that the specified
 	// RoleAssignment does not exist in the store. They are only used to convey an
 	// actual failure.
-	Exists(context.Context, RoleAssignment) (bool, error)
+	Exists(context.Context, libAuthz.RoleAssignment) (bool, error)
 }

--- a/v2/apiserver/internal/authz/role_assignments_test.go
+++ b/v2/apiserver/internal/authz/role_assignments_test.go
@@ -38,7 +38,7 @@ func TestNewRoleAssignmentsService(t *testing.T) {
 func TestRoleAssignmentsServiceGrant(t *testing.T) {
 	testCases := []struct {
 		name           string
-		roleAssignment RoleAssignment
+		roleAssignment libAuthz.RoleAssignment
 		service        RoleAssignmentsService
 		assertions     func(error)
 	}{
@@ -54,7 +54,7 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "error retrieving user from store",
-			roleAssignment: RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeUser,
 					ID:   "foo",
@@ -76,7 +76,7 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "error retrieving service account from store",
-			roleAssignment: RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeServiceAccount,
 					ID:   "foo",
@@ -98,7 +98,7 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "error granting the role",
-			roleAssignment: RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeServiceAccount,
 					ID:   "foo",
@@ -112,7 +112,7 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 					},
 				},
 				roleAssignmentsStore: &MockRoleAssignmentsStore{
-					GrantFn: func(context.Context, RoleAssignment) error {
+					GrantFn: func(context.Context, libAuthz.RoleAssignment) error {
 						return errors.New("something went wrong")
 					},
 				},
@@ -125,7 +125,7 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "success",
-			roleAssignment: RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeServiceAccount,
 					ID:   "foo",
@@ -139,7 +139,7 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 					},
 				},
 				roleAssignmentsStore: &MockRoleAssignmentsStore{
-					GrantFn: func(context.Context, RoleAssignment) error {
+					GrantFn: func(context.Context, libAuthz.RoleAssignment) error {
 						return nil
 					},
 				},
@@ -163,7 +163,7 @@ func TestRoleAssignmentsServiceGrant(t *testing.T) {
 func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 	testCases := []struct {
 		name           string
-		roleAssignment RoleAssignment
+		roleAssignment libAuthz.RoleAssignment
 		service        RoleAssignmentsService
 		assertions     func(error)
 	}{
@@ -179,7 +179,7 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "error retrieving user from store",
-			roleAssignment: RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeUser,
 					ID:   "foo",
@@ -201,7 +201,7 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "error retrieving service account from store",
-			roleAssignment: RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeServiceAccount,
 					ID:   "foo",
@@ -223,7 +223,7 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "error revoking the role",
-			roleAssignment: RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeServiceAccount,
 					ID:   "foo",
@@ -237,7 +237,7 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 					},
 				},
 				roleAssignmentsStore: &MockRoleAssignmentsStore{
-					RevokeFn: func(context.Context, RoleAssignment) error {
+					RevokeFn: func(context.Context, libAuthz.RoleAssignment) error {
 						return errors.New("something went wrong")
 					},
 				},
@@ -250,7 +250,7 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "success",
-			roleAssignment: RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: PrincipalTypeServiceAccount,
 					ID:   "foo",
@@ -264,7 +264,7 @@ func TestRoleAssignmentsServiceRevoke(t *testing.T) {
 					},
 				},
 				roleAssignmentsStore: &MockRoleAssignmentsStore{
-					RevokeFn: func(context.Context, RoleAssignment) error {
+					RevokeFn: func(context.Context, libAuthz.RoleAssignment) error {
 						return nil
 					},
 				},

--- a/v2/apiserver/internal/core/project_role_assignments.go
+++ b/v2/apiserver/internal/core/project_role_assignments.go
@@ -37,7 +37,7 @@ func NewProjectRoleAssignmentsService(
 
 func (p *projectRoleAssignmentsService) Grant(
 	ctx context.Context,
-	roleAssignment authz.RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	projectID := roleAssignment.Role.Scope
 	if err := p.authorize(ctx, RoleProjectAdmin(projectID)); err != nil {
@@ -101,7 +101,7 @@ func (p *projectRoleAssignmentsService) Grant(
 
 func (p *projectRoleAssignmentsService) Revoke(
 	ctx context.Context,
-	roleAssignment authz.RoleAssignment,
+	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	projectID := roleAssignment.Role.Scope
 	if err := p.authorize(ctx, RoleProjectAdmin(projectID)); err != nil {

--- a/v2/apiserver/internal/core/project_role_assignments_test.go
+++ b/v2/apiserver/internal/core/project_role_assignments_test.go
@@ -46,7 +46,7 @@ func TestNewProjectRoleAssignmentsService(t *testing.T) {
 func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 	testCases := []struct {
 		name           string
-		roleAssignment authz.RoleAssignment
+		roleAssignment libAuthz.RoleAssignment
 		service        authz.RoleAssignmentsService
 		assertions     func(error)
 	}{
@@ -62,7 +62,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "error retrieving project from store",
-			roleAssignment: authz.RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeUser,
 					ID:   "foo",
@@ -84,7 +84,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "error retrieving user from store",
-			roleAssignment: authz.RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeUser,
 					ID:   "foo",
@@ -111,7 +111,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "error retrieving service account from store",
-			roleAssignment: authz.RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeServiceAccount,
 					ID:   "foo",
@@ -138,7 +138,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "error granting the role",
-			roleAssignment: authz.RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeServiceAccount,
 					ID:   "foo",
@@ -157,7 +157,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					GrantFn: func(context.Context, authz.RoleAssignment) error {
+					GrantFn: func(context.Context, libAuthz.RoleAssignment) error {
 						return errors.New("something went wrong")
 					},
 				},
@@ -170,7 +170,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 		},
 		{
 			name: "success",
-			roleAssignment: authz.RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeServiceAccount,
 					ID:   "foo",
@@ -189,7 +189,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					GrantFn: func(context.Context, authz.RoleAssignment) error {
+					GrantFn: func(context.Context, libAuthz.RoleAssignment) error {
 						return nil
 					},
 				},
@@ -213,7 +213,7 @@ func TestProjectRoleAssignmentsServiceGrant(t *testing.T) {
 func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 	testCases := []struct {
 		name           string
-		roleAssignment authz.RoleAssignment
+		roleAssignment libAuthz.RoleAssignment
 		service        authz.RoleAssignmentsService
 		assertions     func(error)
 	}{
@@ -229,7 +229,7 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "error retrieving project from store",
-			roleAssignment: authz.RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeUser,
 					ID:   "foo",
@@ -251,7 +251,7 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "error retrieving user from store",
-			roleAssignment: authz.RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeUser,
 					ID:   "foo",
@@ -278,7 +278,7 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "error retrieving service account from store",
-			roleAssignment: authz.RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeServiceAccount,
 					ID:   "foo",
@@ -305,7 +305,7 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "error revoking the role",
-			roleAssignment: authz.RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeServiceAccount,
 					ID:   "foo",
@@ -324,7 +324,7 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeFn: func(context.Context, authz.RoleAssignment) error {
+					RevokeFn: func(context.Context, libAuthz.RoleAssignment) error {
 						return errors.New("something went wrong")
 					},
 				},
@@ -337,7 +337,7 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 		},
 		{
 			name: "success",
-			roleAssignment: authz.RoleAssignment{
+			roleAssignment: libAuthz.RoleAssignment{
 				Principal: libAuthz.PrincipalReference{
 					Type: authz.PrincipalTypeServiceAccount,
 					ID:   "foo",
@@ -356,7 +356,7 @@ func TestProjectRoleAssignmentsServiceRevoke(t *testing.T) {
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeFn: func(context.Context, authz.RoleAssignment) error {
+					RevokeFn: func(context.Context, libAuthz.RoleAssignment) error {
 						return nil
 					},
 				},

--- a/v2/apiserver/internal/core/projects.go
+++ b/v2/apiserver/internal/core/projects.go
@@ -250,7 +250,7 @@ func (p *projectsService) Create(
 
 	if err = p.roleAssignmentsStore.Grant(
 		ctx,
-		authz.RoleAssignment{
+		libAuthz.RoleAssignment{
 			Principal: principalRef,
 			Role:      RoleProjectAdmin(project.ID),
 		},
@@ -265,7 +265,7 @@ func (p *projectsService) Create(
 	}
 	if err = p.roleAssignmentsStore.Grant(
 		ctx,
-		authz.RoleAssignment{
+		libAuthz.RoleAssignment{
 			Principal: principalRef,
 			Role:      RoleProjectDeveloper(project.ID),
 		},
@@ -280,7 +280,7 @@ func (p *projectsService) Create(
 	}
 	if err = p.roleAssignmentsStore.Grant(
 		ctx,
-		authz.RoleAssignment{
+		libAuthz.RoleAssignment{
 			Principal: principalRef,
 			Role:      RoleProjectUser(project.ID),
 		},
@@ -387,7 +387,7 @@ func (p *projectsService) Delete(ctx context.Context, id string) error {
 	// permissions they ought not have.
 	if err := p.roleAssignmentsStore.RevokeMany(
 		ctx,
-		authz.RoleAssignment{
+		libAuthz.RoleAssignment{
 			Role: libAuthz.Role{
 				Type:  RoleTypeProject,
 				Scope: id,

--- a/v2/apiserver/internal/core/projects_test.go
+++ b/v2/apiserver/internal/core/projects_test.go
@@ -395,7 +395,7 @@ func TestProjectServiceDelete(t *testing.T) {
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, authz.RoleAssignment) error {
+					RevokeManyFn: func(context.Context, libAuthz.RoleAssignment) error {
 						return nil
 					},
 				},
@@ -439,7 +439,7 @@ func TestProjectServiceDelete(t *testing.T) {
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, authz.RoleAssignment) error {
+					RevokeManyFn: func(context.Context, libAuthz.RoleAssignment) error {
 						return errors.New("something went wrong")
 					},
 				},
@@ -483,7 +483,7 @@ func TestProjectServiceDelete(t *testing.T) {
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, authz.RoleAssignment) error {
+					RevokeManyFn: func(context.Context, libAuthz.RoleAssignment) error {
 						return nil
 					},
 				},
@@ -523,7 +523,7 @@ func TestProjectServiceDelete(t *testing.T) {
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, authz.RoleAssignment) error {
+					RevokeManyFn: func(context.Context, libAuthz.RoleAssignment) error {
 						return nil
 					},
 				},
@@ -568,7 +568,7 @@ func TestProjectServiceDelete(t *testing.T) {
 					},
 				},
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, authz.RoleAssignment) error {
+					RevokeManyFn: func(context.Context, libAuthz.RoleAssignment) error {
 						return nil
 					},
 				},

--- a/v2/apiserver/internal/core/rest/project_role_assignments_endpoints.go
+++ b/v2/apiserver/internal/core/rest/project_role_assignments_endpoints.go
@@ -38,7 +38,7 @@ func (p *ProjectRoleAssignmentsEndpoints) grant(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	roleAssignment := authz.RoleAssignment{}
+	roleAssignment := libAuthz.RoleAssignment{}
 	restmachinery.ServeRequest(
 		restmachinery.InboundRequest{
 			W:                   w,
@@ -57,7 +57,7 @@ func (p *ProjectRoleAssignmentsEndpoints) revoke(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
-	roleAssignment := authz.RoleAssignment{
+	roleAssignment := libAuthz.RoleAssignment{
 		Role: libAuthz.Role{
 			Type:  core.RoleTypeProject,
 			Name:  libAuthz.RoleName(r.URL.Query().Get("roleName")),

--- a/v2/apiserver/internal/lib/authz/role_assignments.go
+++ b/v2/apiserver/internal/lib/authz/role_assignments.go
@@ -1,0 +1,10 @@
+package authz
+
+// RoleAssignment represents the assignment of a Role to a principal such as a
+// User or ServiceAccount.
+type RoleAssignment struct {
+	// Role assigns a Role to the specified principal.
+	Role Role `json:"role" bson:"role"`
+	// Principal specifies the principal to whom the Role is assigned.
+	Principal PrincipalReference `json:"principal" bson:"principal"`
+}

--- a/v2/apiserver/internal/system/authz/authorizers.go
+++ b/v2/apiserver/internal/system/authz/authorizers.go
@@ -47,7 +47,7 @@ func (a *authorizer) Authorize(
 	if principal == nil {
 		return &meta.ErrAuthorization{}
 	}
-	roleAssignment := authz.RoleAssignment{}
+	roleAssignment := libAuthz.RoleAssignment{}
 	switch p := principal.(type) {
 	case roleHolder: // Any principal with hard-coded roles
 		for _, allowedRole := range allowedRoles {

--- a/v2/apiserver/internal/system/authz/authorizers_test.go
+++ b/v2/apiserver/internal/system/authz/authorizers_test.go
@@ -74,7 +74,10 @@ func TestAuthorizerAuthorize(t *testing.T) {
 			principal: &authn.User{},
 			authorizer: &authorizer{
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					ExistsFn: func(context.Context, authz.RoleAssignment) (bool, error) {
+					ExistsFn: func(
+						context.Context,
+						libAuthz.RoleAssignment,
+					) (bool, error) {
 						return false, errors.New("something went wrong")
 					},
 				},
@@ -89,7 +92,10 @@ func TestAuthorizerAuthorize(t *testing.T) {
 			principal: &authn.User{},
 			authorizer: &authorizer{
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					ExistsFn: func(context.Context, authz.RoleAssignment) (bool, error) {
+					ExistsFn: func(
+						context.Context,
+						libAuthz.RoleAssignment,
+					) (bool, error) {
 						return false, nil
 					},
 				},
@@ -104,7 +110,10 @@ func TestAuthorizerAuthorize(t *testing.T) {
 			principal: &authn.User{},
 			authorizer: &authorizer{
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					ExistsFn: func(context.Context, authz.RoleAssignment) (bool, error) {
+					ExistsFn: func(
+						context.Context,
+						libAuthz.RoleAssignment,
+					) (bool, error) {
 						return true, nil
 					},
 				},
@@ -118,7 +127,10 @@ func TestAuthorizerAuthorize(t *testing.T) {
 			principal: &authn.ServiceAccount{},
 			authorizer: &authorizer{
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					ExistsFn: func(context.Context, authz.RoleAssignment) (bool, error) {
+					ExistsFn: func(
+						context.Context,
+						libAuthz.RoleAssignment,
+					) (bool, error) {
 						return false, errors.New("something went wrong")
 					},
 				},
@@ -133,7 +145,10 @@ func TestAuthorizerAuthorize(t *testing.T) {
 			principal: &authn.ServiceAccount{},
 			authorizer: &authorizer{
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					ExistsFn: func(context.Context, authz.RoleAssignment) (bool, error) {
+					ExistsFn: func(
+						context.Context,
+						libAuthz.RoleAssignment,
+					) (bool, error) {
 						return false, nil
 					},
 				},
@@ -148,7 +163,10 @@ func TestAuthorizerAuthorize(t *testing.T) {
 			principal: &authn.ServiceAccount{},
 			authorizer: &authorizer{
 				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					ExistsFn: func(context.Context, authz.RoleAssignment) (bool, error) {
+					ExistsFn: func(
+						context.Context,
+						libAuthz.RoleAssignment,
+					) (bool, error) {
 						return true, nil
 					},
 				},

--- a/v2/cli/project_role_commands.go
+++ b/v2/cli/project_role_commands.go
@@ -156,7 +156,7 @@ func grantProjectRole(
 			return err
 		}
 
-		roleAssignment := authz.RoleAssignment{
+		roleAssignment := libAuthz.RoleAssignment{
 			Role: libAuthz.Role{
 				Type:  core.RoleTypeProject,
 				Name:  roleName,
@@ -206,7 +206,7 @@ func revokeProjectRole(
 			return err
 		}
 
-		roleAssignment := authz.RoleAssignment{
+		roleAssignment := libAuthz.RoleAssignment{
 			Role: libAuthz.Role{
 				Type:  core.RoleTypeProject,
 				Name:  roleName,

--- a/v2/cli/role_commands.go
+++ b/v2/cli/role_commands.go
@@ -163,7 +163,7 @@ func grantSystemRole(roleName libAuthz.RoleName) func(c *cli.Context) error {
 			)
 		}
 
-		roleAssignment := authz.RoleAssignment{
+		roleAssignment := libAuthz.RoleAssignment{
 			Role: libAuthz.Role{
 				Type: system.RoleTypeSystem,
 				Name: roleName,
@@ -216,7 +216,7 @@ func revokeSystemRole(
 			)
 		}
 
-		roleAssignment := authz.RoleAssignment{
+		roleAssignment := libAuthz.RoleAssignment{
 			Role: libAuthz.Role{
 				Type: system.RoleTypeSystem,
 				Name: roleName,


### PR DESCRIPTION
Related to #1257

Builds on #1356. That should be merged first and then this needs a rebase.

Like #1356, this is a baby step as part of a larger refactor. It just moves a type to a package that has fewer dependencies to avoid dependency cycles as the refactor continues.

There are no functional changes in this PR.