### PR TITLE
fix(Makefile): set ghr title to tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,7 @@ publish-cli: build-cli
 			-r $(GITHUB_REPO) \
 			-c $$(git rev-parse HEAD) \
 			-t $${GITHUB_TOKEN} \
+			-n ${VERSION} \
 			${VERSION} ./bin \
 	'
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* Explicitly sets the GitHub release title to match the release tag when using `ghr` (otherwise, it seems to auto-populate with tagged commit message)

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
