### PR TITLE
fix(login_command.go): remove extra spaces in login completion message

### DIFF
--- a/v2/cli/login_command.go
+++ b/v2/cli/login_command.go
@@ -121,14 +121,14 @@ func login(c *cli.Context) error {
 			return errors.Wrapf(
 				err,
 				"Error opening authentication URL using the system's default web "+
-					"browser.\n\nPlease visit  %s  to complete authentication.\n",
+					"browser.\n\nPlease visit %s to complete authentication.\n",
 				authURL,
 			)
 		}
 		return nil
 	}
 
-	fmt.Printf("Please visit  %s  to complete authentication.\n", authURL)
+	fmt.Printf("Please visit %s to complete authentication.\n", authURL)
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

* Removes the extra space padding around the url presented in the login completion message

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
