### PR TITLE
fix(logger): fix Windows logger agent build

### DIFF
--- a/v2/logger/Dockerfile.winserv-2019
+++ b/v2/logger/Dockerfile.winserv-2019
@@ -19,7 +19,7 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'"
 RUN choco install -y msys2 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
 
-RUN ridk install 2 3 \
+RUN ridk install 3 \
   && echo gem: --no-document >> C:\ProgramData\gemrc \
   && gem install cool.io -v 1.5.4 --platform ruby \
   && gem install oj -v 3.3.10 \


### PR DESCRIPTION
**What this PR does / why we need it**:

- Removes option 2 (pacman update) from the `ridk install` command, which is currently failing (see https://github.com/brigadecore/brigade/issues/1345).  (The issue appears to be fixed upstream in ridk, but has yet to be released.)

Fixes https://github.com/brigadecore/brigade/issues/1345

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
