### PR TITLE
brigadier local run fixes

### DIFF
--- a/v2/brigadier/src/events.ts
+++ b/v2/brigadier/src/events.ts
@@ -64,20 +64,24 @@ export class EventRegistry {
       let source: string
       let type: string
       if (process.env.BRIGADE_EVENT) {
-        const eventTokens = process.env.BRIGADE_EVENT.split(":")
-        if (eventTokens.length != 2) {
+        let eventTokens: string[] = []
+        const match = process.env.BRIGADE_EVENT.match(/^(.+?):(.+)$/)
+        if (match) {
+          eventTokens = Array.from(match)
+        }
+        if (eventTokens.length != 3) {
           throw new Error(
             `${process.env.BRIGADE_EVENT} is not a valid event of the form <source>:<type>`
           )
         }
-        source = eventTokens[0]
-        type = eventTokens[1]
-        console.log(`Using specified dummy event type ${source}:${type}`)
+        source = eventTokens[1]
+        type = eventTokens[2]
+        console.log(`Using specified dummy event with source "${source}" and type "${type}"`)
       } else {
         console.log("No dummy event type provided")
-        source = "github.com/brigadecore/brigade/cli"
+        source = "brigade.sh/cli"
         type = "exec"
-        console.log(`Using default dummy event type ${source}:${type}`)
+        console.log(`Using default dummy event with source "${source}" and type "${type}"`)
       }
       event = {
         id: this.newUUID(),


### PR DESCRIPTION
This PR corrects two issues related to running a brigadier-based script locally in Node.

1. The default event source is currently `github.com/brigadecore/brigade/cli`, but we stopped using that value to represent the source events emitted from the command line quite some time ago, in favor of `brigade.sh/cli`. This PR corrects that.

1. We've been parsing both event source and type from the value of the `BRIGADE_EVENT` by splitting on `:`. This doesn't account for event types that contain colons. (That's allowed.) To fix this, we should split only on the first `:`. Curiously, JS/TS doesn't have an easy way to split a string on only the first n instances of the delimiter, so this PR uses a regex to do the split instead.