### PR TITLE
Fix marshal job when status is empty

### DIFF
--- a/sdk/v2/core/jobs.go
+++ b/sdk/v2/core/jobs.go
@@ -82,7 +82,7 @@ type Job struct {
 	// Spec is the technical blueprint for the Job.
 	Spec JobSpec `json:"spec"`
 	// Status contains details of the Job's current state.
-	Status *JobStatus `json:"status"`
+	Status *JobStatus `json:"status,omitempty"`
 }
 
 // MarshalJSON amends Job instances with type metadata so that clients do not


### PR DESCRIPTION
**What this PR does / why we need it**:
When status is empty on a job, create fails when called through the rest API because it's marshaled as `"status": null`, and status is not an allowed field on the job document. I have marked it as omitempty so that a nil status isn't included in the json.

```
Bad request: Request body failed JSON validation:
  0. (root): Additional property status is not allowed
```

**Special notes for your reviewer**:
I'm not 100% sure why this is something that just I ran into implementing brigdrake. When brigade uses its own api, does it not go through the json schema validation?

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
