### PR TITLE
small tweak to make event cloning more restful

### DIFF
--- a/sdk/v2/core/events.go
+++ b/sdk/v2/core/events.go
@@ -337,7 +337,7 @@ func (e *eventsClient) Clone(
 		ctx,
 		rm.OutboundRequest{
 			Method:      http.MethodPost,
-			Path:        fmt.Sprintf("v2/events/%s/clone", id),
+			Path:        fmt.Sprintf("v2/events/%s/clones", id),
 			SuccessCode: http.StatusCreated,
 			RespObj:     &event,
 		},

--- a/sdk/v2/core/events_test.go
+++ b/sdk/v2/core/events_test.go
@@ -219,7 +219,7 @@ func TestEventsClientClone(t *testing.T) {
 				require.Equal(t, http.MethodPost, r.Method)
 				require.Equal(
 					t,
-					fmt.Sprintf("/v2/events/%s/clone", testEventID),
+					fmt.Sprintf("/v2/events/%s/clones", testEventID),
 					r.URL.Path,
 				)
 				bodyBytes, err := json.Marshal(testEvent)

--- a/v2/apiserver/internal/core/rest/events_endpoints.go
+++ b/v2/apiserver/internal/core/rest/events_endpoints.go
@@ -42,7 +42,7 @@ func (e *EventsEndpoints) Register(router *mux.Router) {
 
 	// Clone event
 	router.HandleFunc(
-		"/v2/events/{id}/clone",
+		"/v2/events/{id}/clones",
 		e.AuthFilter.Decorate(e.clone),
 	).Methods(http.MethodPost)
 


### PR DESCRIPTION
This is a small, anal retentive tweak. An event can be cloned more than once, so the endpoint for cloning should be `event/<id>/clones` (plural).