### PR TITLE
split RoleAssignment and ProjectRoleAssignment into separate types

### DIFF
--- a/sdk/v2/authz/role_assignments.go
+++ b/sdk/v2/authz/role_assignments.go
@@ -64,7 +64,6 @@ func (r *roleAssignmentsClient) Revoke(
 	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	queryParams := map[string]string{
-		"roleType":      string(roleAssignment.Role.Type),
 		"role":          string(roleAssignment.Role.Name),
 		"principalType": string(roleAssignment.Principal.Type),
 		"principalID":   roleAssignment.Principal.ID,

--- a/sdk/v2/authz/role_assignments_test.go
+++ b/sdk/v2/authz/role_assignments_test.go
@@ -11,7 +11,6 @@ import (
 	rmTesting "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery/testing" // nolint: lll
 	libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
 	metaTesting "github.com/brigadecore/brigade/sdk/v2/meta/testing"
-	"github.com/brigadecore/brigade/sdk/v2/system"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,7 +35,6 @@ func TestNewRoleAssignmentsClient(t *testing.T) {
 func TestRoleAssignmentsClientGrant(t *testing.T) {
 	testRoleAssignment := libAuthz.RoleAssignment{
 		Role: libAuthz.Role{
-			Type: system.RoleTypeSystem,
 			Name: libAuthz.RoleName("ceo"),
 		},
 		Principal: libAuthz.PrincipalReference{
@@ -69,7 +67,6 @@ func TestRoleAssignmentsClientGrant(t *testing.T) {
 func TestRoleAssignmentsClientRevoke(t *testing.T) {
 	testRoleAssignment := libAuthz.RoleAssignment{
 		Role: libAuthz.Role{
-			Type: system.RoleTypeSystem,
 			Name: libAuthz.RoleName("ceo"),
 		},
 		Principal: libAuthz.PrincipalReference{
@@ -82,11 +79,6 @@ func TestRoleAssignmentsClientRevoke(t *testing.T) {
 			func(w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, http.MethodDelete, r.Method)
 				require.Equal(t, "/v2/role-assignments", r.URL.Path)
-				require.Equal(
-					t,
-					testRoleAssignment.Role.Type,
-					libAuthz.RoleType(r.URL.Query().Get("roleType")),
-				)
 				require.Equal(
 					t,
 					testRoleAssignment.Role.Name,

--- a/sdk/v2/core/authz.go
+++ b/sdk/v2/core/authz.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"github.com/brigadecore/brigade/sdk/v2/authz"
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
@@ -10,13 +9,13 @@ import (
 type AuthzClient interface {
 	// RoleAssignments returns a specialized client for managing project-level
 	// RoleAssignments.
-	RoleAssignments() authz.RoleAssignmentsClient
+	RoleAssignments() ProjectRoleAssignmentsClient
 }
 
 type authzClient struct {
-	// roleAssignmentsClient is a specialized client for managing project-level
-	// RoleAssignments.
-	roleAssignmentsClient authz.RoleAssignmentsClient
+	// projectRoleAssignmentsClient is a specialized client for managing
+	// ProjectRoleAssignments.
+	projectRoleAssignmentsClient ProjectRoleAssignmentsClient
 }
 
 // NewAuthzClient returns a specialized client for managing project-level
@@ -27,7 +26,7 @@ func NewAuthzClient(
 	opts *restmachinery.APIClientOptions,
 ) AuthzClient {
 	return &authzClient{
-		roleAssignmentsClient: NewProjectRoleAssignmentsClient(
+		projectRoleAssignmentsClient: NewProjectRoleAssignmentsClient(
 			apiAddress,
 			apiToken,
 			opts,
@@ -35,6 +34,6 @@ func NewAuthzClient(
 	}
 }
 
-func (a *authzClient) RoleAssignments() authz.RoleAssignmentsClient {
-	return a.roleAssignmentsClient
+func (a *authzClient) RoleAssignments() ProjectRoleAssignmentsClient {
+	return a.projectRoleAssignmentsClient
 }

--- a/sdk/v2/core/authz_test.go
+++ b/sdk/v2/core/authz_test.go
@@ -14,10 +14,10 @@ func TestNewAuthzClient(t *testing.T) {
 		nil,
 	)
 	require.IsType(t, &authzClient{}, client)
-	require.NotNil(t, client.(*authzClient).roleAssignmentsClient)
+	require.NotNil(t, client.(*authzClient).projectRoleAssignmentsClient)
 	require.Equal(
 		t,
-		client.(*authzClient).roleAssignmentsClient,
+		client.(*authzClient).projectRoleAssignmentsClient,
 		client.RoleAssignments(),
 	)
 }

--- a/sdk/v2/core/named_roles.go
+++ b/sdk/v2/core/named_roles.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
-	"github.com/brigadecore/brigade/sdk/v2/system"
 )
 
 const (
@@ -40,7 +39,6 @@ const (
 // create Events for all Projects.
 func RoleEventCreator() libAuthz.Role {
 	return libAuthz.Role{
-		Type: system.RoleTypeSystem,
 		Name: RoleNameEventCreator,
 	}
 }
@@ -49,36 +47,32 @@ func RoleEventCreator() libAuthz.Role {
 // create new Projects.
 func RoleProjectCreator() libAuthz.Role {
 	return libAuthz.Role{
-		Type: system.RoleTypeSystem,
 		Name: RoleNameProjectCreator,
 	}
 }
 
 // Core-specific, project-level roles...
 
-// RoleProjectAdmin returns a project-level Role that enables a principal to
-// manage a Project.
-func RoleProjectAdmin() libAuthz.Role {
-	return libAuthz.Role{
-		Type: RoleTypeProject,
+// RoleProjectAdmin returns a ProjectRole that enables a principal to manage a
+// Project.
+func RoleProjectAdmin() ProjectRole {
+	return ProjectRole{
 		Name: RoleNameProjectAdmin,
 	}
 }
 
-// RoleProjectDeveloper returns a project-level Role that enables a principal to
-// update a Project.
-func RoleProjectDeveloper() libAuthz.Role {
-	return libAuthz.Role{
-		Type: RoleTypeProject,
+// RoleProjectDeveloper returns a ProjectRole that enables a principal to update
+// a Project.
+func RoleProjectDeveloper() ProjectRole {
+	return ProjectRole{
 		Name: RoleNameProjectDeveloper,
 	}
 }
 
-// RoleProjectUser returns a project-level Role that enables a principal to
-// create and manage Events for a Project.
-func RoleProjectUser() libAuthz.Role {
-	return libAuthz.Role{
-		Type: RoleTypeProject,
+// RoleProjectUser returns a ProjectRole that enables a principal to create and
+// manage Events for a Project.
+func RoleProjectUser() ProjectRole {
+	return ProjectRole{
 		Name: RoleNameProjectUser,
 	}
 }

--- a/sdk/v2/core/project_role_assignments.go
+++ b/sdk/v2/core/project_role_assignments.go
@@ -2,13 +2,54 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
-	"github.com/brigadecore/brigade/sdk/v2/authz"
 	rm "github.com/brigadecore/brigade/sdk/v2/internal/restmachinery"
 	libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
+	"github.com/brigadecore/brigade/sdk/v2/meta"
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
+
+// ProjectRoleAssignment represents the assignment of a ProjectRole to a
+// principal such as a User or ServiceAccount.
+type ProjectRoleAssignment struct {
+	// Role assigns a Role to the specified principal.
+	Role ProjectRole `json:"role"`
+	// Principal specifies the principal to whom the Role is assigned.
+	Principal libAuthz.PrincipalReference `json:"principal"`
+	// ProjectID qualifies the scope of the Role.
+	ProjectID string `json:"projectID,omitempty"`
+}
+
+// MarshalJSON amends ProjectRoleAssignment instances with type metadata so that
+// clients do not need to be concerned with the tedium of doing so.
+func (p ProjectRoleAssignment) MarshalJSON() ([]byte, error) {
+	type Alias ProjectRoleAssignment
+	return json.Marshal(
+		struct {
+			meta.TypeMeta `json:",inline"`
+			Alias         `json:",inline"`
+		}{
+			TypeMeta: meta.TypeMeta{
+				APIVersion: meta.APIVersion,
+				Kind:       "ProjectRoleAssignment",
+			},
+			Alias: (Alias)(p),
+		},
+	)
+}
+
+// ProjectRoleAssignmentsClient is the specialized client for managing
+// ProjectRoleAssignments with the Brigade API.
+type ProjectRoleAssignmentsClient interface {
+	// Grant grants the ProjectRole specified by the ProjectRoleAssignment to the
+	// principal also specified by the ProjectRoleAssignment.
+	Grant(context.Context, ProjectRoleAssignment) error
+	// Revoke revokes the ProjectRole specified by the ProjectRoleAssignment for
+	// the principal also specified by the ProjectRoleAssignment.
+	Revoke(context.Context, ProjectRoleAssignment) error
+}
 
 type projectRoleAssignmentsClient struct {
 	*rm.BaseClient
@@ -20,7 +61,7 @@ func NewProjectRoleAssignmentsClient(
 	apiAddress string,
 	apiToken string,
 	opts *restmachinery.APIClientOptions,
-) authz.RoleAssignmentsClient {
+) ProjectRoleAssignmentsClient {
 	return &projectRoleAssignmentsClient{
 		BaseClient: rm.NewBaseClient(apiAddress, apiToken, opts),
 	}
@@ -28,14 +69,14 @@ func NewProjectRoleAssignmentsClient(
 
 func (p *projectRoleAssignmentsClient) Grant(
 	ctx context.Context,
-	roleAssignment libAuthz.RoleAssignment,
+	projectRoleAssignment ProjectRoleAssignment,
 ) error {
 	return p.ExecuteRequest(
 		ctx,
 		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        "v2/project-role-assignments",
-			ReqBodyObj:  roleAssignment,
+			ReqBodyObj:  projectRoleAssignment,
 			SuccessCode: http.StatusOK,
 		},
 	)
@@ -43,13 +84,13 @@ func (p *projectRoleAssignmentsClient) Grant(
 
 func (p *projectRoleAssignmentsClient) Revoke(
 	ctx context.Context,
-	roleAssignment libAuthz.RoleAssignment,
+	projectRoleAssignment ProjectRoleAssignment,
 ) error {
 	queryParams := map[string]string{
-		"role":          string(roleAssignment.Role.Name),
-		"scope":         roleAssignment.Scope,
-		"principalType": string(roleAssignment.Principal.Type),
-		"principalID":   roleAssignment.Principal.ID,
+		"role":          string(projectRoleAssignment.Role.Name),
+		"projectID":     projectRoleAssignment.ProjectID,
+		"principalType": string(projectRoleAssignment.Principal.Type),
+		"principalID":   projectRoleAssignment.Principal.ID,
 	}
 	return p.ExecuteRequest(
 		ctx,

--- a/sdk/v2/core/project_roles.go
+++ b/sdk/v2/core/project_roles.go
@@ -1,0 +1,12 @@
+package core
+
+import libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
+
+// ProjectRoleScopeGlobal represents an unbounded project scope.
+const ProjectRoleScopeGlobal = "*"
+
+// ProjectRole represents a set of project-level permissions.
+type ProjectRole struct {
+	// Name is the name of a ProjectRole and has domain-specific meaning.
+	Name libAuthz.RoleName `json:"name,omitempty"`
+}

--- a/sdk/v2/core/project_roles_assignments_test.go
+++ b/sdk/v2/core/project_roles_assignments_test.go
@@ -28,12 +28,11 @@ func TestNewProjectRoleAssignmentsClient(t *testing.T) {
 }
 
 func TestProjectRoleAssignmentsClientGrant(t *testing.T) {
-	testRoleAssignment := libAuthz.RoleAssignment{
-		Role: libAuthz.Role{
-			Type: RoleTypeProject,
+	testProjectRoleAssignment := ProjectRoleAssignment{
+		Role: ProjectRole{
 			Name: libAuthz.RoleName("ceo"),
 		},
-		Scope: "bluebook",
+		ProjectID: "bluebook",
 		Principal: libAuthz.PrincipalReference{
 			Type: authz.PrincipalTypeUser,
 			ID:   "tony@starkindustries.com",
@@ -47,10 +46,10 @@ func TestProjectRoleAssignmentsClientGrant(t *testing.T) {
 				require.Equal(t, "/v2/project-role-assignments", r.URL.Path)
 				bodyBytes, err := ioutil.ReadAll(r.Body)
 				require.NoError(t, err)
-				roleAssignment := libAuthz.RoleAssignment{}
-				err = json.Unmarshal(bodyBytes, &roleAssignment)
+				projectRoleAssignment := ProjectRoleAssignment{}
+				err = json.Unmarshal(bodyBytes, &projectRoleAssignment)
 				require.NoError(t, err)
-				require.Equal(t, testRoleAssignment, roleAssignment)
+				require.Equal(t, testProjectRoleAssignment, projectRoleAssignment)
 				w.WriteHeader(http.StatusOK)
 			},
 		),
@@ -61,17 +60,16 @@ func TestProjectRoleAssignmentsClientGrant(t *testing.T) {
 		rmTesting.TestAPIToken,
 		nil,
 	)
-	err := client.Grant(context.Background(), testRoleAssignment)
+	err := client.Grant(context.Background(), testProjectRoleAssignment)
 	require.NoError(t, err)
 }
 
 func TestProjectRoleAssignmentsClientRevoke(t *testing.T) {
-	testRoleAssignment := libAuthz.RoleAssignment{
-		Role: libAuthz.Role{
-			Type: RoleTypeProject,
+	testProjectRoleAssignment := ProjectRoleAssignment{
+		Role: ProjectRole{
 			Name: libAuthz.RoleName("ceo"),
 		},
-		Scope: "bluebook",
+		ProjectID: "bluebook",
 		Principal: libAuthz.PrincipalReference{
 			Type: authz.PrincipalTypeUser,
 			ID:   "tony@starkindustries.com",
@@ -84,22 +82,22 @@ func TestProjectRoleAssignmentsClientRevoke(t *testing.T) {
 				require.Equal(t, "/v2/project-role-assignments", r.URL.Path)
 				require.Equal(
 					t,
-					testRoleAssignment.Role.Name,
+					testProjectRoleAssignment.Role.Name,
 					libAuthz.RoleName(r.URL.Query().Get("role")),
 				)
 				require.Equal(
 					t,
-					testRoleAssignment.Scope,
-					r.URL.Query().Get("scope"),
+					testProjectRoleAssignment.ProjectID,
+					r.URL.Query().Get("projectID"),
 				)
 				require.Equal(
 					t,
-					testRoleAssignment.Principal.Type,
+					testProjectRoleAssignment.Principal.Type,
 					libAuthz.PrincipalType(r.URL.Query().Get("principalType")),
 				)
 				require.Equal(
 					t,
-					testRoleAssignment.Principal.ID,
+					testProjectRoleAssignment.Principal.ID,
 					r.URL.Query().Get("principalID"),
 				)
 				w.WriteHeader(http.StatusOK)
@@ -112,6 +110,6 @@ func TestProjectRoleAssignmentsClientRevoke(t *testing.T) {
 		rmTesting.TestAPIToken,
 		nil,
 	)
-	err := client.Revoke(context.Background(), testRoleAssignment)
+	err := client.Revoke(context.Background(), testProjectRoleAssignment)
 	require.NoError(t, err)
 }

--- a/sdk/v2/core/roles.go
+++ b/sdk/v2/core/roles.go
@@ -1,6 +1,0 @@
-package core
-
-import libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
-
-// RoleTypeProject represents a project-level Role.
-const RoleTypeProject libAuthz.RoleType = "PROJECT"

--- a/sdk/v2/lib/authz/roles.go
+++ b/sdk/v2/lib/authz/roles.go
@@ -1,9 +1,5 @@
 package authz
 
-// RoleType is a type whose values can be used to disambiguate one type of Role
-// from another.
-type RoleType string
-
 // RoleName is a type whose value maps to a well-defined Brigade Role.
 type RoleName string
 
@@ -13,9 +9,6 @@ const RoleScopeGlobal = "*"
 // Role represents a set of permissions, with domain-specific meaning, held by a
 // principal, such as a User or ServiceAccount via a RoleAssignment.
 type Role struct {
-	// Type indicates the Role's type, for instance, system-level or
-	// project-level.
-	Type RoleType `json:"type,omitempty"`
 	// Name is the name of a Role and has domain-specific meaning.
 	Name RoleName `json:"name,omitempty"`
 }

--- a/sdk/v2/system/named_roles.go
+++ b/sdk/v2/system/named_roles.go
@@ -18,7 +18,6 @@ const (
 // ServiceAccounts.
 func RoleAdmin() libAuthz.Role {
 	return libAuthz.Role{
-		Type: RoleTypeSystem,
 		Name: RoleNameAdmin,
 	}
 }
@@ -26,7 +25,6 @@ func RoleAdmin() libAuthz.Role {
 // RoleReader returns a system-level Role that enables global read access.
 func RoleReader() libAuthz.Role {
 	return libAuthz.Role{
-		Type: RoleTypeSystem,
 		Name: RoleNameReader,
 	}
 }

--- a/sdk/v2/system/roles.go
+++ b/sdk/v2/system/roles.go
@@ -1,6 +1,0 @@
-package system
-
-import libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
-
-// RoleTypeSystem represents a system-level Role.
-const RoleTypeSystem libAuthz.RoleType = "SYSTEM"

--- a/v2/apiserver/internal/authz/mock_roles_assignments_store.go
+++ b/v2/apiserver/internal/authz/mock_roles_assignments_store.go
@@ -7,10 +7,9 @@ import (
 )
 
 type MockRoleAssignmentsStore struct {
-	GrantFn      func(context.Context, libAuthz.RoleAssignment) error
-	RevokeFn     func(context.Context, libAuthz.RoleAssignment) error
-	RevokeManyFn func(context.Context, libAuthz.RoleAssignment) error
-	ExistsFn     func(context.Context, libAuthz.RoleAssignment) (bool, error)
+	GrantFn  func(context.Context, libAuthz.RoleAssignment) error
+	RevokeFn func(context.Context, libAuthz.RoleAssignment) error
+	ExistsFn func(context.Context, libAuthz.RoleAssignment) (bool, error)
 }
 
 func (m *MockRoleAssignmentsStore) Grant(
@@ -25,13 +24,6 @@ func (m *MockRoleAssignmentsStore) Revoke(
 	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	return m.RevokeFn(ctx, roleAssignment)
-}
-
-func (m *MockRoleAssignmentsStore) RevokeMany(
-	ctx context.Context,
-	roleAssignment libAuthz.RoleAssignment,
-) error {
-	return m.RevokeManyFn(ctx, roleAssignment)
 }
 
 func (m *MockRoleAssignmentsStore) Exists(

--- a/v2/apiserver/internal/authz/mongodb/role_assignments_store.go
+++ b/v2/apiserver/internal/authz/mongodb/role_assignments_store.go
@@ -65,38 +65,11 @@ func (r *roleAssignmentsStore) Revoke(
 	return nil
 }
 
-func (r *roleAssignmentsStore) RevokeMany(
-	ctx context.Context,
-	roleAssignment libAuthz.RoleAssignment,
-) error {
-	criteria := bson.M{}
-	if roleAssignment.Role.Type != "" {
-		criteria["role.type"] = roleAssignment.Role.Type
-	}
-	if roleAssignment.Role.Name != "" {
-		criteria["role.name"] = roleAssignment.Role.Name
-	}
-	if roleAssignment.Scope != "" {
-		criteria["scope"] = roleAssignment.Scope
-	}
-	if roleAssignment.Principal.Type != "" {
-		criteria["principal.type"] = roleAssignment.Principal.Type
-	}
-	if roleAssignment.Principal.ID != "" {
-		criteria["principal.id"] = roleAssignment.Principal.ID
-	}
-	if _, err := r.collection.DeleteMany(ctx, criteria); err != nil {
-		return errors.Wrap(err, "error deleting role assignments")
-	}
-	return nil
-}
-
 func (r *roleAssignmentsStore) Exists(
 	ctx context.Context,
 	roleAssignment libAuthz.RoleAssignment,
 ) (bool, error) {
 	criteria := bson.M{
-		"role.type":      roleAssignment.Role.Type,
 		"role.name":      roleAssignment.Role.Name,
 		"principal.type": roleAssignment.Principal.Type,
 		"principal.id":   roleAssignment.Principal.ID,

--- a/v2/apiserver/internal/authz/rest/role_assignments_endpoints.go
+++ b/v2/apiserver/internal/authz/rest/role_assignments_endpoints.go
@@ -6,7 +6,6 @@ import (
 	"github.com/brigadecore/brigade/v2/apiserver/internal/authz"
 	libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/restmachinery"
-	"github.com/brigadecore/brigade/v2/apiserver/internal/system"
 	"github.com/gorilla/mux"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -58,7 +57,6 @@ func (r *RoleAssignmentsEndpoints) revoke(
 ) {
 	roleAssignment := libAuthz.RoleAssignment{
 		Role: libAuthz.Role{
-			Type: system.RoleTypeSystem,
 			Name: libAuthz.RoleName(req.URL.Query().Get("role")),
 		},
 		Scope: req.URL.Query().Get("scope"),

--- a/v2/apiserver/internal/authz/role_assignments.go
+++ b/v2/apiserver/internal/authz/role_assignments.go
@@ -172,22 +172,6 @@ type RoleAssignmentsStore interface {
 	// Revoke the role specified by the RoleAssignment for the principal specified
 	// by the RoleAssignment.
 	Revoke(context.Context, libAuthz.RoleAssignment) error
-	// RevokeMany revokes all RoleAssignments that share ALL properties of the
-	// specified RoleAssignment. Properties left unspecified are ignored, i.e.
-	// not factored into the match.
-	//
-	// Example -- revoking all project-level RoleAssignments for a given Project:
-	//
-	//   err := p.roleAssignmentsStore.RevokeMany(
-	// 	  ctx,
-	// 	  authz.RoleAssignment{
-	// 		  Role: libAuthz.Role{
-	// 			  Type:  RoleTypeProject,
-	// 			  Scope: projectID,
-	// 		  },
-	// 	  },
-	//   )
-	RevokeMany(ctx context.Context, roleAssignment libAuthz.RoleAssignment) error
 
 	// Exists returns a bool indicating whether the specified RoleAssignment
 	// exists within the store. Implementations MUST also return true if a

--- a/v2/apiserver/internal/core/authorizers.go
+++ b/v2/apiserver/internal/core/authorizers.go
@@ -1,0 +1,121 @@
+package core
+
+import (
+	"context"
+	"log"
+
+	"github.com/brigadecore/brigade/v2/apiserver/internal/authn"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/authz"
+	libAuthn "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authn"
+	libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
+)
+
+// ProjectAuthorizeFn is the signature for any function that can, presumably,
+// retrieve a principal from the provided Context and make an access control
+// decision based on the principal having (or not having) the specified
+// ProjectRole for the specified Project. Implementations MUST return a
+// *meta.ErrAuthorization error if the principal is not authorized.
+type ProjectAuthorizeFn func(
+	ctx context.Context,
+	projectID string,
+	projectRole ProjectRole,
+) error
+
+// alwaysProjectAuthorize is an implementation of the ProjectAuthorizeFn
+// function signature that unconditionally passes authorization requests by
+// returning nil. This is used only for testing purposes.
+func alwaysProjectAuthorize(context.Context, string, ProjectRole) error {
+	return nil
+}
+
+// neverProjectAuthorize is an implementation of the ProjectAuthorizeFn function
+// signature that unconditionally fails authorization requests by returning a
+// *meta.ErrAuthorization error. This is used only for testing purposes.
+func neverProjectAuthorize(context.Context, string, ProjectRole) error {
+	return &meta.ErrAuthorization{}
+}
+
+// projectRoleAssignmentsHolder is an interface for any sort of security
+// principal that can directly return its own ProjectRoleAssignments from a
+// function call without making a database call.
+type projectRoleAssignmentsHolder interface {
+	ProjectRoleAssignments() []ProjectRoleAssignment
+}
+
+// ProjectAuthorizer is the public interface for the component returned by the
+// NewProjectAuthorizer function.
+type ProjectAuthorizer interface {
+	// Authorize retrieves a principal from the provided Context and asserts that
+	// it has the specified ProjectRole for the specified Project. If it does not,
+	// implementations MUST return a *meta.ErrAuthorization error.
+	Authorize(ctx context.Context, projectID string, role ProjectRole) error
+}
+
+// projectAuthorizer is a component that can authorize a request.
+type projectAuthorizer struct {
+	projectRoleAssignmentsStore ProjectRoleAssignmentsStore
+}
+
+// NewProjectAuthorizer returns a component that can authorize a request.
+func NewProjectAuthorizer(
+	projectRoleAssignmentsStore ProjectRoleAssignmentsStore,
+) ProjectAuthorizer {
+	return &projectAuthorizer{
+		projectRoleAssignmentsStore: projectRoleAssignmentsStore,
+	}
+}
+
+func (p *projectAuthorizer) Authorize(
+	ctx context.Context,
+	projectID string,
+	projectRole ProjectRole,
+) error {
+	principal := libAuthn.PrincipalFromContext(ctx)
+	if principal == nil {
+		return &meta.ErrAuthorization{}
+	}
+	projectRoleAssignment := ProjectRoleAssignment{
+		ProjectID: projectID,
+		Role:      projectRole,
+	}
+	switch p := principal.(type) {
+	case projectRoleAssignmentsHolder:
+		// A principal with hard-coded RoleAssignments
+		for _, projectRoleAssignment = range p.ProjectRoleAssignments() {
+			if projectRoleAssignment.Matches(projectID, projectRole) {
+				return nil
+			}
+		}
+		return &meta.ErrAuthorization{}
+	case *authn.User:
+		projectRoleAssignment.Principal = libAuthz.PrincipalReference{
+			Type: authz.PrincipalTypeUser,
+			ID:   p.ID,
+		}
+	case *authn.ServiceAccount:
+		projectRoleAssignment.Principal = libAuthz.PrincipalReference{
+			Type: authz.PrincipalTypeServiceAccount,
+			ID:   p.ID,
+		}
+	default:
+		// This case might occur for a specialized principal like the scheduler or
+		// observer that is neither a User or ServiceAccount nor implements the
+		// roleAssignmentHolder interface.
+		return &meta.ErrAuthorization{}
+	}
+	// We only get here if the principal was a User or ServiceAccount
+	if exists, err := p.projectRoleAssignmentsStore.Exists(
+		ctx,
+		projectRoleAssignment,
+	); err != nil {
+		// We encountered an unexpected error when looking for a
+		// ProjectRoleAssignment in the store. We're going to treat this as an authz
+		// failure, but we're also going to log it for good measure.
+		log.Println(err)
+		return &meta.ErrAuthorization{}
+	} else if exists {
+		return nil
+	}
+	return &meta.ErrAuthorization{}
+}

--- a/v2/apiserver/internal/core/events_test.go
+++ b/v2/apiserver/internal/core/events_test.go
@@ -42,6 +42,7 @@ func TestNewEventsService(t *testing.T) {
 	substrate := &mockSubstrate{}
 	svc := NewEventsService(
 		libAuthz.AlwaysAuthorize,
+		alwaysProjectAuthorize,
 		projectsStore,
 		eventsStore,
 		logsStore,
@@ -77,7 +78,7 @@ func TestEventsServiceCreate(t *testing.T) {
 				ProjectID: "blue-book",
 			},
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, errors.New("projects store error")
@@ -97,7 +98,7 @@ func TestEventsServiceCreate(t *testing.T) {
 				ProjectID: "blue-book",
 			},
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -122,7 +123,7 @@ func TestEventsServiceCreate(t *testing.T) {
 				ProjectID: "blue-book",
 			},
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -629,7 +630,7 @@ func TestEventsServiceCancel(t *testing.T) {
 		{
 			name: "unauthorized",
 			service: &eventsService{
-				authorize: libAuthz.NeverAuthorize,
+				projectAuthorize: neverProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -644,7 +645,7 @@ func TestEventsServiceCancel(t *testing.T) {
 		{
 			name: "error retrieving project from store",
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -665,7 +666,7 @@ func TestEventsServiceCancel(t *testing.T) {
 		{
 			name: "error canceling event in store",
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -689,7 +690,7 @@ func TestEventsServiceCancel(t *testing.T) {
 		{
 			name: "error deleting event from substrate",
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -720,7 +721,7 @@ func TestEventsServiceCancel(t *testing.T) {
 		{
 			name: "success",
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -780,7 +781,7 @@ func TestEventsServiceCancelMany(t *testing.T) {
 				ProjectID: "blue-book",
 			},
 			service: &eventsService{
-				authorize: libAuthz.NeverAuthorize,
+				projectAuthorize: neverProjectAuthorize,
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
@@ -793,7 +794,7 @@ func TestEventsServiceCancelMany(t *testing.T) {
 				ProjectID: "blue-book",
 			},
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
@@ -813,7 +814,7 @@ func TestEventsServiceCancelMany(t *testing.T) {
 				WorkerPhases: []WorkerPhase{WorkerPhaseFailed},
 			},
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, errors.New("error getting project")
@@ -833,7 +834,7 @@ func TestEventsServiceCancelMany(t *testing.T) {
 				WorkerPhases: []WorkerPhase{WorkerPhaseFailed},
 			},
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -861,7 +862,7 @@ func TestEventsServiceCancelMany(t *testing.T) {
 				WorkerPhases: []WorkerPhase{WorkerPhaseFailed},
 			},
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -917,7 +918,7 @@ func TestEventsServiceDelete(t *testing.T) {
 		{
 			name: "unauthorized",
 			service: &eventsService{
-				authorize: libAuthz.NeverAuthorize,
+				projectAuthorize: neverProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -932,7 +933,7 @@ func TestEventsServiceDelete(t *testing.T) {
 		{
 			name: "error retrieving project from store",
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -953,7 +954,7 @@ func TestEventsServiceDelete(t *testing.T) {
 		{
 			name: "error deleting event from store",
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -977,7 +978,7 @@ func TestEventsServiceDelete(t *testing.T) {
 		{
 			name: "error deleting event from substrate",
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -1008,7 +1009,7 @@ func TestEventsServiceDelete(t *testing.T) {
 		{
 			name: "error deleting event logs",
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -1041,7 +1042,7 @@ func TestEventsServiceDelete(t *testing.T) {
 		{
 			name: "success",
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -1106,7 +1107,7 @@ func TestEventsServiceDeleteMany(t *testing.T) {
 				ProjectID: "blue-book",
 			},
 			service: &eventsService{
-				authorize: libAuthz.NeverAuthorize,
+				projectAuthorize: neverProjectAuthorize,
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
@@ -1119,7 +1120,7 @@ func TestEventsServiceDeleteMany(t *testing.T) {
 				ProjectID: "blue-book",
 			},
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
@@ -1139,7 +1140,7 @@ func TestEventsServiceDeleteMany(t *testing.T) {
 				WorkerPhases: []WorkerPhase{WorkerPhaseFailed},
 			},
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, errors.New("error getting project")
@@ -1159,7 +1160,7 @@ func TestEventsServiceDeleteMany(t *testing.T) {
 				WorkerPhases: []WorkerPhase{WorkerPhaseFailed},
 			},
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -1187,7 +1188,7 @@ func TestEventsServiceDeleteMany(t *testing.T) {
 				WorkerPhases: []WorkerPhase{WorkerPhaseFailed},
 			},
 			service: &eventsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil

--- a/v2/apiserver/internal/core/logs_test.go
+++ b/v2/apiserver/internal/core/logs_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
 	metaTesting "github.com/brigadecore/brigade/v2/apiserver/internal/meta/testing" // nolint: lll
 	"github.com/stretchr/testify/require"
@@ -21,13 +20,13 @@ func TestLogsService(t *testing.T) {
 	warmLogsStore := &mockLogsStore{}
 	coolLogsStore := &mockLogsStore{}
 	svc := NewLogsService(
-		libAuthz.AlwaysAuthorize,
+		alwaysProjectAuthorize,
 		projectsStore,
 		eventsStore,
 		warmLogsStore,
 		coolLogsStore,
 	)
-	require.NotNil(t, svc.(*logsService).authorize)
+	require.NotNil(t, svc.(*logsService).projectAuthorize)
 	require.Same(t, projectsStore, svc.(*logsService).projectsStore)
 	require.Same(t, eventsStore, svc.(*logsService).eventsStore)
 	require.Same(t, warmLogsStore, svc.(*logsService).warmLogsStore)
@@ -74,7 +73,7 @@ func TestLogsServiceStream(t *testing.T) {
 		{
 			name: "unauthorized",
 			service: &logsService{
-				authorize: libAuthz.NeverAuthorize,
+				projectAuthorize: neverProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -92,7 +91,7 @@ func TestLogsServiceStream(t *testing.T) {
 				Job: "foo",
 			},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -113,7 +112,7 @@ func TestLogsServiceStream(t *testing.T) {
 				Container: "bar",
 			},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{
@@ -139,7 +138,7 @@ func TestLogsServiceStream(t *testing.T) {
 			name:     "error retrieving project from store",
 			selector: LogsSelector{},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -161,7 +160,7 @@ func TestLogsServiceStream(t *testing.T) {
 			name:     "warm logs succeed",
 			selector: LogsSelector{},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -205,7 +204,7 @@ func TestLogsServiceStream(t *testing.T) {
 			name:     "warm logs store has unexpected error",
 			selector: LogsSelector{},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -237,7 +236,7 @@ func TestLogsServiceStream(t *testing.T) {
 			name:     "cool logs succeed",
 			selector: LogsSelector{},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil
@@ -281,7 +280,7 @@ func TestLogsServiceStream(t *testing.T) {
 			name:     "warm and cool logs both fail",
 			selector: LogsSelector{},
 			service: &logsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				eventsStore: &mockEventsStore{
 					GetFn: func(context.Context, string) (Event, error) {
 						return Event{}, nil

--- a/v2/apiserver/internal/core/mongodb/project_role_assignments_store.go
+++ b/v2/apiserver/internal/core/mongodb/project_role_assignments_store.go
@@ -1,0 +1,113 @@
+package mongodb
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/v2/apiserver/internal/core"
+	"github.com/brigadecore/brigade/v2/apiserver/internal/lib/mongodb"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// projectRoleAssignmentsStore is a MongoDB-based implementation of the
+// core.ProjectRoleAssignmentsStore interface.
+type projectRoleAssignmentsStore struct {
+	collection mongodb.Collection
+}
+
+// NewProjectRoleAssignmentsStore returns a MongoDB-based implementation of the
+// core.ProjectRoleAssignmentsStore interface.
+func NewProjectRoleAssignmentsStore(
+	database *mongo.Database,
+) core.ProjectRoleAssignmentsStore {
+	// TODO: Add indices
+	return &projectRoleAssignmentsStore{
+		collection: database.Collection("project-role-assignments"),
+	}
+}
+
+func (p *projectRoleAssignmentsStore) Grant(
+	ctx context.Context,
+	projectRoleAssignment core.ProjectRoleAssignment,
+) error {
+	tru := true
+	criteria := bson.M{
+		"projectID":      projectRoleAssignment.ProjectID,
+		"role.name":      projectRoleAssignment.Role.Name,
+		"principal.type": projectRoleAssignment.Principal.Type,
+		"principal.id":   projectRoleAssignment.Principal.ID,
+	}
+	if res := p.collection.FindOneAndReplace(
+		ctx,
+		criteria,
+		projectRoleAssignment,
+		&options.FindOneAndReplaceOptions{
+			Upsert: &tru,
+		},
+	); res.Err() != nil && res.Err() != mongo.ErrNoDocuments {
+		return errors.Wrapf(
+			res.Err(),
+			"error upserting project role assignment %v",
+			projectRoleAssignment,
+		)
+	}
+	return nil
+}
+
+func (p *projectRoleAssignmentsStore) Revoke(
+	ctx context.Context,
+	projectRoleAssignment core.ProjectRoleAssignment,
+) error {
+	criteria := bson.M{
+		"projectID":      projectRoleAssignment.ProjectID,
+		"role.name":      projectRoleAssignment.Role.Name,
+		"principal.type": projectRoleAssignment.Principal.Type,
+		"principal.id":   projectRoleAssignment.Principal.ID,
+	}
+	if _, err := p.collection.DeleteOne(ctx, criteria); err != nil {
+		return errors.Wrapf(
+			err,
+			"error deleting project role assignment %v",
+			projectRoleAssignment,
+		)
+	}
+	return nil
+}
+
+func (p *projectRoleAssignmentsStore) RevokeByProjectID(
+	ctx context.Context,
+	projectID string,
+) error {
+	if _, err := p.collection.DeleteMany(
+		ctx,
+		bson.M{"projectID": projectID},
+	); err != nil {
+		return errors.Wrapf(
+			err,
+			"error deleting project role assignments for project %q",
+			projectID,
+		)
+	}
+	return nil
+}
+
+func (p *projectRoleAssignmentsStore) Exists(
+	ctx context.Context,
+	projectRoleAssignment core.ProjectRoleAssignment,
+) (bool, error) {
+	criteria := bson.M{
+		"projectID":      projectRoleAssignment.ProjectID,
+		"role.name":      projectRoleAssignment.Role.Name,
+		"principal.type": projectRoleAssignment.Principal.Type,
+		"principal.id":   projectRoleAssignment.Principal.ID,
+	}
+	if err :=
+		p.collection.FindOne(ctx, criteria).Err(); err == mongo.ErrNoDocuments {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Wrap(err, "error finding project role assignment")
+	}
+	return true, nil
+}

--- a/v2/apiserver/internal/core/named_roles.go
+++ b/v2/apiserver/internal/core/named_roles.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
-	"github.com/brigadecore/brigade/v2/apiserver/internal/system"
 )
 
 // Core-specific, system-level roles...
@@ -11,7 +10,6 @@ import (
 // create Events for all Projects.
 func RoleEventCreator() libAuthz.Role {
 	return libAuthz.Role{
-		Type: system.RoleTypeSystem,
 		Name: "EVENT_CREATOR",
 	}
 }
@@ -20,36 +18,32 @@ func RoleEventCreator() libAuthz.Role {
 // create new Projects.
 func RoleProjectCreator() libAuthz.Role {
 	return libAuthz.Role{
-		Type: system.RoleTypeSystem,
 		Name: "PROJECT_CREATOR",
 	}
 }
 
-// Core-specific, project-level roles...
+// Core-specific, ProjectRoles...
 
-// RoleProjectAdmin returns a project-level Role that enables a principal to
-// manage a Project.
-func RoleProjectAdmin() libAuthz.Role {
-	return libAuthz.Role{
-		Type: RoleTypeProject,
+// RoleProjectAdmin returns a ProjectRole that enables a principal to manage a
+// Project.
+func RoleProjectAdmin() ProjectRole {
+	return ProjectRole{
 		Name: "ADMIN",
 	}
 }
 
-// RoleProjectDeveloper returns a project-level Role that enables a principal to
-// update a Project.
-func RoleProjectDeveloper() libAuthz.Role {
-	return libAuthz.Role{
-		Type: RoleTypeProject,
+// RoleProjectDeveloper returns a ProjectRole that enables a principal to update
+// a Project.
+func RoleProjectDeveloper() ProjectRole {
+	return ProjectRole{
 		Name: "DEVELOPER",
 	}
 }
 
-// RoleProjectUser returns a project-level Role that enables a principal to
-// create and manage Events for a Project.
-func RoleProjectUser() libAuthz.Role {
-	return libAuthz.Role{
-		Type: RoleTypeProject,
+// RoleProjectUser returns a ProjectRole that enables a principal to create and
+// manage Events for a Project.
+func RoleProjectUser() ProjectRole {
+	return ProjectRole{
 		Name: "USER",
 	}
 }
@@ -65,7 +59,6 @@ func RoleProjectUser() libAuthz.Role {
 // Observer component.
 func RoleObserver() libAuthz.Role {
 	return libAuthz.Role{
-		Type: system.RoleTypeSystem,
 		Name: "OBSERVER",
 	}
 }
@@ -75,7 +68,6 @@ func RoleObserver() libAuthz.Role {
 // This Role exists exclusively for use by Brigade's Scheduler component.
 func RoleScheduler() libAuthz.Role {
 	return libAuthz.Role{
-		Type: system.RoleTypeSystem,
 		Name: "SCHEDULER",
 	}
 }
@@ -85,7 +77,6 @@ func RoleScheduler() libAuthz.Role {
 // exclusively for the use of Brigade Workers.
 func RoleWorker() libAuthz.Role {
 	return libAuthz.Role{
-		Type: system.RoleTypeSystem,
 		Name: "WORKER",
 	}
 }

--- a/v2/apiserver/internal/core/project_role_assignments.go
+++ b/v2/apiserver/internal/core/project_role_assignments.go
@@ -9,38 +9,77 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ProjectRoleAssignment represents the assignment of a ProjectRole to a
+// principal such as a User or ServiceAccount.
+type ProjectRoleAssignment struct {
+	// Role assigns a Role to the specified principal.
+	Role ProjectRole `json:"role" bson:"role"`
+	// Principal specifies the principal to whom the Role is assigned.
+	Principal libAuthz.PrincipalReference `json:"principal" bson:"principal"`
+	// ProjectID qualifies the scope of the Role.
+	ProjectID string `json:"projectID,omitempty" bson:"projectID,omitempty"`
+}
+
+// Matches determines if this ProjectRoleAssignment matches the projectID and
+// role arguments.
+func (p ProjectRoleAssignment) Matches(
+	projectID string,
+	role ProjectRole,
+) bool {
+	return p.Role.Name == role.Name &&
+		(p.ProjectID == projectID || p.ProjectID == ProjectRoleScopeGlobal)
+}
+
+// ProjectRoleAssignmentsService is the specialized interface for managing
+// ProjectRoleAssignments. It's decoupled from underlying technology choices
+// (e.g. data store, message bus, etc.) to keep business logic reusable and
+// consistent while the underlying tech stack remains free to change.
+type ProjectRoleAssignmentsService interface {
+	// Grant grants the ProjectRole specified by the ProjectRoleAssignment to the
+	// principal also specified by the ProjectRoleAssignment. If the specified
+	// Project or principal does not exist, implementations must return a
+	// *meta.ErrNotFound error.
+	Grant(context.Context, ProjectRoleAssignment) error
+
+	// Revoke revokes the ProjectRole specified by the ProjectRoleAssignment for
+	// the principal also specified by the ProjectRoleAssignment. If the specified
+	// principal does not exist, implementations must return a *meta.ErrNotFound
+	// error.
+	Revoke(context.Context, ProjectRoleAssignment) error
+}
+
 type projectRoleAssignmentsService struct {
-	authorize            libAuthz.AuthorizeFn
-	projectsStore        ProjectsStore
-	usersStore           authn.UsersStore
-	serviceAccountsStore authn.ServiceAccountsStore
-	roleAssignmentsStore authz.RoleAssignmentsStore
+	projectAuthorize            ProjectAuthorizeFn
+	projectsStore               ProjectsStore
+	usersStore                  authn.UsersStore
+	serviceAccountsStore        authn.ServiceAccountsStore
+	projectRoleAssignmentsStore ProjectRoleAssignmentsStore
 }
 
 // NewProjectRoleAssignmentsService returns a specialized interface for managing
 // project-level RoleAssignments.
 func NewProjectRoleAssignmentsService(
-	authorizeFn libAuthz.AuthorizeFn,
+	projectAuthorize ProjectAuthorizeFn,
 	projectsStore ProjectsStore,
 	usersStore authn.UsersStore,
 	serviceAccountsStore authn.ServiceAccountsStore,
-	roleAssignmentsStore authz.RoleAssignmentsStore,
-) authz.RoleAssignmentsService {
+	projectRoleAssignmentsStore ProjectRoleAssignmentsStore,
+) ProjectRoleAssignmentsService {
 	return &projectRoleAssignmentsService{
-		authorize:            authorizeFn,
-		projectsStore:        projectsStore,
-		usersStore:           usersStore,
-		serviceAccountsStore: serviceAccountsStore,
-		roleAssignmentsStore: roleAssignmentsStore,
+		projectAuthorize:            projectAuthorize,
+		projectsStore:               projectsStore,
+		usersStore:                  usersStore,
+		serviceAccountsStore:        serviceAccountsStore,
+		projectRoleAssignmentsStore: projectRoleAssignmentsStore,
 	}
 }
 
 func (p *projectRoleAssignmentsService) Grant(
 	ctx context.Context,
-	roleAssignment libAuthz.RoleAssignment,
+	projectRoleAssignment ProjectRoleAssignment,
 ) error {
-	projectID := roleAssignment.Scope
-	if err := p.authorize(ctx, RoleProjectAdmin(), projectID); err != nil {
+	projectID := projectRoleAssignment.ProjectID
+	if err := p.projectAuthorize(ctx, projectID, RoleProjectAdmin()); err != nil {
 		return err
 	}
 
@@ -54,30 +93,32 @@ func (p *projectRoleAssignmentsService) Grant(
 		)
 	}
 
-	if roleAssignment.Principal.Type == authz.PrincipalTypeUser {
+	if projectRoleAssignment.Principal.Type == authz.PrincipalTypeUser {
 		// Make sure the User exists
-		user, err := p.usersStore.Get(ctx, roleAssignment.Principal.ID)
+		user, err := p.usersStore.Get(ctx, projectRoleAssignment.Principal.ID)
 		if err != nil {
 			return errors.Wrapf(
 				err,
 				"error retrieving user %q from store",
-				roleAssignment.Principal.ID,
+				projectRoleAssignment.Principal.ID,
 			)
 		}
 		// From an end-user's perspective, User IDs are case insensitive, but when
-		// creating a role assignment, we'd like to respect case. So we DON'T use
-		// the ID from the inbound RoleAssignment-- which may have incorrect case.
-		// Instead we replace it with the ID (with correct case) from the User we
-		// found.
-		roleAssignment.Principal.ID = user.ID
-	} else if roleAssignment.Principal.Type == authz.PrincipalTypeServiceAccount {
+		// creating a ProjectRoleAssignment, we'd like to respect case. So we DON'T
+		// use the ID from the inbound ProjectRoleAssignment-- which may have
+		// incorrect case. Instead we replace it with the ID (with correct case)
+		// from the User we found.
+		projectRoleAssignment.Principal.ID = user.ID
+	} else if projectRoleAssignment.Principal.Type == authz.PrincipalTypeServiceAccount { // nolint: lll
 		// Make sure the ServiceAccount exists
-		if _, err :=
-			p.serviceAccountsStore.Get(ctx, roleAssignment.Principal.ID); err != nil {
+		if _, err := p.serviceAccountsStore.Get(
+			ctx,
+			projectRoleAssignment.Principal.ID,
+		); err != nil {
 			return errors.Wrapf(
 				err,
 				"error retrieving service account %q from store",
-				roleAssignment.Principal.ID,
+				projectRoleAssignment.Principal.ID,
 			)
 		}
 	} else {
@@ -85,14 +126,17 @@ func (p *projectRoleAssignmentsService) Grant(
 	}
 
 	// Give them the Role
-	if err := p.roleAssignmentsStore.Grant(ctx, roleAssignment); err != nil {
+	if err := p.projectRoleAssignmentsStore.Grant(
+		ctx,
+		projectRoleAssignment,
+	); err != nil {
 		return errors.Wrapf(
 			err,
 			"error granting project %q role %q to %s %q in store",
 			projectID,
-			roleAssignment.Role.Name,
-			roleAssignment.Principal.Type,
-			roleAssignment.Principal.ID,
+			projectRoleAssignment.Role.Name,
+			projectRoleAssignment.Principal.Type,
+			projectRoleAssignment.Principal.ID,
 		)
 	}
 
@@ -101,10 +145,10 @@ func (p *projectRoleAssignmentsService) Grant(
 
 func (p *projectRoleAssignmentsService) Revoke(
 	ctx context.Context,
-	roleAssignment libAuthz.RoleAssignment,
+	projectRoleAssignment ProjectRoleAssignment,
 ) error {
-	projectID := roleAssignment.Scope
-	if err := p.authorize(ctx, RoleProjectAdmin(), projectID); err != nil {
+	projectID := projectRoleAssignment.ProjectID
+	if err := p.projectAuthorize(ctx, projectID, RoleProjectAdmin()); err != nil {
 		return err
 	}
 
@@ -118,30 +162,32 @@ func (p *projectRoleAssignmentsService) Revoke(
 		)
 	}
 
-	if roleAssignment.Principal.Type == authz.PrincipalTypeUser {
+	if projectRoleAssignment.Principal.Type == authz.PrincipalTypeUser {
 		// Make sure the User exists
-		user, err := p.usersStore.Get(ctx, roleAssignment.Principal.ID)
+		user, err := p.usersStore.Get(ctx, projectRoleAssignment.Principal.ID)
 		if err != nil {
 			return errors.Wrapf(
 				err,
 				"error retrieving user %q from store",
-				roleAssignment.Principal.ID,
+				projectRoleAssignment.Principal.ID,
 			)
 		}
 		// From an end-user's perspective, User IDs are case insensitive, but when
-		// creating a role assignment, we'd like to respect case. So we DON'T use
-		// the ID from the inbound RoleAssignment-- which may have incorrect case.
-		// Instead we replace it with the ID (with correct case) from the User we
-		// found.
-		roleAssignment.Principal.ID = user.ID
-	} else if roleAssignment.Principal.Type == authz.PrincipalTypeServiceAccount {
+		// creating a ProjectRoleAssignment, we'd like to respect case. So we DON'T
+		// use the ID from the inbound ProjectRoleAssignment-- which may have
+		// incorrect case. Instead we replace it with the ID (with correct case)
+		// from the User we found.
+		projectRoleAssignment.Principal.ID = user.ID
+	} else if projectRoleAssignment.Principal.Type == authz.PrincipalTypeServiceAccount { // nolint: lll
 		// Make sure the ServiceAccount exists
-		if _, err :=
-			p.serviceAccountsStore.Get(ctx, roleAssignment.Principal.ID); err != nil {
+		if _, err := p.serviceAccountsStore.Get(
+			ctx,
+			projectRoleAssignment.Principal.ID,
+		); err != nil {
 			return errors.Wrapf(
 				err,
 				"error retrieving service account %q from store",
-				roleAssignment.Principal.ID,
+				projectRoleAssignment.Principal.ID,
 			)
 		}
 	} else {
@@ -149,15 +195,46 @@ func (p *projectRoleAssignmentsService) Revoke(
 	}
 
 	// Revoke the Role
-	if err := p.roleAssignmentsStore.Revoke(ctx, roleAssignment); err != nil {
+	if err := p.projectRoleAssignmentsStore.Revoke(
+		ctx,
+		projectRoleAssignment,
+	); err != nil {
 		return errors.Wrapf(
 			err,
 			"error revoking project %q role %q for %s %q in store",
 			projectID,
-			roleAssignment.Role.Name,
-			roleAssignment.Principal.Type,
-			roleAssignment.Principal.ID,
+			projectRoleAssignment.Role.Name,
+			projectRoleAssignment.Principal.Type,
+			projectRoleAssignment.Principal.ID,
 		)
 	}
 	return nil
+}
+
+// ProjectRoleAssignmentsStore is an interface for components that implement
+// ProjectRoleAssignment persistence concerns.
+type ProjectRoleAssignmentsStore interface {
+	// Grant the ProjectRole specified by the ProjectRoleAssignment to the
+	// principal specified by the ProjectRoleAssignment.
+	Grant(context.Context, ProjectRoleAssignment) error
+	// Revoke the Project specified by the ProjectRoleAssignment for the principal
+	// specified by the ProjectRoleAssignment.
+	Revoke(context.Context, ProjectRoleAssignment) error
+	// RevokeByProjectID revokes all ProjectRoleAssignments for the specified
+	// Project.
+	RevokeByProjectID(ctx context.Context, projectID string) error
+
+	// Exists returns a bool indicating whether the specified
+	// ProjectRoleAssignment exists within the store. Implementations MUST also
+	// return true if a ProjectRoleAssignment exists in the store that logically
+	// "overlaps" the specified ProjectRoleAssignment. For instance, when seeking
+	// to determine whether a ProjectRoleAssignment exists that endows some
+	// principal P with Role X for Project Y, and such a ProjectRoleAssignment
+	// does not exist, but one does that endows that principal P with Role X
+	// having GLOBAL PROJECT SCOPE (*), then true MUST be returned.
+	// Implementations MUST also return an error if and only if anything goes
+	// wrong. i.e. Errors are never used to communicate that the specified
+	// ProjectRoleAssignment does not exist in the store. They are only used to
+	// convey an actual failure.
+	Exists(context.Context, ProjectRoleAssignment) (bool, error)
 }

--- a/v2/apiserver/internal/core/project_roles.go
+++ b/v2/apiserver/internal/core/project_roles.go
@@ -1,0 +1,12 @@
+package core
+
+import libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
+
+// ProjectRoleScopeGlobal represents an unbounded project scope.
+const ProjectRoleScopeGlobal = "*"
+
+// ProjectRole represents a set of project-level permissions.
+type ProjectRole struct {
+	// Name is the name of a Role and has domain-specific meaning.
+	Name libAuthz.RoleName `json:"name,omitempty" bson:"name,omitempty"`
+}

--- a/v2/apiserver/internal/core/projects_test.go
+++ b/v2/apiserver/internal/core/projects_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/brigadecore/brigade/v2/apiserver/internal/authz"
 	libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
 	"github.com/brigadecore/brigade/v2/apiserver/internal/meta"
 	metaTesting "github.com/brigadecore/brigade/v2/apiserver/internal/meta/testing" // nolint: lll
@@ -24,23 +23,25 @@ func TestNewProjectsService(t *testing.T) {
 	projectsStore := &mockProjectsStore{}
 	eventsStore := &mockEventsStore{}
 	logsStore := &mockLogsStore{}
-	roleAssignmentsStore := &authz.MockRoleAssignmentsStore{}
+	projectRoleAssignmentsStore := &mockProjectRoleAssignmentsStore{}
 	substrate := &mockSubstrate{}
 	svc := NewProjectsService(
 		libAuthz.AlwaysAuthorize,
+		alwaysProjectAuthorize,
 		projectsStore,
 		eventsStore,
 		logsStore,
-		roleAssignmentsStore,
+		projectRoleAssignmentsStore,
 		substrate,
 	)
 	require.NotNil(t, svc.(*projectsService).authorize)
+	require.NotNil(t, svc.(*projectsService).projectAuthorize)
 	require.Same(t, projectsStore, svc.(*projectsService).projectsStore)
 	require.Same(t, eventsStore, svc.(*projectsService).eventsStore)
 	require.Same(
 		t,
-		roleAssignmentsStore,
-		svc.(*projectsService).roleAssignmentsStore,
+		projectRoleAssignmentsStore,
+		svc.(*projectsService).projectRoleAssignmentsStore,
 	)
 	require.Same(t, substrate, svc.(*projectsService).substrate)
 }
@@ -256,7 +257,7 @@ func TestProjectServiceUpdate(t *testing.T) {
 		{
 			name: "unauthorized",
 			service: &projectsService{
-				authorize: libAuthz.NeverAuthorize,
+				projectAuthorize: neverProjectAuthorize,
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
@@ -266,7 +267,7 @@ func TestProjectServiceUpdate(t *testing.T) {
 		{
 			name: "error updating project in store",
 			service: &projectsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					UpdateFn: func(context.Context, Project) error {
 						return errors.New("store error")
@@ -282,7 +283,7 @@ func TestProjectServiceUpdate(t *testing.T) {
 		{
 			name: "success",
 			service: &projectsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					UpdateFn: func(context.Context, Project) error {
 						return nil
@@ -311,7 +312,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "unauthorized",
 			service: &projectsService{
-				authorize: libAuthz.NeverAuthorize,
+				projectAuthorize: neverProjectAuthorize,
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
@@ -321,7 +322,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "error retrieving project from store",
 			service: &projectsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, errors.New("store error")
@@ -337,7 +338,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "error deleting events associated with project",
 			service: &projectsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -369,7 +370,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "error deleting project logs",
 			service: &projectsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -394,8 +395,8 @@ func TestProjectServiceDelete(t *testing.T) {
 						return errors.New("error deleting project logs")
 					},
 				},
-				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, libAuthz.RoleAssignment) error {
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					RevokeManyFn: func(context.Context, string) error {
 						return nil
 					},
 				},
@@ -413,7 +414,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "error deleting role assignments associated with project",
 			service: &projectsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -438,8 +439,8 @@ func TestProjectServiceDelete(t *testing.T) {
 						return nil
 					},
 				},
-				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, libAuthz.RoleAssignment) error {
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					RevokeManyFn: func(context.Context, string) error {
 						return errors.New("something went wrong")
 					},
 				},
@@ -457,7 +458,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "error deleting project from store",
 			service: &projectsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -482,8 +483,8 @@ func TestProjectServiceDelete(t *testing.T) {
 						return nil
 					},
 				},
-				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, libAuthz.RoleAssignment) error {
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					RevokeManyFn: func(context.Context, string) error {
 						return nil
 					},
 				},
@@ -497,7 +498,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "error deleting project from substrate",
 			service: &projectsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -522,8 +523,8 @@ func TestProjectServiceDelete(t *testing.T) {
 						return nil
 					},
 				},
-				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, libAuthz.RoleAssignment) error {
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					RevokeManyFn: func(context.Context, string) error {
 						return nil
 					},
 				},
@@ -542,7 +543,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "success",
 			service: &projectsService{
-				authorize: libAuthz.AlwaysAuthorize,
+				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, nil
@@ -567,8 +568,8 @@ func TestProjectServiceDelete(t *testing.T) {
 						return nil
 					},
 				},
-				roleAssignmentsStore: &authz.MockRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, libAuthz.RoleAssignment) error {
+				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
+					RevokeManyFn: func(context.Context, string) error {
 						return nil
 					},
 				},

--- a/v2/apiserver/internal/core/roles.go
+++ b/v2/apiserver/internal/core/roles.go
@@ -1,6 +1,0 @@
-package core
-
-import libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
-
-// RoleTypeProject represents a project-level Role.
-const RoleTypeProject libAuthz.RoleType = "PROJECT"

--- a/v2/apiserver/internal/core/secrets.go
+++ b/v2/apiserver/internal/core/secrets.go
@@ -109,21 +109,24 @@ type SecretsService interface {
 }
 
 type secretsService struct {
-	authorize     libAuthz.AuthorizeFn
-	projectsStore ProjectsStore
-	secretsStore  SecretsStore
+	authorize        libAuthz.AuthorizeFn
+	projectAuthorize ProjectAuthorizeFn
+	projectsStore    ProjectsStore
+	secretsStore     SecretsStore
 }
 
 // NewSecretsService returns a specialized interface for managing Secrets.
 func NewSecretsService(
 	authorizeFn libAuthz.AuthorizeFn,
+	projectAuthorize ProjectAuthorizeFn,
 	projectsStore ProjectsStore,
 	secretsStore SecretsStore,
 ) SecretsService {
 	return &secretsService{
-		authorize:     authorizeFn,
-		projectsStore: projectsStore,
-		secretsStore:  secretsStore,
+		authorize:        authorizeFn,
+		projectAuthorize: projectAuthorize,
+		projectsStore:    projectsStore,
+		secretsStore:     secretsStore,
 	}
 }
 
@@ -164,7 +167,7 @@ func (s *secretsService) Set(
 	projectID string,
 	secret Secret,
 ) error {
-	if err := s.authorize(ctx, RoleProjectAdmin(), projectID); err != nil {
+	if err := s.projectAuthorize(ctx, projectID, RoleProjectAdmin()); err != nil {
 		return err
 	}
 
@@ -191,7 +194,7 @@ func (s *secretsService) Unset(
 	projectID string,
 	key string,
 ) error {
-	if err := s.authorize(ctx, RoleProjectAdmin(), projectID); err != nil {
+	if err := s.projectAuthorize(ctx, projectID, RoleProjectAdmin()); err != nil {
 		return err
 	}
 

--- a/v2/apiserver/internal/lib/authz/role_assignments.go
+++ b/v2/apiserver/internal/lib/authz/role_assignments.go
@@ -15,7 +15,6 @@ type RoleAssignment struct {
 // Matches determines if this RoleAssignment matches the role and scope
 // arguments.
 func (r RoleAssignment) Matches(role Role, scope string) bool {
-	return r.Role.Type == role.Type &&
-		r.Role.Name == role.Name &&
+	return r.Role.Name == role.Name &&
 		(r.Scope == scope || r.Scope == RoleScopeGlobal)
 }

--- a/v2/apiserver/internal/lib/authz/role_assignments_test.go
+++ b/v2/apiserver/internal/lib/authz/role_assignments_test.go
@@ -15,32 +15,14 @@ func TestMatches(t *testing.T) {
 		matches        bool
 	}{
 		{
-			name: "types do not match",
-			roleAssignment: RoleAssignment{
-				Role: Role{
-					Type: "foo",
-					Name: "foo",
-				},
-				Scope: "foo",
-			},
-			role: Role{
-				Type: "bar",
-				Name: "foo",
-			},
-			scope:   "foo",
-			matches: false,
-		},
-		{
 			name: "names do not match",
 			roleAssignment: RoleAssignment{
 				Role: Role{
-					Type: "foo",
 					Name: "foo",
 				},
 				Scope: "foo",
 			},
 			role: Role{
-				Type: "foo",
 				Name: "bar",
 			},
 			scope:   "foo",
@@ -50,13 +32,11 @@ func TestMatches(t *testing.T) {
 			name: "scopes do not match",
 			roleAssignment: RoleAssignment{
 				Role: Role{
-					Type: "foo",
 					Name: "foo",
 				},
 				Scope: "foo",
 			},
 			role: Role{
-				Type: "foo",
 				Name: "foo",
 			},
 			scope:   "bar",
@@ -66,13 +46,11 @@ func TestMatches(t *testing.T) {
 			name: "scopes are an exact match",
 			roleAssignment: RoleAssignment{
 				Role: Role{
-					Type: "foo",
 					Name: "foo",
 				},
 				Scope: "foo",
 			},
 			role: Role{
-				Type: "foo",
 				Name: "foo",
 			},
 			scope:   "foo",
@@ -82,13 +60,11 @@ func TestMatches(t *testing.T) {
 			name: "a global scope matches b scope",
 			roleAssignment: RoleAssignment{
 				Role: Role{
-					Type: "foo",
 					Name: "foo",
 				},
 				Scope: RoleScopeGlobal,
 			},
 			role: Role{
-				Type: "foo",
 				Name: "foo",
 			},
 			scope:   "foo",

--- a/v2/apiserver/internal/lib/authz/roles.go
+++ b/v2/apiserver/internal/lib/authz/roles.go
@@ -1,9 +1,5 @@
 package authz
 
-// RoleType is a type whose values can be used to disambiguate one type of Role
-// from another.
-type RoleType string
-
 // RoleName is a type whose value maps to a well-defined Brigade Role.
 type RoleName string
 
@@ -12,9 +8,6 @@ const RoleScopeGlobal = "*"
 
 // Role represents a set of permissions.
 type Role struct {
-	// Type indicates the Role's type, for instance, system-level or
-	// project-level.
-	Type RoleType `json:"type,omitempty" bson:"type,omitempty"`
 	// Name is the name of a Role and has domain-specific meaning.
 	Name RoleName `json:"name,omitempty" bson:"name,omitempty"`
 }

--- a/v2/apiserver/internal/system/authn/named_principals.go
+++ b/v2/apiserver/internal/system/authn/named_principals.go
@@ -27,18 +27,23 @@ func (r *rootPrincipal) RoleAssignments() []libAuthz.RoleAssignment {
 			Role:  core.RoleEventCreator(),
 			Scope: libAuthz.RoleScopeGlobal,
 		},
-		{
-			Role:  core.RoleProjectAdmin(),
-			Scope: libAuthz.RoleScopeGlobal,
-		},
 		{Role: core.RoleProjectCreator()},
+	}
+}
+
+func (r *rootPrincipal) ProjectRoleAssignments() []core.ProjectRoleAssignment {
+	return []core.ProjectRoleAssignment{
 		{
-			Role:  core.RoleProjectDeveloper(),
-			Scope: libAuthz.RoleScopeGlobal,
+			ProjectID: core.ProjectRoleScopeGlobal,
+			Role:      core.RoleProjectAdmin(),
 		},
 		{
-			Role:  core.RoleProjectUser(),
-			Scope: libAuthz.RoleScopeGlobal,
+			ProjectID: core.ProjectRoleScopeGlobal,
+			Role:      core.RoleProjectDeveloper(),
+		},
+		{
+			ProjectID: core.ProjectRoleScopeGlobal,
+			Role:      core.RoleProjectUser(),
 		},
 	}
 }

--- a/v2/apiserver/internal/system/named_roles.go
+++ b/v2/apiserver/internal/system/named_roles.go
@@ -7,7 +7,6 @@ import libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
 // ServiceAccounts.
 func RoleAdmin() libAuthz.Role {
 	return libAuthz.Role{
-		Type: RoleTypeSystem,
 		Name: "ADMIN",
 	}
 }
@@ -15,7 +14,6 @@ func RoleAdmin() libAuthz.Role {
 // RoleReader returns a system-level Role that enables global read access.
 func RoleReader() libAuthz.Role {
 	return libAuthz.Role{
-		Type: RoleTypeSystem,
 		Name: "READER",
 	}
 }

--- a/v2/apiserver/internal/system/roles.go
+++ b/v2/apiserver/internal/system/roles.go
@@ -1,6 +1,0 @@
-package system
-
-import libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
-
-// RoleTypeSystem represents a system-level Role.
-const RoleTypeSystem libAuthz.RoleType = "SYSTEM"

--- a/v2/apiserver/schemas/project-role-assignment.json
+++ b/v2/apiserver/schemas/project-role-assignment.json
@@ -7,7 +7,7 @@
 		"kind": {
 			"type": "string",
 			"description": "The type of object represented by the document",
-			"enum": ["RoleAssignment"]
+			"enum": ["ProjectRoleAssignment"]
 		}
 
 	},
@@ -28,14 +28,9 @@
 		},
 		"role": {
 			"type": "object",
-			"required": ["type", "name", "scope"],
+			"required": ["name", "projectID"],
 			"additionalProperties": false,
 			"properties": {
-				"type": {
-					"type": "string",
-					"description": "The type of role being assigned-- must be PROJECT",
-					"enum": ["PROJECT"]
-				},
 				"name": {
 					"type": "string",
 					"description": "A role name",
@@ -45,7 +40,7 @@
 						"USER"
 					]
 				},
-				"scope": {
+				"projectID": {
 					"type": "string",
 					"description": "The project this role should be scoped to",
 					"pattern": "^[a-z][a-z\\d-]*[a-z\\d]$",

--- a/v2/apiserver/schemas/role-assignment.json
+++ b/v2/apiserver/schemas/role-assignment.json
@@ -12,14 +12,9 @@
 
 		"role": {
 			"type": "object",
-			"required": ["type", "name"],
+			"required": ["name"],
 			"additionalProperties": false,
 			"properties": {
-				"type": {
-					"type": "string",
-					"description": "The type of role being assigned-- must be SYSTEM",
-					"enum": ["SYSTEM"]
-				},
 				"name": {
 					"type": "string",
 					"description": "A role name",
@@ -34,14 +29,9 @@
 
 		"eventCreatorRole": {
 			"type": "object",
-			"required": ["type", "name"],
+			"required": ["name"],
 			"additionalProperties": false,
 			"properties": {
-				"type": {
-					"type": "string",
-					"description": "The type of role being assigned-- must be SYSTEM",
-					"enum": ["SYSTEM"]
-				},
 				"name": {
 					"type": "string",
 					"description": "A role name",

--- a/v2/cli/project_role_commands.go
+++ b/v2/cli/project_role_commands.go
@@ -156,28 +156,27 @@ func grantProjectRole(
 			return err
 		}
 
-		roleAssignment := libAuthz.RoleAssignment{
-			Role: libAuthz.Role{
-				Type: core.RoleTypeProject,
+		projectRoleAssignment := core.ProjectRoleAssignment{
+			ProjectID: projectID,
+			Role: core.ProjectRole{
 				Name: roleName,
 			},
-			Scope: projectID,
 		}
 
-		roleAssignment.Principal.Type = authz.PrincipalTypeUser
-		for _, roleAssignment.Principal.ID = range userIDs {
+		projectRoleAssignment.Principal.Type = authz.PrincipalTypeUser
+		for _, projectRoleAssignment.Principal.ID = range userIDs {
 			if err = client.Core().Projects().Authz().RoleAssignments().Grant(
 				c.Context,
-				roleAssignment,
+				projectRoleAssignment,
 			); err != nil {
 				return err
 			}
 		}
-		roleAssignment.Principal.Type = authz.PrincipalTypeServiceAccount
-		for _, roleAssignment.Principal.ID = range serviceAccountIDs {
+		projectRoleAssignment.Principal.Type = authz.PrincipalTypeServiceAccount
+		for _, projectRoleAssignment.Principal.ID = range serviceAccountIDs {
 			if err = client.Core().Projects().Authz().RoleAssignments().Grant(
 				c.Context,
-				roleAssignment,
+				projectRoleAssignment,
 			); err != nil {
 				return err
 			}
@@ -206,28 +205,27 @@ func revokeProjectRole(
 			return err
 		}
 
-		roleAssignment := libAuthz.RoleAssignment{
-			Role: libAuthz.Role{
-				Type: core.RoleTypeProject,
+		projectRoleAssignment := core.ProjectRoleAssignment{
+			ProjectID: projectID,
+			Role: core.ProjectRole{
 				Name: roleName,
 			},
-			Scope: projectID,
 		}
 
-		roleAssignment.Principal.Type = authz.PrincipalTypeUser
-		for _, roleAssignment.Principal.ID = range userIDs {
+		projectRoleAssignment.Principal.Type = authz.PrincipalTypeUser
+		for _, projectRoleAssignment.Principal.ID = range userIDs {
 			if err = client.Core().Projects().Authz().RoleAssignments().Revoke(
 				c.Context,
-				roleAssignment,
+				projectRoleAssignment,
 			); err != nil {
 				return err
 			}
 		}
-		roleAssignment.Principal.Type = authz.PrincipalTypeServiceAccount
-		for _, roleAssignment.Principal.ID = range serviceAccountIDs {
+		projectRoleAssignment.Principal.Type = authz.PrincipalTypeServiceAccount
+		for _, projectRoleAssignment.Principal.ID = range serviceAccountIDs {
 			if err = client.Core().Projects().Authz().RoleAssignments().Revoke(
 				c.Context,
-				roleAssignment,
+				projectRoleAssignment,
 			); err != nil {
 				return err
 			}

--- a/v2/cli/role_commands.go
+++ b/v2/cli/role_commands.go
@@ -165,7 +165,6 @@ func grantSystemRole(roleName libAuthz.RoleName) func(c *cli.Context) error {
 
 		roleAssignment := libAuthz.RoleAssignment{
 			Role: libAuthz.Role{
-				Type: system.RoleTypeSystem,
 				Name: roleName,
 			},
 		}
@@ -218,7 +217,6 @@ func revokeSystemRole(
 
 		roleAssignment := libAuthz.RoleAssignment{
 			Role: libAuthz.Role{
-				Type: system.RoleTypeSystem,
 				Name: roleName,
 			},
 		}


### PR DESCRIPTION
Related to #1257 

Builds on #1356, #1357, and #1358 which must be merged first.

As I continue working toward solving #1257, I've been finding that the differences between system-level and project-level role assignments may actually outweigh their similarities, which are more superficial.

This un-DRYs some stuff because I'm finding it easier to keep everything straight if we just treat these like two separate things. As work on #1257 continues, you'll see the code unDRY code start to diverge and move in different directions.