### PR TITLE
another improvement to how secrets are parsed from a JSON or YAML file

### DIFF
--- a/v2/cli/secret_commands_test.go
+++ b/v2/cli/secret_commands_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEnvVars(t *testing.T) {
+	testCases := []struct {
+		name           string
+		setup          func()
+		input          string
+		expectedResult string
+	}{
+		{
+			name:           "no substitutions",
+			input:          "foobar",
+			expectedResult: "foobar",
+		},
+		{
+			name:           "failed substitution",
+			input:          "${SUB}bar",
+			expectedResult: "bar",
+		},
+		{
+			name: "one substitution",
+			setup: func() {
+				os.Setenv("SUB", "foo")
+			},
+			input:          "${SUB}bar",
+			expectedResult: "foobar",
+		},
+		{
+			name: "multiple substitutions",
+			setup: func() {
+				os.Setenv("SUB1", "foo")
+				os.Setenv("SUB2", "bar")
+			},
+			input:          "${SUB1}${SUB2}",
+			expectedResult: "foobar",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.setup != nil {
+				testCase.setup()
+			}
+			require.Equal(t, testCase.expectedResult, resolveEnvVars(testCase.input))
+		})
+	}
+}


### PR DESCRIPTION
In the first pass at improving how secrets are parsed from a file, we could only handle the simplest substitutions from env vars.

For instance, this was ok:

```yaml
foo=${FOO}
```

But it's a safe assumption that at some point, someone will try something like the following, expecting it to work. They'd end up disappointed:

```yaml
foobar=my-${FOO}-${BAR}
```

This PR corrects this-- and adds a unit test for the function that performs these resolutions.