### PR TITLE
add system client to the client tree

### DIFF
--- a/sdk/v2/api_client.go
+++ b/sdk/v2/api_client.go
@@ -5,6 +5,7 @@ import (
 	"github.com/brigadecore/brigade/sdk/v2/authz"
 	"github.com/brigadecore/brigade/sdk/v2/core"
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
+	"github.com/brigadecore/brigade/sdk/v2/system"
 )
 
 // APIClient is the general interface for the Brigade API. It does little more
@@ -14,12 +15,14 @@ type APIClient interface {
 	Authn() authn.APIClient
 	Authz() authz.APIClient
 	Core() core.APIClient
+	System() system.APIClient
 }
 
 type apiClient struct {
-	authnClient authn.APIClient
-	authzClient authz.APIClient
-	coreClient  core.APIClient
+	authnClient  authn.APIClient
+	authzClient  authz.APIClient
+	coreClient   core.APIClient
+	systemClient system.APIClient
 }
 
 // NewAPIClient returns a Brigade client.
@@ -29,9 +32,10 @@ func NewAPIClient(
 	opts *restmachinery.APIClientOptions,
 ) APIClient {
 	return &apiClient{
-		authnClient: authn.NewAPIClient(apiAddress, apiToken, opts),
-		authzClient: authz.NewAPIClient(apiAddress, apiToken, opts),
-		coreClient:  core.NewAPIClient(apiAddress, apiToken, opts),
+		authnClient:  authn.NewAPIClient(apiAddress, apiToken, opts),
+		authzClient:  authz.NewAPIClient(apiAddress, apiToken, opts),
+		coreClient:   core.NewAPIClient(apiAddress, apiToken, opts),
+		systemClient: system.NewAPIClient(apiAddress, apiToken, opts),
 	}
 }
 
@@ -45,4 +49,8 @@ func (a *apiClient) Authz() authz.APIClient {
 
 func (a *apiClient) Core() core.APIClient {
 	return a.coreClient
+}
+
+func (a *apiClient) System() system.APIClient {
+	return a.systemClient
 }

--- a/sdk/v2/api_client_test.go
+++ b/sdk/v2/api_client_test.go
@@ -20,4 +20,6 @@ func TestNewAPIClient(t *testing.T) {
 	require.Equal(t, client.(*apiClient).authzClient, client.Authz())
 	require.NotNil(t, client.(*apiClient).coreClient)
 	require.Equal(t, client.(*apiClient).coreClient, client.Core())
+	require.NotNil(t, client.(*apiClient).systemClient)
+	require.Equal(t, client.(*apiClient).systemClient, client.System())
 }


### PR DESCRIPTION
I noticed today that the system client was missing from the client tree. This PR adds it.