### PR TITLE
minor clone cleanup

### DIFF
--- a/sdk/v2/core/events.go
+++ b/sdk/v2/core/events.go
@@ -235,7 +235,7 @@ type EventsClient interface {
 	// Clones a pre-existing Event, removing the original's metadata and Worker
 	// config in the process.  A new Event is created using the rest of the
 	// details preserved from the original.
-	Clone(context.Context, string) (EventList, error)
+	Clone(context.Context, string) (Event, error)
 	// UpdateSourceState updates source-specific (e.g. gateway-specific) Event
 	// state.
 	UpdateSourceState(context.Context, string, SourceState) error
@@ -331,15 +331,15 @@ func (e *eventsClient) Get(
 func (e *eventsClient) Clone(
 	ctx context.Context,
 	id string,
-) (EventList, error) {
-	events := EventList{}
-	return events, e.ExecuteRequest(
+) (Event, error) {
+	event := Event{}
+	return event, e.ExecuteRequest(
 		ctx,
 		rm.OutboundRequest{
 			Method:      http.MethodPost,
 			Path:        fmt.Sprintf("v2/events/%s/clone", id),
 			SuccessCode: http.StatusCreated,
-			RespObj:     &events,
+			RespObj:     &event,
 		},
 	)
 }

--- a/sdk/v2/core/events_test.go
+++ b/sdk/v2/core/events_test.go
@@ -208,18 +208,9 @@ func TestEventsClientGet(t *testing.T) {
 
 func TestEventsClientClone(t *testing.T) {
 	const testEventID = "12345"
-	testEvents := EventList{
-		Items: []Event{
-			{
-				ObjectMeta: meta.ObjectMeta{
-					ID: "12345",
-				},
-			},
-			{
-				ObjectMeta: meta.ObjectMeta{
-					ID: "abcde",
-				},
-			},
+	testEvent := Event{
+		ObjectMeta: meta.ObjectMeta{
+			ID: "12345",
 		},
 	}
 	server := httptest.NewServer(
@@ -231,7 +222,7 @@ func TestEventsClientClone(t *testing.T) {
 					fmt.Sprintf("/v2/events/%s/clone", testEventID),
 					r.URL.Path,
 				)
-				bodyBytes, err := json.Marshal(testEvents)
+				bodyBytes, err := json.Marshal(testEvent)
 				require.NoError(t, err)
 				w.WriteHeader(http.StatusCreated)
 				fmt.Fprintln(w, string(bodyBytes))
@@ -240,9 +231,9 @@ func TestEventsClientClone(t *testing.T) {
 	)
 	defer server.Close()
 	client := NewEventsClient(server.URL, rmTesting.TestAPIToken, nil)
-	events, err := client.Clone(context.Background(), testEventID)
+	event, err := client.Clone(context.Background(), testEventID)
 	require.NoError(t, err)
-	require.Equal(t, testEvents, events)
+	require.Equal(t, testEvent, event)
 }
 
 func TestEventsClientUpdateSourceState(t *testing.T) {

--- a/v2/apiserver/internal/core/common_test.go
+++ b/v2/apiserver/internal/core/common_test.go
@@ -57,7 +57,6 @@ type mockEventsStore struct {
 	) (EventList, error)
 	GetFn                    func(context.Context, string) (Event, error)
 	GetByHashedWorkerTokenFn func(context.Context, string) (Event, error)
-	CloneFn                  func(context.Context, string) (EventList, error)
 	UpdateSourceStateFn      func(context.Context, string, SourceState) error
 	CancelFn                 func(context.Context, string) error
 	CancelManyFn             func(
@@ -92,13 +91,6 @@ func (m *mockEventsStore) GetByHashedWorkerToken(
 	hashedToken string,
 ) (Event, error) {
 	return m.GetByHashedWorkerTokenFn(ctx, hashedToken)
-}
-
-func (m *mockEventsStore) Clone(
-	ctx context.Context,
-	id string,
-) (EventList, error) {
-	return m.CloneFn(ctx, id)
 }
 
 func (m *mockEventsStore) UpdateSourceState(

--- a/v2/cli/event_commands.go
+++ b/v2/cli/event_commands.go
@@ -806,14 +806,14 @@ func eventClone(c *cli.Context) error {
 		return err
 	}
 
-	events, err := client.Core().Events().Clone(c.Context, id)
+	event, err := client.Core().Events().Clone(c.Context, id)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf(
 		"Created event %q from original event %q.\n\n",
-		events.Items[0].ID,
+		event.ID,
 		id,
 	)
 


### PR DESCRIPTION
This simplifies the client and service interfaces for cloning an `Event`. It was previously returning an `EventList` but cloning an `Event` can only ever produce _one_ new `Event`, so it seems simpler to return just an `Event` instead of an `EventList`.

This PR also removes an unused bit of the `MockEventStore`.