### PR TITLE
simplify role type

### DIFF
--- a/sdk/v2/authz/role_assignments.go
+++ b/sdk/v2/authz/role_assignments.go
@@ -64,7 +64,7 @@ func (r *roleAssignmentsClient) Revoke(
 	roleAssignment libAuthz.RoleAssignment,
 ) error {
 	queryParams := map[string]string{
-		"role":          string(roleAssignment.Role.Name),
+		"role":          string(roleAssignment.Role),
 		"principalType": string(roleAssignment.Principal.Type),
 		"principalID":   roleAssignment.Principal.ID,
 	}

--- a/sdk/v2/authz/role_assignments_test.go
+++ b/sdk/v2/authz/role_assignments_test.go
@@ -34,9 +34,7 @@ func TestNewRoleAssignmentsClient(t *testing.T) {
 
 func TestRoleAssignmentsClientGrant(t *testing.T) {
 	testRoleAssignment := libAuthz.RoleAssignment{
-		Role: libAuthz.Role{
-			Name: libAuthz.RoleName("ceo"),
-		},
+		Role: libAuthz.Role("ceo"),
 		Principal: libAuthz.PrincipalReference{
 			Type: PrincipalTypeUser,
 			ID:   "tony@starkindustries.com",
@@ -66,9 +64,7 @@ func TestRoleAssignmentsClientGrant(t *testing.T) {
 
 func TestRoleAssignmentsClientRevoke(t *testing.T) {
 	testRoleAssignment := libAuthz.RoleAssignment{
-		Role: libAuthz.Role{
-			Name: libAuthz.RoleName("ceo"),
-		},
+		Role: libAuthz.Role("ceo"),
 		Principal: libAuthz.PrincipalReference{
 			Type: PrincipalTypeUser,
 			ID:   "tony@starkindustries.com",
@@ -81,8 +77,8 @@ func TestRoleAssignmentsClientRevoke(t *testing.T) {
 				require.Equal(t, "/v2/role-assignments", r.URL.Path)
 				require.Equal(
 					t,
-					testRoleAssignment.Role.Name,
-					libAuthz.RoleName(r.URL.Query().Get("role")),
+					testRoleAssignment.Role,
+					libAuthz.Role(r.URL.Query().Get("role")),
 				)
 				require.Equal(
 					t,

--- a/sdk/v2/core/named_roles.go
+++ b/sdk/v2/core/named_roles.go
@@ -7,72 +7,28 @@ import (
 const (
 	// Core-specific, system-level roles...
 
-	// RoleNameEventCreator is the name of a system-level Role that enables
-	// principals to create Events for all Projects-- provided the Events have a
-	// specific value in the Source field. This is useful for Event gateways,
-	// which should be able to create Events for all Projects, but should NOT be
-	// able to impersonate other gateways.
-	RoleNameEventCreator libAuthz.RoleName = "EVENT_CREATOR"
+	// RoleEventCreator is the name of a system-level Role that enables principals
+	// to create Events for all Projects-- provided the Events have a specific
+	// value in the Source field. This is useful for Event gateways, which should
+	// be able to create Events for all Projects, but should NOT be able to
+	// impersonate other gateways.
+	RoleEventCreator libAuthz.Role = "EVENT_CREATOR"
 
-	// RoleNameProjectCreator is the name of a system-level Role that enables
+	// RoleProjectCreator is the name of a system-level Role that enables
 	// principals to create new Projects.
-	RoleNameProjectCreator libAuthz.RoleName = "PROJECT_CREATOR"
+	RoleProjectCreator libAuthz.Role = "PROJECT_CREATOR"
 
 	// Core-specific, project-level roles...
 
-	// RoleNameProjectAdmin is the name of a project-level Role that enables a
+	// RoleProjectAdmin is the name of a project-level Role that enables a
 	// principal to manage a specific Project.
-	RoleNameProjectAdmin libAuthz.RoleName = "ADMIN"
+	RoleProjectAdmin libAuthz.Role = "PROJECT_ADMIN"
 
-	// RoleNameProjectDeveloper is the name of a project-level Role that enables a
+	// RoleProjectDeveloper is the name of a project-level Role that enables a
 	// principal to update a specific project.
-	RoleNameProjectDeveloper libAuthz.RoleName = "DEVELOPER"
+	RoleProjectDeveloper libAuthz.Role = "PROJECT_DEVELOPER"
 
-	// RoleNameProjectUser is the name of project-level Role that enables a
-	// principal to create and manage Events for a specific Project.
-	RoleNameProjectUser libAuthz.RoleName = "USER"
+	// RoleProjectUser is the name of project-level Role that enables a principal
+	// to create and manage Events for a specific Project.
+	RoleProjectUser libAuthz.Role = "PROJECT_USER"
 )
-
-// Core-specific, system-level roles...
-
-// RoleEventCreator returns a system-level Role that enables principals to
-// create Events for all Projects.
-func RoleEventCreator() libAuthz.Role {
-	return libAuthz.Role{
-		Name: RoleNameEventCreator,
-	}
-}
-
-// RoleProjectCreator returns a system-level Role that enables principals to
-// create new Projects.
-func RoleProjectCreator() libAuthz.Role {
-	return libAuthz.Role{
-		Name: RoleNameProjectCreator,
-	}
-}
-
-// Core-specific, project-level roles...
-
-// RoleProjectAdmin returns a ProjectRole that enables a principal to manage a
-// Project.
-func RoleProjectAdmin() ProjectRole {
-	return ProjectRole{
-		Name: RoleNameProjectAdmin,
-	}
-}
-
-// RoleProjectDeveloper returns a ProjectRole that enables a principal to update
-// a Project.
-func RoleProjectDeveloper() ProjectRole {
-	return ProjectRole{
-		Name: RoleNameProjectDeveloper,
-	}
-}
-
-// RoleProjectUser returns a ProjectRole that enables a principal to create and
-// manage Events for a Project.
-func RoleProjectUser() ProjectRole {
-	return ProjectRole{
-		Name: RoleNameProjectUser,
-	}
-}

--- a/sdk/v2/core/project_role_assignments.go
+++ b/sdk/v2/core/project_role_assignments.go
@@ -14,12 +14,12 @@ import (
 // ProjectRoleAssignment represents the assignment of a ProjectRole to a
 // principal such as a User or ServiceAccount.
 type ProjectRoleAssignment struct {
-	// Role assigns a Role to the specified principal.
-	Role ProjectRole `json:"role"`
-	// Principal specifies the principal to whom the Role is assigned.
-	Principal libAuthz.PrincipalReference `json:"principal"`
 	// ProjectID qualifies the scope of the Role.
 	ProjectID string `json:"projectID,omitempty"`
+	// Role assigns a Role to the specified principal.
+	Role libAuthz.Role `json:"role"`
+	// Principal specifies the principal to whom the Role is assigned.
+	Principal libAuthz.PrincipalReference `json:"principal"`
 }
 
 // MarshalJSON amends ProjectRoleAssignment instances with type metadata so that
@@ -87,7 +87,7 @@ func (p *projectRoleAssignmentsClient) Revoke(
 	projectRoleAssignment ProjectRoleAssignment,
 ) error {
 	queryParams := map[string]string{
-		"role":          string(projectRoleAssignment.Role.Name),
+		"role":          string(projectRoleAssignment.Role),
 		"projectID":     projectRoleAssignment.ProjectID,
 		"principalType": string(projectRoleAssignment.Principal.Type),
 		"principalID":   projectRoleAssignment.Principal.ID,

--- a/sdk/v2/core/project_roles.go
+++ b/sdk/v2/core/project_roles.go
@@ -1,12 +1,4 @@
 package core
 
-import libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
-
 // ProjectRoleScopeGlobal represents an unbounded project scope.
 const ProjectRoleScopeGlobal = "*"
-
-// ProjectRole represents a set of project-level permissions.
-type ProjectRole struct {
-	// Name is the name of a ProjectRole and has domain-specific meaning.
-	Name libAuthz.RoleName `json:"name,omitempty"`
-}

--- a/sdk/v2/core/project_roles_assignments_test.go
+++ b/sdk/v2/core/project_roles_assignments_test.go
@@ -29,9 +29,7 @@ func TestNewProjectRoleAssignmentsClient(t *testing.T) {
 
 func TestProjectRoleAssignmentsClientGrant(t *testing.T) {
 	testProjectRoleAssignment := ProjectRoleAssignment{
-		Role: ProjectRole{
-			Name: libAuthz.RoleName("ceo"),
-		},
+		Role:      libAuthz.Role("ceo"),
 		ProjectID: "bluebook",
 		Principal: libAuthz.PrincipalReference{
 			Type: authz.PrincipalTypeUser,
@@ -66,9 +64,7 @@ func TestProjectRoleAssignmentsClientGrant(t *testing.T) {
 
 func TestProjectRoleAssignmentsClientRevoke(t *testing.T) {
 	testProjectRoleAssignment := ProjectRoleAssignment{
-		Role: ProjectRole{
-			Name: libAuthz.RoleName("ceo"),
-		},
+		Role:      libAuthz.Role("ceo"),
 		ProjectID: "bluebook",
 		Principal: libAuthz.PrincipalReference{
 			Type: authz.PrincipalTypeUser,
@@ -82,8 +78,8 @@ func TestProjectRoleAssignmentsClientRevoke(t *testing.T) {
 				require.Equal(t, "/v2/project-role-assignments", r.URL.Path)
 				require.Equal(
 					t,
-					testProjectRoleAssignment.Role.Name,
-					libAuthz.RoleName(r.URL.Query().Get("role")),
+					testProjectRoleAssignment.Role,
+					libAuthz.Role(r.URL.Query().Get("role")),
 				)
 				require.Equal(
 					t,

--- a/sdk/v2/lib/authz/role_assignments.go
+++ b/sdk/v2/lib/authz/role_assignments.go
@@ -14,7 +14,7 @@ type RoleAssignment struct {
 	// Principal specifies the principal to whom the Role is assigned.
 	Principal PrincipalReference `json:"principal"`
 	// Scope qualifies the scope of the Role. The value is opaque and has meaning
-	// only in relation to a specific RoleName.
+	// only in relation to a specific Role.
 	Scope string `json:"scope,omitempty"`
 }
 

--- a/sdk/v2/lib/authz/roles.go
+++ b/sdk/v2/lib/authz/roles.go
@@ -1,14 +1,7 @@
 package authz
 
-// RoleName is a type whose value maps to a well-defined Brigade Role.
-type RoleName string
+// Role is a type whose value maps to a well-defined Brigade Role.
+type Role string
 
 // RoleScopeGlobal represents an unbounded scope.
 const RoleScopeGlobal = "*"
-
-// Role represents a set of permissions, with domain-specific meaning, held by a
-// principal, such as a User or ServiceAccount via a RoleAssignment.
-type Role struct {
-	// Name is the name of a Role and has domain-specific meaning.
-	Name RoleName `json:"name,omitempty"`
-}

--- a/sdk/v2/system/named_roles.go
+++ b/sdk/v2/system/named_roles.go
@@ -3,28 +3,12 @@ package system
 import libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
 
 const (
-	// RoleNameAdmin is the name of a system-level Role that enables principals to
+	// RoleAdmin is the name of a system-level Role that enables principals to
 	// manage Users, ServiceAccounts, and system-level permissions for Users and
 	// ServiceAccounts.
-	RoleNameAdmin libAuthz.RoleName = "ADMIN"
+	RoleAdmin libAuthz.Role = "ADMIN"
 
-	// RoleNameReader is the name of a system-level Role that enables global read
+	// RoleReader is the name of a system-level Role that enables global read
 	// access.
-	RoleNameReader libAuthz.RoleName = "READER"
+	RoleReader libAuthz.Role = "READER"
 )
-
-// RoleAdmin returns a system-level Role that enables principals to manage
-// Users, ServiceAccounts, and system-level permissions for Users and
-// ServiceAccounts.
-func RoleAdmin() libAuthz.Role {
-	return libAuthz.Role{
-		Name: RoleNameAdmin,
-	}
-}
-
-// RoleReader returns a system-level Role that enables global read access.
-func RoleReader() libAuthz.Role {
-	return libAuthz.Role{
-		Name: RoleNameReader,
-	}
-}

--- a/v2/apiserver/internal/authn/service_accounts.go
+++ b/v2/apiserver/internal/authn/service_accounts.go
@@ -126,7 +126,7 @@ func (s *serviceAccountsService) Create(
 ) (Token, error) {
 	token := Token{}
 
-	if err := s.authorize(ctx, system.RoleAdmin(), ""); err != nil {
+	if err := s.authorize(ctx, system.RoleAdmin, ""); err != nil {
 		return token, err
 	}
 
@@ -148,7 +148,7 @@ func (s *serviceAccountsService) List(
 	ctx context.Context,
 	opts meta.ListOptions,
 ) (ServiceAccountList, error) {
-	if err := s.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := s.authorize(ctx, system.RoleReader, ""); err != nil {
 		return ServiceAccountList{}, err
 	}
 
@@ -167,7 +167,7 @@ func (s *serviceAccountsService) Get(
 	ctx context.Context,
 	id string,
 ) (ServiceAccount, error) {
-	if err := s.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := s.authorize(ctx, system.RoleReader, ""); err != nil {
 		return ServiceAccount{}, err
 	}
 
@@ -203,7 +203,7 @@ func (s *serviceAccountsService) GetByToken(
 }
 
 func (s *serviceAccountsService) Lock(ctx context.Context, id string) error {
-	if err := s.authorize(ctx, system.RoleAdmin(), ""); err != nil {
+	if err := s.authorize(ctx, system.RoleAdmin, ""); err != nil {
 		return err
 	}
 
@@ -221,7 +221,7 @@ func (s *serviceAccountsService) Unlock(
 	ctx context.Context,
 	id string,
 ) (Token, error) {
-	if err := s.authorize(ctx, system.RoleAdmin(), ""); err != nil {
+	if err := s.authorize(ctx, system.RoleAdmin, ""); err != nil {
 		return Token{}, err
 	}
 

--- a/v2/apiserver/internal/authn/users.go
+++ b/v2/apiserver/internal/authn/users.go
@@ -109,7 +109,7 @@ func (u *usersService) List(
 	ctx context.Context,
 	opts meta.ListOptions,
 ) (UserList, error) {
-	if err := u.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := u.authorize(ctx, system.RoleReader, ""); err != nil {
 		return UserList{}, err
 	}
 
@@ -124,7 +124,7 @@ func (u *usersService) List(
 }
 
 func (u *usersService) Get(ctx context.Context, id string) (User, error) {
-	if err := u.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := u.authorize(ctx, system.RoleReader, ""); err != nil {
 		return User{}, err
 	}
 
@@ -140,7 +140,7 @@ func (u *usersService) Get(ctx context.Context, id string) (User, error) {
 }
 
 func (u *usersService) Lock(ctx context.Context, id string) error {
-	if err := u.authorize(ctx, system.RoleAdmin(), ""); err != nil {
+	if err := u.authorize(ctx, system.RoleAdmin, ""); err != nil {
 		return err
 	}
 
@@ -154,7 +154,7 @@ func (u *usersService) Lock(ctx context.Context, id string) error {
 }
 
 func (u *usersService) Unlock(ctx context.Context, id string) error {
-	if err := u.authorize(ctx, system.RoleAdmin(), ""); err != nil {
+	if err := u.authorize(ctx, system.RoleAdmin, ""); err != nil {
 		return err
 	}
 

--- a/v2/apiserver/internal/authz/mongodb/role_assignments_store.go
+++ b/v2/apiserver/internal/authz/mongodb/role_assignments_store.go
@@ -70,7 +70,7 @@ func (r *roleAssignmentsStore) Exists(
 	roleAssignment libAuthz.RoleAssignment,
 ) (bool, error) {
 	criteria := bson.M{
-		"role.name":      roleAssignment.Role.Name,
+		"role":           roleAssignment.Role,
 		"principal.type": roleAssignment.Principal.Type,
 		"principal.id":   roleAssignment.Principal.ID,
 	}

--- a/v2/apiserver/internal/authz/rest/role_assignments_endpoints.go
+++ b/v2/apiserver/internal/authz/rest/role_assignments_endpoints.go
@@ -56,9 +56,7 @@ func (r *RoleAssignmentsEndpoints) revoke(
 	req *http.Request,
 ) {
 	roleAssignment := libAuthz.RoleAssignment{
-		Role: libAuthz.Role{
-			Name: libAuthz.RoleName(req.URL.Query().Get("role")),
-		},
+		Role:  libAuthz.Role(req.URL.Query().Get("role")),
 		Scope: req.URL.Query().Get("scope"),
 		Principal: libAuthz.PrincipalReference{
 			Type: libAuthz.PrincipalType(req.URL.Query().Get("principalType")),

--- a/v2/apiserver/internal/authz/role_assignments.go
+++ b/v2/apiserver/internal/authz/role_assignments.go
@@ -60,7 +60,7 @@ func (r *roleAssignmentsService) Grant(
 	ctx context.Context,
 	roleAssignment libAuthz.RoleAssignment,
 ) error {
-	if err := r.authorize(ctx, system.RoleAdmin(), ""); err != nil {
+	if err := r.authorize(ctx, system.RoleAdmin, ""); err != nil {
 		return err
 	}
 
@@ -100,7 +100,7 @@ func (r *roleAssignmentsService) Grant(
 		return errors.Wrapf(
 			err,
 			"error granting role %q with scope %q to %s %q in store",
-			roleAssignment.Role.Name,
+			roleAssignment.Role,
 			roleAssignment.Scope,
 			roleAssignment.Principal.Type,
 			roleAssignment.Principal.ID,
@@ -114,7 +114,7 @@ func (r *roleAssignmentsService) Revoke(
 	ctx context.Context,
 	roleAssignment libAuthz.RoleAssignment,
 ) error {
-	if err := r.authorize(ctx, system.RoleAdmin(), ""); err != nil {
+	if err := r.authorize(ctx, system.RoleAdmin, ""); err != nil {
 		return err
 	}
 
@@ -154,7 +154,7 @@ func (r *roleAssignmentsService) Revoke(
 		return errors.Wrapf(
 			err,
 			"error revoking role %q with scope %q for %s %q in store",
-			roleAssignment.Role.Name,
+			roleAssignment.Role,
 			roleAssignment.Scope,
 			roleAssignment.Principal.Type,
 			roleAssignment.Principal.ID,

--- a/v2/apiserver/internal/core/authorizers_test.go
+++ b/v2/apiserver/internal/core/authorizers_test.go
@@ -30,9 +30,7 @@ func TestNewProjectAuthorizer(t *testing.T) {
 }
 
 func TestProjectAuthorizerAuthorize(t *testing.T) {
-	testProjectRole := ProjectRole{
-		Name: "foo",
-	}
+	const testProjectRole = "foo"
 	const testProjectID = "foo"
 	testCases := []struct {
 		name              string

--- a/v2/apiserver/internal/core/events.go
+++ b/v2/apiserver/internal/core/events.go
@@ -334,7 +334,7 @@ func (e *eventsService) Create(
 		// events coming from gateways.
 		if err := e.authorize(
 			ctx,
-			RoleEventCreator(),
+			RoleEventCreator,
 			event.Source,
 		); err != nil {
 			return events, err
@@ -347,7 +347,7 @@ func (e *eventsService) Create(
 		if err := e.projectAuthorize(
 			ctx,
 			event.ProjectID,
-			RoleProjectUser(),
+			RoleProjectUser,
 		); err != nil {
 			return events, err
 		}
@@ -481,7 +481,7 @@ func (e *eventsService) List(
 	selector EventsSelector,
 	opts meta.ListOptions,
 ) (EventList, error) {
-	if err := e.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := e.authorize(ctx, system.RoleReader, ""); err != nil {
 		return EventList{}, err
 	}
 
@@ -504,7 +504,7 @@ func (e *eventsService) Get(
 	ctx context.Context,
 	id string,
 ) (Event, error) {
-	if err := e.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := e.authorize(ctx, system.RoleReader, ""); err != nil {
 		return Event{}, err
 	}
 
@@ -542,7 +542,7 @@ func (e *eventsService) UpdateSourceState(
 		return errors.Wrapf(err, "error retrieving event %q from store", id)
 	}
 
-	if err = e.authorize(ctx, RoleEventCreator(), event.Source); err != nil {
+	if err = e.authorize(ctx, RoleEventCreator, event.Source); err != nil {
 		return err
 	}
 
@@ -561,7 +561,7 @@ func (e *eventsService) Cancel(ctx context.Context, id string) error {
 	}
 
 	if err =
-		e.projectAuthorize(ctx, event.ProjectID, RoleProjectUser()); err != nil {
+		e.projectAuthorize(ctx, event.ProjectID, RoleProjectUser); err != nil {
 		return err
 	}
 
@@ -604,7 +604,7 @@ func (e *eventsService) CancelMany(
 	}
 
 	if err :=
-		e.projectAuthorize(ctx, selector.ProjectID, RoleProjectUser()); err != nil {
+		e.projectAuthorize(ctx, selector.ProjectID, RoleProjectUser); err != nil {
 		return CancelManyEventsResult{}, err
 	}
 
@@ -664,7 +664,7 @@ func (e *eventsService) Delete(ctx context.Context, id string) error {
 	}
 
 	if err =
-		e.projectAuthorize(ctx, event.ProjectID, RoleProjectUser()); err != nil {
+		e.projectAuthorize(ctx, event.ProjectID, RoleProjectUser); err != nil {
 		return err
 	}
 
@@ -709,7 +709,7 @@ func (e *eventsService) DeleteMany(
 	if err := e.projectAuthorize(
 		ctx,
 		selector.ProjectID,
-		RoleProjectUser(),
+		RoleProjectUser,
 	); err != nil {
 		return DeleteManyEventsResult{}, err
 	}

--- a/v2/apiserver/internal/core/jobs.go
+++ b/v2/apiserver/internal/core/jobs.go
@@ -245,7 +245,7 @@ func (j *jobsService) Create(
 	eventID string,
 	job Job,
 ) error {
-	if err := j.authorize(ctx, RoleWorker(), eventID); err != nil {
+	if err := j.authorize(ctx, RoleWorker, eventID); err != nil {
 		return err
 	}
 
@@ -391,7 +391,7 @@ func (j *jobsService) Start(
 	eventID string,
 	jobName string,
 ) error {
-	if err := j.authorize(ctx, RoleScheduler(), ""); err != nil {
+	if err := j.authorize(ctx, RoleScheduler, ""); err != nil {
 		return err
 	}
 
@@ -461,7 +461,7 @@ func (j *jobsService) GetStatus(
 	eventID string,
 	jobName string,
 ) (JobStatus, error) {
-	if err := j.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := j.authorize(ctx, system.RoleReader, ""); err != nil {
 		return JobStatus{}, err
 	}
 
@@ -485,7 +485,7 @@ func (j *jobsService) WatchStatus(
 	eventID string,
 	jobName string,
 ) (<-chan JobStatus, error) {
-	if err := j.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := j.authorize(ctx, system.RoleReader, ""); err != nil {
 		return nil, err
 	}
 
@@ -535,7 +535,7 @@ func (j *jobsService) UpdateStatus(
 	jobName string,
 	status JobStatus,
 ) error {
-	if err := j.authorize(ctx, RoleObserver(), ""); err != nil {
+	if err := j.authorize(ctx, RoleObserver, ""); err != nil {
 		return err
 	}
 
@@ -583,7 +583,7 @@ func (j *jobsService) Cleanup(
 	eventID string,
 	jobName string,
 ) error {
-	if err := j.authorize(ctx, RoleObserver(), ""); err != nil {
+	if err := j.authorize(ctx, RoleObserver, ""); err != nil {
 		return err
 	}
 

--- a/v2/apiserver/internal/core/logs.go
+++ b/v2/apiserver/internal/core/logs.go
@@ -146,7 +146,7 @@ func (l *logsService) Stream(
 	// this one read-only operation and require the principal to be a project user
 	// in order to stream logs.
 	if err =
-		l.projectAuthorize(ctx, event.ProjectID, RoleProjectUser()); err != nil {
+		l.projectAuthorize(ctx, event.ProjectID, RoleProjectUser); err != nil {
 		return nil, err
 	}
 

--- a/v2/apiserver/internal/core/mongodb/project_role_assignments_store.go
+++ b/v2/apiserver/internal/core/mongodb/project_role_assignments_store.go
@@ -35,7 +35,7 @@ func (p *projectRoleAssignmentsStore) Grant(
 	tru := true
 	criteria := bson.M{
 		"projectID":      projectRoleAssignment.ProjectID,
-		"role.name":      projectRoleAssignment.Role.Name,
+		"role":           projectRoleAssignment.Role,
 		"principal.type": projectRoleAssignment.Principal.Type,
 		"principal.id":   projectRoleAssignment.Principal.ID,
 	}
@@ -62,7 +62,7 @@ func (p *projectRoleAssignmentsStore) Revoke(
 ) error {
 	criteria := bson.M{
 		"projectID":      projectRoleAssignment.ProjectID,
-		"role.name":      projectRoleAssignment.Role.Name,
+		"role":           projectRoleAssignment.Role,
 		"principal.type": projectRoleAssignment.Principal.Type,
 		"principal.id":   projectRoleAssignment.Principal.ID,
 	}
@@ -99,7 +99,7 @@ func (p *projectRoleAssignmentsStore) Exists(
 ) (bool, error) {
 	criteria := bson.M{
 		"projectID":      projectRoleAssignment.ProjectID,
-		"role.name":      projectRoleAssignment.Role.Name,
+		"role":           projectRoleAssignment.Role,
 		"principal.type": projectRoleAssignment.Principal.Type,
 		"principal.id":   projectRoleAssignment.Principal.ID,
 	}

--- a/v2/apiserver/internal/core/named_roles.go
+++ b/v2/apiserver/internal/core/named_roles.go
@@ -4,79 +4,50 @@ import (
 	libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
 )
 
-// Core-specific, system-level roles...
+const (
+	// Core-specific, system-level roles...
 
-// RoleEventCreator returns a system-level Role that enables principals to
-// create Events for all Projects.
-func RoleEventCreator() libAuthz.Role {
-	return libAuthz.Role{
-		Name: "EVENT_CREATOR",
-	}
-}
+	// RoleEventCreator represents a system-level Role that enables principals to
+	// create Events for all Projects.
+	RoleEventCreator libAuthz.Role = "EVENT_CREATOR"
 
-// RoleProjectCreator returns a system-level Role that enables principals to
-// create new Projects.
-func RoleProjectCreator() libAuthz.Role {
-	return libAuthz.Role{
-		Name: "PROJECT_CREATOR",
-	}
-}
+	// RoleProjectCreator represents a system-level Role that enables principals
+	// to create new Projects.
+	RoleProjectCreator libAuthz.Role = "PROJECT_CREATOR"
 
-// Core-specific, ProjectRoles...
+	// Core-specific, ProjectRoles...
 
-// RoleProjectAdmin returns a ProjectRole that enables a principal to manage a
-// Project.
-func RoleProjectAdmin() ProjectRole {
-	return ProjectRole{
-		Name: "ADMIN",
-	}
-}
+	// RoleProjectAdmin represents a project-level Role that enables a principal
+	// to manage a Project.
+	RoleProjectAdmin libAuthz.Role = "PROJECT_ADMIN"
 
-// RoleProjectDeveloper returns a ProjectRole that enables a principal to update
-// a Project.
-func RoleProjectDeveloper() ProjectRole {
-	return ProjectRole{
-		Name: "DEVELOPER",
-	}
-}
+	// RoleProjectDeveloper represents a project-level Role that enables a
+	// principal to update a Project.
+	RoleProjectDeveloper libAuthz.Role = "PROJECT_DEVELOPER"
 
-// RoleProjectUser returns a ProjectRole that enables a principal to create and
-// manage Events for a Project.
-func RoleProjectUser() ProjectRole {
-	return ProjectRole{
-		Name: "USER",
-	}
-}
+	// RoleProjectUser represents a project-level Role that enables a principal to
+	// create and manage Events for a Project.
+	RoleProjectUser libAuthz.Role = "PROJECT_USER"
 
-// Special core-specific roles...
-//
-// These are reserved for use by system components and are NOT assignable to
-// Users and ServiceAccounts.
+	// Special core-specific roles...
+	//
+	// These are reserved for use by system components and are NOT assignable to
+	// Users and ServiceAccounts.
 
-// RoleObserver returns a system-level Role that enables principals to update
-// Worker and Job status based on observation of the underlying workload
-// execution substrate. This Role exists exclusively for use by Brigade's
-// Observer component.
-func RoleObserver() libAuthz.Role {
-	return libAuthz.Role{
-		Name: "OBSERVER",
-	}
-}
+	// RoleObserver represents a system-level Role that enables principals to
+	// update Worker and Job status based on observation of the underlying
+	// workload execution substrate. This Role exists exclusively for use by
+	// Brigade's Observer component.
+	RoleObserver libAuthz.Role = "OBSERVER"
 
-// RoleScheduler returns a system-level Role that enables principals to initiate
-// execution of a Worker or Job on the underlying workload execution substrate.
-// This Role exists exclusively for use by Brigade's Scheduler component.
-func RoleScheduler() libAuthz.Role {
-	return libAuthz.Role{
-		Name: "SCHEDULER",
-	}
-}
+	// RoleScheduler represents a system-level Role that enables principals to
+	// initiate execution of a Worker or Job on the underlying workload execution
+	// substrate. This Role exists exclusively for use by Brigade's Scheduler
+	// component.
+	RoleScheduler libAuthz.Role = "SCHEDULER"
 
-// RoleWorker returns an event-level Role that enables principals to create new
-// Jobs, monitor the status of those Jobs, and access their logs. This Role is
-// exclusively for the use of Brigade Workers.
-func RoleWorker() libAuthz.Role {
-	return libAuthz.Role{
-		Name: "WORKER",
-	}
-}
+	// RoleWorker represents an event-level Role that enables principals to create
+	// new Jobs, monitor the status of those Jobs, and access their logs. This
+	// Role is exclusively for the use of Brigade Workers.
+	RoleWorker libAuthz.Role = "WORKER"
+)

--- a/v2/apiserver/internal/core/project_role_assignments_test.go
+++ b/v2/apiserver/internal/core/project_role_assignments_test.go
@@ -12,67 +12,51 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMatches(t *testing.T) {
+func TestProjectRoleAssignmentMatches(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		projectRoleAssignment ProjectRoleAssignment
-		projectRole           ProjectRole
+		role                  libAuthz.Role
 		projectID             string
 		matches               bool
 	}{
 		{
 			name: "names do not match",
 			projectRoleAssignment: ProjectRoleAssignment{
-				Role: ProjectRole{
-					Name: "foo",
-				},
+				Role:      "foo",
 				ProjectID: "foo",
 			},
-			projectRole: ProjectRole{
-				Name: "bar",
-			},
+			role:      "bar",
 			projectID: "foo",
 			matches:   false,
 		},
 		{
 			name: "scopes do not match",
 			projectRoleAssignment: ProjectRoleAssignment{
-				Role: ProjectRole{
-					Name: "foo",
-				},
+				Role:      "foo",
 				ProjectID: "foo",
 			},
-			projectRole: ProjectRole{
-				Name: "foo",
-			},
+			role:      "foo",
 			projectID: "bar",
 			matches:   false,
 		},
 		{
 			name: "scopes are an exact match",
 			projectRoleAssignment: ProjectRoleAssignment{
-				Role: ProjectRole{
-					Name: "foo",
-				},
+				Role:      "foo",
 				ProjectID: "foo",
 			},
-			projectRole: ProjectRole{
-				Name: "foo",
-			},
+			role:      "foo",
 			projectID: "foo",
 			matches:   true,
 		},
 		{
 			name: "a global project scope matches b project",
 			projectRoleAssignment: ProjectRoleAssignment{
-				Role: ProjectRole{
-					Name: "foo",
-				},
+				Role:      "foo",
 				ProjectID: ProjectRoleScopeGlobal,
 			},
-			projectRole: ProjectRole{
-				Name: "foo",
-			},
+			role:      "foo",
 			projectID: "foo",
 			matches:   true,
 		},
@@ -84,7 +68,7 @@ func TestMatches(t *testing.T) {
 				testCase.matches,
 				testCase.projectRoleAssignment.Matches(
 					testCase.projectID,
-					testCase.projectRole,
+					testCase.role,
 				),
 			)
 		})

--- a/v2/apiserver/internal/core/project_roles.go
+++ b/v2/apiserver/internal/core/project_roles.go
@@ -1,12 +1,4 @@
 package core
 
-import libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
-
 // ProjectRoleScopeGlobal represents an unbounded project scope.
 const ProjectRoleScopeGlobal = "*"
-
-// ProjectRole represents a set of project-level permissions.
-type ProjectRole struct {
-	// Name is the name of a Role and has domain-specific meaning.
-	Name libAuthz.RoleName `json:"name,omitempty" bson:"name,omitempty"`
-}

--- a/v2/apiserver/internal/core/projects.go
+++ b/v2/apiserver/internal/core/projects.go
@@ -210,7 +210,7 @@ func (p *projectsService) Create(
 	ctx context.Context,
 	project Project,
 ) (Project, error) {
-	if err := p.authorize(ctx, RoleProjectCreator(), ""); err != nil {
+	if err := p.authorize(ctx, RoleProjectCreator, ""); err != nil {
 		return project, err
 	}
 
@@ -255,7 +255,7 @@ func (p *projectsService) Create(
 		ctx,
 		ProjectRoleAssignment{
 			ProjectID: project.ID,
-			Role:      RoleProjectAdmin(),
+			Role:      RoleProjectAdmin,
 			Principal: principalRef,
 		},
 	); err != nil {
@@ -271,7 +271,7 @@ func (p *projectsService) Create(
 		ctx,
 		ProjectRoleAssignment{
 			ProjectID: project.ID,
-			Role:      RoleProjectDeveloper(),
+			Role:      RoleProjectDeveloper,
 			Principal: principalRef,
 		},
 	); err != nil {
@@ -287,7 +287,7 @@ func (p *projectsService) Create(
 		ctx,
 		ProjectRoleAssignment{
 			ProjectID: project.ID,
-			Role:      RoleProjectUser(),
+			Role:      RoleProjectUser,
 			Principal: principalRef,
 		},
 	); err != nil {
@@ -307,7 +307,7 @@ func (p *projectsService) List(
 	ctx context.Context,
 	opts meta.ListOptions,
 ) (ProjectList, error) {
-	if err := p.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := p.authorize(ctx, system.RoleReader, ""); err != nil {
 		return ProjectList{}, err
 	}
 
@@ -325,7 +325,7 @@ func (p *projectsService) Get(
 	ctx context.Context,
 	id string,
 ) (Project, error) {
-	if err := p.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := p.authorize(ctx, system.RoleReader, ""); err != nil {
 		return Project{}, err
 	}
 
@@ -342,7 +342,7 @@ func (p *projectsService) Get(
 
 func (p *projectsService) Update(ctx context.Context, project Project) error {
 	if err :=
-		p.projectAuthorize(ctx, project.ID, RoleProjectDeveloper()); err != nil {
+		p.projectAuthorize(ctx, project.ID, RoleProjectDeveloper); err != nil {
 		return err
 	}
 
@@ -357,7 +357,7 @@ func (p *projectsService) Update(ctx context.Context, project Project) error {
 }
 
 func (p *projectsService) Delete(ctx context.Context, id string) error {
-	if err := p.projectAuthorize(ctx, id, RoleProjectAdmin()); err != nil {
+	if err := p.projectAuthorize(ctx, id, RoleProjectAdmin); err != nil {
 		return err
 	}
 

--- a/v2/apiserver/internal/core/rest/project_role_assignments_endpoints.go
+++ b/v2/apiserver/internal/core/rest/project_role_assignments_endpoints.go
@@ -57,9 +57,7 @@ func (p *ProjectRoleAssignmentsEndpoints) revoke(
 	r *http.Request,
 ) {
 	projectRoleAssignment := core.ProjectRoleAssignment{
-		Role: core.ProjectRole{
-			Name: libAuthz.RoleName(r.URL.Query().Get("role")),
-		},
+		Role:      libAuthz.Role(r.URL.Query().Get("role")),
 		ProjectID: r.URL.Query().Get("projectID"),
 		Principal: libAuthz.PrincipalReference{
 			Type: libAuthz.PrincipalType(r.URL.Query().Get("principalType")),

--- a/v2/apiserver/internal/core/secrets.go
+++ b/v2/apiserver/internal/core/secrets.go
@@ -135,7 +135,7 @@ func (s *secretsService) List(
 	projectID string,
 	opts meta.ListOptions,
 ) (SecretList, error) {
-	if err := s.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := s.authorize(ctx, system.RoleReader, ""); err != nil {
 		return SecretList{}, err
 	}
 
@@ -167,7 +167,7 @@ func (s *secretsService) Set(
 	projectID string,
 	secret Secret,
 ) error {
-	if err := s.projectAuthorize(ctx, projectID, RoleProjectAdmin()); err != nil {
+	if err := s.projectAuthorize(ctx, projectID, RoleProjectAdmin); err != nil {
 		return err
 	}
 
@@ -194,7 +194,7 @@ func (s *secretsService) Unset(
 	projectID string,
 	key string,
 ) error {
-	if err := s.projectAuthorize(ctx, projectID, RoleProjectAdmin()); err != nil {
+	if err := s.projectAuthorize(ctx, projectID, RoleProjectAdmin); err != nil {
 		return err
 	}
 

--- a/v2/apiserver/internal/core/substrate.go
+++ b/v2/apiserver/internal/core/substrate.go
@@ -93,7 +93,7 @@ func (s *substrateService) CountRunningWorkers(
 	// a hypothetical new dashboard, wanting to grant users some summary-level
 	// insight into what's going on with the substrate, so we'll only require
 	// system.RoleReader() to authorize this operation.
-	if err := s.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := s.authorize(ctx, system.RoleReader, ""); err != nil {
 		return SubstrateWorkerCount{}, err
 	}
 
@@ -115,7 +115,7 @@ func (s *substrateService) CountRunningJobs(
 	// a hypothetical new dashboard, wanting to grant users some summary-level
 	// insight into what's going on with the substrate, so we'll only require
 	// system.RoleReader() to authorize this operation.
-	if err := s.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := s.authorize(ctx, system.RoleReader, ""); err != nil {
 		return SubstrateJobCount{}, err
 	}
 

--- a/v2/apiserver/internal/core/workers.go
+++ b/v2/apiserver/internal/core/workers.go
@@ -271,7 +271,7 @@ func NewWorkersService(
 }
 
 func (w *workersService) Start(ctx context.Context, eventID string) error {
-	if err := w.authorize(ctx, RoleScheduler(), ""); err != nil {
+	if err := w.authorize(ctx, RoleScheduler, ""); err != nil {
 		return err
 	}
 
@@ -324,7 +324,7 @@ func (w *workersService) GetStatus(
 	ctx context.Context,
 	eventID string,
 ) (WorkerStatus, error) {
-	if err := w.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := w.authorize(ctx, system.RoleReader, ""); err != nil {
 		return WorkerStatus{}, err
 	}
 
@@ -340,7 +340,7 @@ func (w *workersService) WatchStatus(
 	ctx context.Context,
 	eventID string,
 ) (<-chan WorkerStatus, error) {
-	if err := w.authorize(ctx, system.RoleReader(), ""); err != nil {
+	if err := w.authorize(ctx, system.RoleReader, ""); err != nil {
 		return nil, err
 	}
 
@@ -380,7 +380,7 @@ func (w *workersService) UpdateStatus(
 	eventID string,
 	status WorkerStatus,
 ) error {
-	if err := w.authorize(ctx, RoleObserver(), ""); err != nil {
+	if err := w.authorize(ctx, RoleObserver, ""); err != nil {
 		return err
 	}
 
@@ -417,7 +417,7 @@ func (w *workersService) Cleanup(
 	ctx context.Context,
 	eventID string,
 ) error {
-	if err := w.authorize(ctx, RoleObserver(), ""); err != nil {
+	if err := w.authorize(ctx, RoleObserver, ""); err != nil {
 		return err
 	}
 

--- a/v2/apiserver/internal/lib/authz/authorizers.go
+++ b/v2/apiserver/internal/lib/authz/authorizers.go
@@ -8,9 +8,9 @@ import (
 
 // AuthorizeFn is the signature for any function that can, presumably, retrieve
 // a principal from the provided Context and make an access control decision
-// based on the principal having (or not having) at least one of the provided
-// Roles. Implementations MUST return a *meta.ErrAuthorization error if the
-// principal is not authorized.
+// based on the principal having (or not having) the specified Role with the
+// specified scope. Implementations MUST return a *meta.ErrAuthorization error
+// if the principal is not authorized.
 type AuthorizeFn func(ctx context.Context, role Role, scope string) error
 
 // AlwaysAuthorize is an implementation of the AuthorizeFn function signature

--- a/v2/apiserver/internal/lib/authz/role_assignments.go
+++ b/v2/apiserver/internal/lib/authz/role_assignments.go
@@ -8,13 +8,13 @@ type RoleAssignment struct {
 	// Principal specifies the principal to whom the Role is assigned.
 	Principal PrincipalReference `json:"principal" bson:"principal"`
 	// Scope qualifies the scope of the Role. The value is opaque and has meaning
-	// only in relation to a specific RoleName.
+	// only in relation to a specific Role.
 	Scope string `json:"scope,omitempty" bson:"scope,omitempty"`
 }
 
 // Matches determines if this RoleAssignment matches the role and scope
 // arguments.
 func (r RoleAssignment) Matches(role Role, scope string) bool {
-	return r.Role.Name == role.Name &&
+	return r.Role == role &&
 		(r.Scope == scope || r.Scope == RoleScopeGlobal)
 }

--- a/v2/apiserver/internal/lib/authz/role_assignments_test.go
+++ b/v2/apiserver/internal/lib/authz/role_assignments_test.go
@@ -17,56 +17,40 @@ func TestMatches(t *testing.T) {
 		{
 			name: "names do not match",
 			roleAssignment: RoleAssignment{
-				Role: Role{
-					Name: "foo",
-				},
+				Role:  "foo",
 				Scope: "foo",
 			},
-			role: Role{
-				Name: "bar",
-			},
+			role:    "bar",
 			scope:   "foo",
 			matches: false,
 		},
 		{
 			name: "scopes do not match",
 			roleAssignment: RoleAssignment{
-				Role: Role{
-					Name: "foo",
-				},
+				Role:  "foo",
 				Scope: "foo",
 			},
-			role: Role{
-				Name: "foo",
-			},
+			role:    "foo",
 			scope:   "bar",
 			matches: false,
 		},
 		{
 			name: "scopes are an exact match",
 			roleAssignment: RoleAssignment{
-				Role: Role{
-					Name: "foo",
-				},
+				Role:  "foo",
 				Scope: "foo",
 			},
-			role: Role{
-				Name: "foo",
-			},
+			role:    "foo",
 			scope:   "foo",
 			matches: true,
 		},
 		{
 			name: "a global scope matches b scope",
 			roleAssignment: RoleAssignment{
-				Role: Role{
-					Name: "foo",
-				},
+				Role:  "foo",
 				Scope: RoleScopeGlobal,
 			},
-			role: Role{
-				Name: "foo",
-			},
+			role:    "foo",
 			scope:   "foo",
 			matches: true,
 		},

--- a/v2/apiserver/internal/lib/authz/roles.go
+++ b/v2/apiserver/internal/lib/authz/roles.go
@@ -1,13 +1,7 @@
 package authz
 
-// RoleName is a type whose value maps to a well-defined Brigade Role.
-type RoleName string
+// Role is a type whose value maps to a well-defined Brigade Role.
+type Role string
 
 // RoleScopeGlobal represents an unbounded scope.
 const RoleScopeGlobal = "*"
-
-// Role represents a set of permissions.
-type Role struct {
-	// Name is the name of a Role and has domain-specific meaning.
-	Name RoleName `json:"name,omitempty" bson:"name,omitempty"`
-}

--- a/v2/apiserver/internal/system/authn/named_principals.go
+++ b/v2/apiserver/internal/system/authn/named_principals.go
@@ -21,13 +21,13 @@ type rootPrincipal struct{}
 
 func (r *rootPrincipal) RoleAssignments() []libAuthz.RoleAssignment {
 	return []libAuthz.RoleAssignment{
-		{Role: system.RoleAdmin()},
-		{Role: system.RoleReader()},
+		{Role: system.RoleAdmin},
+		{Role: system.RoleReader},
 		{
-			Role:  core.RoleEventCreator(),
+			Role:  core.RoleEventCreator,
 			Scope: libAuthz.RoleScopeGlobal,
 		},
-		{Role: core.RoleProjectCreator()},
+		{Role: core.RoleProjectCreator},
 	}
 }
 
@@ -35,15 +35,15 @@ func (r *rootPrincipal) ProjectRoleAssignments() []core.ProjectRoleAssignment {
 	return []core.ProjectRoleAssignment{
 		{
 			ProjectID: core.ProjectRoleScopeGlobal,
-			Role:      core.RoleProjectAdmin(),
+			Role:      core.RoleProjectAdmin,
 		},
 		{
 			ProjectID: core.ProjectRoleScopeGlobal,
-			Role:      core.RoleProjectDeveloper(),
+			Role:      core.RoleProjectDeveloper,
 		},
 		{
 			ProjectID: core.ProjectRoleScopeGlobal,
-			Role:      core.RoleProjectUser(),
+			Role:      core.RoleProjectUser,
 		},
 	}
 }
@@ -56,8 +56,8 @@ type schedulerPrincipal struct{}
 
 func (s *schedulerPrincipal) RoleAssignments() []libAuthz.RoleAssignment {
 	return []libAuthz.RoleAssignment{
-		{Role: system.RoleReader()},
-		{Role: core.RoleScheduler()},
+		{Role: system.RoleReader},
+		{Role: core.RoleScheduler},
 	}
 }
 
@@ -69,8 +69,8 @@ type observerPrincipal struct{}
 
 func (o *observerPrincipal) RoleAssignments() []libAuthz.RoleAssignment {
 	return []libAuthz.RoleAssignment{
-		{Role: system.RoleReader()},
-		{Role: core.RoleObserver()},
+		{Role: system.RoleReader},
+		{Role: core.RoleObserver},
 	}
 }
 
@@ -83,9 +83,9 @@ type workerPrincipal struct {
 
 func (w *workerPrincipal) RoleAssignments() []libAuthz.RoleAssignment {
 	return []libAuthz.RoleAssignment{
-		{Role: system.RoleReader()},
+		{Role: system.RoleReader},
 		{
-			Role:  core.RoleWorker(),
+			Role:  core.RoleWorker,
 			Scope: w.eventID,
 		},
 	}

--- a/v2/apiserver/internal/system/authz/authorizers.go
+++ b/v2/apiserver/internal/system/authz/authorizers.go
@@ -22,8 +22,8 @@ type roleAssignmentsHolder interface {
 // NewAuthorizer function.
 type Authorizer interface {
 	// Authorize retrieves a principal from the provided Context and asserts that
-	// it has at least one of the allowed Roles. If it does not, implementations
-	// MUST return a *meta.ErrAuthorization error.
+	// it has the specified Role with the specified scope. If it does not,
+	// implementations MUST return a *meta.ErrAuthorization error.
 	Authorize(ctx context.Context, roles libAuthz.Role, scope string) error
 }
 

--- a/v2/apiserver/internal/system/authz/authorizers_test.go
+++ b/v2/apiserver/internal/system/authz/authorizers_test.go
@@ -28,9 +28,7 @@ func TestNewAuthorizer(t *testing.T) {
 }
 
 func TestAuthorizerAuthorize(t *testing.T) {
-	testRole := libAuthz.Role{
-		Name: "foo",
-	}
+	const testRole = "foo"
 	const testScope = "foo"
 	testCases := []struct {
 		name       string

--- a/v2/apiserver/internal/system/named_roles.go
+++ b/v2/apiserver/internal/system/named_roles.go
@@ -2,18 +2,12 @@ package system
 
 import libAuthz "github.com/brigadecore/brigade/v2/apiserver/internal/lib/authz"
 
-// RoleAdmin returns a system-level Role that enables principals to manage
-// Users, ServiceAccounts, and system-level permissions for Users and
-// ServiceAccounts.
-func RoleAdmin() libAuthz.Role {
-	return libAuthz.Role{
-		Name: "ADMIN",
-	}
-}
+const (
+	// RoleAdmin represents a system-level Role that enables principals to manage
+	// Users, ServiceAccounts, and system-level permissions for Users and
+	// ServiceAccounts.
+	RoleAdmin libAuthz.Role = "ADMIN"
 
-// RoleReader returns a system-level Role that enables global read access.
-func RoleReader() libAuthz.Role {
-	return libAuthz.Role{
-		Name: "READER",
-	}
-}
+	// RoleReader represents a system-level Role that enables global read access.
+	RoleReader libAuthz.Role = "READER"
+)

--- a/v2/apiserver/schemas/project-role-assignment.json
+++ b/v2/apiserver/schemas/project-role-assignment.json
@@ -14,7 +14,7 @@
 
 	"title": "ProjectRoleAssignment",
 	"type": "object",
-	"required": ["apiVersion", "kind", "principal", "role"],
+	"required": ["apiVersion", "kind", "principal", "projectID", "role"],
 	"additionalProperties": false,
 	"properties": {
 		"apiVersion": {
@@ -26,28 +26,21 @@
 		"principal": {
 			"$ref": "common.json#/definitions/principalReference"
 		},
+		"projectID": {
+			"type": "string",
+			"description": "The project this role should be scoped to",
+			"pattern": "^[a-z][a-z\\d-]*[a-z\\d]$",
+			"minLength": 3,
+			"maxLength": 18
+		},
 		"role": {
-			"type": "object",
-			"required": ["name", "projectID"],
-			"additionalProperties": false,
-			"properties": {
-				"name": {
-					"type": "string",
-					"description": "A role name",
-					"enum": [
-						"ADMIN",
-						"DEVELOPER",
-						"USER"
-					]
-				},
-				"projectID": {
-					"type": "string",
-					"description": "The project this role should be scoped to",
-					"pattern": "^[a-z][a-z\\d-]*[a-z\\d]$",
-					"minLength": 3,
-					"maxLength": 18
-				}
-			}
+			"type": "string",
+			"description": "A role name",
+			"enum": [
+				"ADMIN",
+				"DEVELOPER",
+				"USER"
+			]
 		}
 	}
 }

--- a/v2/apiserver/schemas/role-assignment.json
+++ b/v2/apiserver/schemas/role-assignment.json
@@ -8,43 +8,6 @@
 			"type": "string",
 			"description": "The type of object represented by the document",
 			"enum": ["RoleAssignment"]
-		},
-
-		"role": {
-			"type": "object",
-			"required": ["name"],
-			"additionalProperties": false,
-			"properties": {
-				"name": {
-					"type": "string",
-					"description": "A role name",
-					"enum": [
-						"ADMIN",
-						"PROJECT_CREATOR",
-						"READER"
-					]
-				}
-			}
-		},
-
-		"eventCreatorRole": {
-			"type": "object",
-			"required": ["name"],
-			"additionalProperties": false,
-			"properties": {
-				"name": {
-					"type": "string",
-					"description": "A role name",
-					"enum": ["EVENT_CREATOR"]
-				},
-				"scope": {
-					"type": "string",
-					"description": "The event source this role should be scoped to",
-					"pattern": "^[a-zA-Z][a-zA-Z\\d./-]*[a-zA-Z\\d]$",
-					"minLength": 3,
-					"maxLength": 50
-				}
-			}
 		}
 
 	},
@@ -64,9 +27,12 @@
 			"$ref": "common.json#/definitions/principalReference"
 		},
 		"role": {
-			"anyOf": [
-				{ "$ref": "#/definitions/role" },
-				{ "$ref": "#/definitions/eventCreatorRole" }
+			"type": "string",
+			"description": "A role name",
+			"enum": [
+				"ADMIN",
+				"PROJECT_CREATOR",
+				"READER"
 			]
 		}
 	}

--- a/v2/cli/project_role_commands.go
+++ b/v2/cli/project_role_commands.go
@@ -59,38 +59,38 @@ var projectRolesCommands = &cli.Command{
 			Usage: "Grant a project-level role to a user or service account",
 			Subcommands: []*cli.Command{
 				{
-					Name: string(core.RoleNameProjectAdmin),
+					Name: string(core.RoleProjectAdmin),
 					Usage: fmt.Sprintf(
 						"Grant the %s project role, which enables management of all "+
 							"aspects of the project, including its secrets, as well as "+
 							"project-level permissions for other users and service "+
 							"accounts.",
-						core.RoleNameProjectAdmin,
+						core.RoleProjectAdmin,
 					),
 					Flags:  projectRoleGrantFlags,
-					Action: grantProjectRole(core.RoleNameProjectAdmin),
+					Action: grantProjectRole(core.RoleProjectAdmin),
 				},
 				{
-					Name: string(core.RoleNameProjectDeveloper),
+					Name: string(core.RoleProjectDeveloper),
 					Usage: fmt.Sprintf(
 						"Grant the %s project role, which enables updating the project "+
 							"definition, but does NOT enable management of the project's "+
 							"secrets or project-level permissions for other users and "+
 							"service accounts.",
-						core.RoleNameProjectDeveloper,
+						core.RoleProjectDeveloper,
 					),
 					Flags:  projectRoleGrantFlags,
-					Action: grantProjectRole(core.RoleNameProjectDeveloper),
+					Action: grantProjectRole(core.RoleProjectDeveloper),
 				},
 				{
-					Name: string(core.RoleNameProjectUser),
+					Name: string(core.RoleProjectUser),
 					Usage: fmt.Sprintf(
 						"Grant the %s project role, which enables creation and management "+
 							"of events associated with the project",
-						core.RoleNameProjectUser,
+						core.RoleProjectUser,
 					),
 					Flags:  projectRoleGrantFlags,
-					Action: grantProjectRole(core.RoleNameProjectUser),
+					Action: grantProjectRole(core.RoleProjectUser),
 				},
 			},
 		},
@@ -99,47 +99,45 @@ var projectRolesCommands = &cli.Command{
 			Usage: "Revoke a project-level role from a user or service account",
 			Subcommands: []*cli.Command{
 				{
-					Name: string(core.RoleNameProjectAdmin),
+					Name: string(core.RoleProjectAdmin),
 					Usage: fmt.Sprintf(
 						"Revoke the %s project role, which enables management of all "+
 							"aspects of the project, including its secrets, as well as "+
 							"project-level permissions for other users and service "+
 							"accounts.",
-						core.RoleNameProjectAdmin,
+						core.RoleProjectAdmin,
 					),
 					Flags:  projectRoleRevokeFlags,
-					Action: revokeProjectRole(core.RoleNameProjectAdmin),
+					Action: revokeProjectRole(core.RoleProjectAdmin),
 				},
 				{
-					Name: string(core.RoleNameProjectDeveloper),
+					Name: string(core.RoleProjectDeveloper),
 					Usage: fmt.Sprintf(
 						"Revoke the %s project role, which enables updating the project "+
 							"definition, but does NOT enable management of the project's "+
 							"secrets or project-level permissions for other users and "+
 							"service accounts.",
-						core.RoleNameProjectDeveloper,
+						core.RoleProjectDeveloper,
 					),
 					Flags:  projectRoleRevokeFlags,
-					Action: revokeProjectRole(core.RoleNameProjectDeveloper),
+					Action: revokeProjectRole(core.RoleProjectDeveloper),
 				},
 				{
-					Name: string(core.RoleNameProjectUser),
+					Name: string(core.RoleProjectUser),
 					Usage: fmt.Sprintf(
 						"Revoke the %s project role, which enables creation and "+
 							"management of events associated with the project",
-						core.RoleNameProjectUser,
+						core.RoleProjectUser,
 					),
 					Flags:  projectRoleRevokeFlags,
-					Action: revokeProjectRole(core.RoleNameProjectUser),
+					Action: revokeProjectRole(core.RoleProjectUser),
 				},
 			},
 		},
 	},
 }
 
-func grantProjectRole(
-	roleName libAuthz.RoleName,
-) func(c *cli.Context) error {
+func grantProjectRole(role libAuthz.Role) func(c *cli.Context) error {
 	return func(c *cli.Context) error {
 		projectID := c.String(flagID)
 		userIDs := c.StringSlice(flagUser)
@@ -158,9 +156,7 @@ func grantProjectRole(
 
 		projectRoleAssignment := core.ProjectRoleAssignment{
 			ProjectID: projectID,
-			Role: core.ProjectRole{
-				Name: roleName,
-			},
+			Role:      role,
 		}
 
 		projectRoleAssignment.Principal.Type = authz.PrincipalTypeUser
@@ -186,9 +182,7 @@ func grantProjectRole(
 	}
 }
 
-func revokeProjectRole(
-	roleName libAuthz.RoleName,
-) func(c *cli.Context) error {
+func revokeProjectRole(role libAuthz.Role) func(c *cli.Context) error {
 	return func(c *cli.Context) error {
 		projectID := c.String(flagID)
 		userIDs := c.StringSlice(flagUser)
@@ -207,9 +201,7 @@ func revokeProjectRole(
 
 		projectRoleAssignment := core.ProjectRoleAssignment{
 			ProjectID: projectID,
-			Role: core.ProjectRole{
-				Name: roleName,
-			},
+			Role:      role,
 		}
 
 		projectRoleAssignment.Principal.Type = authz.PrincipalTypeUser

--- a/v2/cli/role_commands.go
+++ b/v2/cli/role_commands.go
@@ -48,21 +48,21 @@ var rolesCommands = &cli.Command{
 			Usage: "Grant a system-level role to a user or service account",
 			Subcommands: []*cli.Command{
 				{
-					Name: string(system.RoleNameAdmin),
+					Name: string(system.RoleAdmin),
 					Usage: fmt.Sprintf(
 						"Grant the %s role, which enables system management including "+
 							"system-level permissions for other users and service accounts.",
-						system.RoleNameAdmin,
+						system.RoleAdmin,
 					),
 					Flags:  roleGrantFlags,
-					Action: grantSystemRole(system.RoleNameAdmin),
+					Action: grantSystemRole(system.RoleAdmin),
 				},
 				{
-					Name: string(core.RoleNameEventCreator),
+					Name: string(core.RoleEventCreator),
 					Usage: fmt.Sprintf(
 						"Grant the %s role, which enables creation of events for all "+
 							"projects.",
-						core.RoleNameEventCreator,
+						core.RoleEventCreator,
 					),
 					Flags: append(
 						roleGrantFlags,
@@ -73,26 +73,26 @@ var rolesCommands = &cli.Command{
 							Required: true,
 						},
 					),
-					Action: grantSystemRole(core.RoleNameEventCreator),
+					Action: grantSystemRole(core.RoleEventCreator),
 				},
 				{
-					Name: string(core.RoleNameProjectCreator),
+					Name: string(core.RoleProjectCreator),
 					Usage: fmt.Sprintf(
 						"Grant the %s role, which enables creation of new projects.",
-						core.RoleNameProjectCreator,
+						core.RoleProjectCreator,
 					),
 					Flags:  roleGrantFlags,
-					Action: grantSystemRole(core.RoleNameProjectCreator),
+					Action: grantSystemRole(core.RoleProjectCreator),
 				},
 				{
-					Name: string(system.RoleNameReader),
+					Name: string(system.RoleReader),
 					Usage: fmt.Sprintf(
 						"Grant the %s role, which enables global read-only access to "+
 							"Brigade.",
-						system.RoleNameReader,
+						system.RoleReader,
 					),
 					Flags:  roleGrantFlags,
-					Action: grantSystemRole(system.RoleNameReader),
+					Action: grantSystemRole(system.RoleReader),
 				},
 			},
 		},
@@ -101,21 +101,21 @@ var rolesCommands = &cli.Command{
 			Usage: "Revoke a system-level role from a user or service account",
 			Subcommands: []*cli.Command{
 				{
-					Name: string(system.RoleNameAdmin),
+					Name: string(system.RoleAdmin),
 					Usage: fmt.Sprintf(
 						"Revoke the %s role, which enables system management including "+
 							"system-level permissions for other users and service accounts.",
-						system.RoleNameAdmin,
+						system.RoleAdmin,
 					),
 					Flags:  roleRevokeFlags,
-					Action: revokeSystemRole(system.RoleNameAdmin),
+					Action: revokeSystemRole(system.RoleAdmin),
 				},
 				{
-					Name: string(core.RoleNameEventCreator),
+					Name: string(core.RoleEventCreator),
 					Usage: fmt.Sprintf(
 						"Grant the %s role, which enables creation of events for all "+
 							"projects.",
-						core.RoleNameEventCreator,
+						core.RoleEventCreator,
 					),
 					Flags: append(
 						roleRevokeFlags,
@@ -126,33 +126,33 @@ var rolesCommands = &cli.Command{
 							Required: true,
 						},
 					),
-					Action: revokeSystemRole(core.RoleNameEventCreator),
+					Action: revokeSystemRole(core.RoleEventCreator),
 				},
 				{
-					Name: string(core.RoleNameProjectCreator),
+					Name: string(core.RoleProjectCreator),
 					Usage: fmt.Sprintf(
 						"Revoke the %s role, which enables creation of new projects.",
-						core.RoleNameProjectCreator,
+						core.RoleProjectCreator,
 					),
 					Flags:  roleRevokeFlags,
-					Action: revokeSystemRole(core.RoleNameProjectCreator),
+					Action: revokeSystemRole(core.RoleProjectCreator),
 				},
 				{
-					Name: string(system.RoleNameReader),
+					Name: string(system.RoleReader),
 					Usage: fmt.Sprintf(
 						"Revoke the %s role, which enables global read-only access to "+
 							"Brigade.",
-						system.RoleNameReader,
+						system.RoleReader,
 					),
 					Flags:  roleRevokeFlags,
-					Action: revokeSystemRole(system.RoleNameReader),
+					Action: revokeSystemRole(system.RoleReader),
 				},
 			},
 		},
 	},
 }
 
-func grantSystemRole(roleName libAuthz.RoleName) func(c *cli.Context) error {
+func grantSystemRole(role libAuthz.Role) func(c *cli.Context) error {
 	return func(c *cli.Context) error {
 		userIDs := c.StringSlice(flagUser)
 		serviceAccountIDs := c.StringSlice(flagServiceAccount)
@@ -164,13 +164,11 @@ func grantSystemRole(roleName libAuthz.RoleName) func(c *cli.Context) error {
 		}
 
 		roleAssignment := libAuthz.RoleAssignment{
-			Role: libAuthz.Role{
-				Name: roleName,
-			},
+			Role: role,
 		}
 
 		// Special logic for EVENT_CREATOR
-		if roleName == core.RoleNameEventCreator {
+		if role == core.RoleEventCreator {
 			roleAssignment.Scope = c.String(flagSource)
 		}
 
@@ -202,9 +200,7 @@ func grantSystemRole(roleName libAuthz.RoleName) func(c *cli.Context) error {
 	}
 }
 
-func revokeSystemRole(
-	roleName libAuthz.RoleName,
-) func(c *cli.Context) error {
+func revokeSystemRole(role libAuthz.Role) func(c *cli.Context) error {
 	return func(c *cli.Context) error {
 		userIDs := c.StringSlice(flagUser)
 		serviceAccountIDs := c.StringSlice(flagServiceAccount)
@@ -216,13 +212,11 @@ func revokeSystemRole(
 		}
 
 		roleAssignment := libAuthz.RoleAssignment{
-			Role: libAuthz.Role{
-				Name: roleName,
-			},
+			Role: role,
 		}
 
 		// Special logic for EVENT_CREATOR
-		if roleName == core.RoleNameEventCreator {
+		if role == core.RoleEventCreator {
 			roleAssignment.Scope = c.String(flagSource)
 		}
 


### PR DESCRIPTION
Another refactor to leave us in better position for #1257

Now that other recent PRs have transplanted `Role` fields (like `Scope`) to `RoleAssignment`, `Role` has only one remaining field, which is `Name`. This PR collapses `Role` and `RoleName` into one type-- `Role`-- which is really just a string.

There are no functional changes in this PR.