### PR TITLE
cli: remediate issues related to global flags

### DIFF
--- a/v2/cli/client.go
+++ b/v2/cli/client.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"github.com/pkg/errors"
-	"github.com/urfave/cli/v2"
 
 	"github.com/brigadecore/brigade/sdk/v2"
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
 )
 
-func getClient(c *cli.Context) (sdk.APIClient, error) {
+func getClient() (sdk.APIClient, error) {
 	cfg, err := getConfig()
 	if err != nil {
 		return nil, errors.Wrapf(
@@ -20,7 +19,7 @@ func getClient(c *cli.Context) (sdk.APIClient, error) {
 		cfg.APIAddress,
 		cfg.APIToken,
 		&restmachinery.APIClientOptions{
-			AllowInsecureConnections: c.Bool(flagInsecure),
+			AllowInsecureConnections: cfg.IgnoreCertErrors,
 		},
 	), nil
 }

--- a/v2/cli/client_test.go
+++ b/v2/cli/client_test.go
@@ -2,14 +2,12 @@ package main
 
 import (
 	"encoding/json"
-	"flag"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 )
 
 func TestGetClient(t *testing.T) {
@@ -33,9 +31,7 @@ func TestGetClient(t *testing.T) {
 	cfg, err := getConfig()
 	require.NoError(t, err)
 	require.Equal(t, testConfig, cfg)
-	client, err := getClient(
-		cli.NewContext(cli.NewApp(), &flag.FlagSet{}, nil),
-	)
+	client, err := getClient()
 	require.NoError(t, err)
 	require.NotNil(t, client)
 }

--- a/v2/cli/common.go
+++ b/v2/cli/common.go
@@ -11,6 +11,12 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+var nonInteractiveFlag = &cli.BoolFlag{
+	Name:    flagNonInteractive,
+	Aliases: []string{"n"},
+	Usage:   "Disable all interactive prompts",
+}
+
 // confirmed prompts the user to confirm an irreversible action and returns a
 // bool indicating assent (true) or dissent (false).
 func confirmed(c *cli.Context) (bool, error) {

--- a/v2/cli/config.go
+++ b/v2/cli/config.go
@@ -12,8 +12,9 @@ import (
 )
 
 type config struct {
-	APIAddress string `json:"apiAddress"`
-	APIToken   string `json:"apiToken"`
+	APIAddress       string `json:"apiAddress"`
+	APIToken         string `json:"apiToken"`
+	IgnoreCertErrors bool   `json:"ignoreCertErrors"`
 }
 
 var getHomeDir = homedir.Dir

--- a/v2/cli/event_commands.go
+++ b/v2/cli/event_commands.go
@@ -35,6 +35,7 @@ var eventCommand = &cli.Command{
 						"(required)",
 					Required: true,
 				},
+				nonInteractiveFlag,
 				&cli.BoolFlag{
 					Name:    flagYes,
 					Aliases: []string{"y"},
@@ -68,6 +69,7 @@ var eventCommand = &cli.Command{
 					Usage: "If set, will additionally abort and cancel events with " +
 						"their worker in a STARTING phase",
 				},
+				nonInteractiveFlag,
 				&cli.BoolFlag{
 					Name:    flagYes,
 					Aliases: []string{"y"},
@@ -152,6 +154,7 @@ var eventCommand = &cli.Command{
 						"(required)",
 					Required: true,
 				},
+				nonInteractiveFlag,
 				&cli.BoolFlag{
 					Name:    flagYes,
 					Aliases: []string{"y"},
@@ -232,6 +235,7 @@ var eventCommand = &cli.Command{
 					Usage: "If set, will delete events with their worker in an UNKNOWN " +
 						"phase; mutually exclusive with --any-phase and --terminal",
 				},
+				nonInteractiveFlag,
 				&cli.BoolFlag{
 					Name:    flagYes,
 					Aliases: []string{"y"},
@@ -284,6 +288,7 @@ var eventCommand = &cli.Command{
 					Usage: "If set, will retrieve events with their worker in a FAILED " +
 						"phase; mutually exclusive with  --terminal and --non-terminal",
 				},
+				nonInteractiveFlag,
 				&cli.BoolFlag{
 					Name: flagNonTerminal,
 					Usage: "If set, will retrieve events with their worker in any " +
@@ -409,7 +414,7 @@ func eventCreate(c *cli.Context) error {
 		Payload:   payload,
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -520,7 +525,7 @@ func eventList(c *cli.Context) error {
 		return err
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -610,7 +615,7 @@ func eventGet(c *cli.Context) error {
 		return err
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -698,7 +703,7 @@ func eventCancel(c *cli.Context) error {
 		return nil
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -733,7 +738,7 @@ func eventCancelMany(c *cli.Context) error {
 		return nil
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -763,7 +768,7 @@ func eventDelete(c *cli.Context) error {
 		return nil
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -834,7 +839,7 @@ func eventDeleteMany(c *cli.Context) error {
 		return nil
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -857,7 +862,7 @@ func eventClone(c *cli.Context) error {
 	id := c.String(flagID)
 	follow := c.Bool(flagFollow)
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -893,7 +898,7 @@ func eventRetry(c *cli.Context) error {
 	id := c.String(flagID)
 	follow := c.Bool(flagFollow)
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}

--- a/v2/cli/log_command.go
+++ b/v2/cli/log_command.go
@@ -52,7 +52,7 @@ func logs(c *cli.Context) error {
 		Follow: follow,
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}

--- a/v2/cli/login_command.go
+++ b/v2/cli/login_command.go
@@ -19,6 +19,12 @@ var loginCommand = &cli.Command{
 	Description: "By default, initiates authentication using a third-party " +
 		"identity provider. This may not be supported by all Brigade API servers.",
 	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:    flagInsecure,
+			Aliases: []string{"k"},
+			Usage:   "Allow insecure API server connections when using HTTPS",
+		},
+		nonInteractiveFlag,
 		&cli.StringFlag{
 			Name:    flagServer,
 			Aliases: []string{"s"},
@@ -104,8 +110,9 @@ func login(c *cli.Context) error {
 
 	if err := saveConfig(
 		config{
-			APIAddress: address,
-			APIToken:   tokenStr,
+			APIAddress:       address,
+			APIToken:         tokenStr,
+			IgnoreCertErrors: c.Bool(flagInsecure),
 		},
 	); err != nil {
 		return errors.Wrap(err, "error persisting configuration")

--- a/v2/cli/logout_command.go
+++ b/v2/cli/logout_command.go
@@ -14,7 +14,7 @@ var logoutCommand = &cli.Command{
 }
 
 func logout(c *cli.Context) error {
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}

--- a/v2/cli/main.go
+++ b/v2/cli/main.go
@@ -18,18 +18,6 @@ func main() {
 		version.Version(),
 		version.Commit(),
 	)
-	app.Flags = []cli.Flag{
-		&cli.BoolFlag{
-			Name:    flagInsecure,
-			Aliases: []string{"k"},
-			Usage:   "Allow insecure API server connections when using HTTPS",
-		},
-		&cli.BoolFlag{
-			Name:    flagNonInteractive,
-			Aliases: []string{"n"},
-			Usage:   "Disable all interactive prompts",
-		},
-	}
 	app.Commands = []*cli.Command{
 		eventCommand,
 		loginCommand,

--- a/v2/cli/project_commands.go
+++ b/v2/cli/project_commands.go
@@ -46,6 +46,7 @@ var projectCommand = &cli.Command{
 					Usage:    "Delete the specified project (required)",
 					Required: true,
 				},
+				nonInteractiveFlag,
 				&cli.BoolFlag{
 					Name:    flagYes,
 					Aliases: []string{"y"},
@@ -80,6 +81,7 @@ var projectCommand = &cli.Command{
 						"previous command back to the server to access the next page " +
 						"of results",
 				},
+				nonInteractiveFlag,
 			},
 			Action: projectList,
 		},
@@ -129,7 +131,7 @@ func projectCreate(c *cli.Context) error {
 		return errors.Wrapf(err, "error unmarshaling project file %s", filename)
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -153,7 +155,7 @@ func projectList(c *cli.Context) error {
 		return err
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -233,7 +235,7 @@ func projectGet(c *cli.Context) error {
 		return err
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -315,7 +317,7 @@ func projectUpdate(c *cli.Context) error {
 		return errors.New("project definition does not specify an ID")
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -344,7 +346,7 @@ func projectDelete(c *cli.Context) error {
 		return nil
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}

--- a/v2/cli/project_role_commands.go
+++ b/v2/cli/project_role_commands.go
@@ -110,6 +110,7 @@ var projectRolesCommands = &cli.Command{
 					Usage:    "List principals and their roles for the specified project",
 					Required: true,
 				},
+				nonInteractiveFlag,
 				&cli.StringFlag{
 					Name:    flagRole,
 					Aliases: []string{"r"},
@@ -186,7 +187,7 @@ func grantProjectRole(role libAuthz.Role) func(c *cli.Context) error {
 			)
 		}
 
-		client, err := getClient(c)
+		client, err := getClient()
 		if err != nil {
 			return err
 		}
@@ -265,7 +266,7 @@ func listProjectRoles(c *cli.Context) error {
 		}
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -352,7 +353,7 @@ func revokeProjectRole(role libAuthz.Role) func(c *cli.Context) error {
 			)
 		}
 
-		client, err := getClient(c)
+		client, err := getClient()
 		if err != nil {
 			return err
 		}

--- a/v2/cli/role_commands.go
+++ b/v2/cli/role_commands.go
@@ -110,6 +110,7 @@ var rolesCommands = &cli.Command{
 					Aliases: []string{"r"},
 					Usage:   "Narrow results to the specified role",
 				},
+				nonInteractiveFlag,
 				&cli.StringFlag{
 					Name:    flagServiceAccount,
 					Aliases: []string{"s"},
@@ -202,7 +203,7 @@ func grantSystemRole(role libAuthz.Role) func(c *cli.Context) error {
 			roleAssignment.Scope = c.String(flagSource)
 		}
 
-		client, err := getClient(c)
+		client, err := getClient()
 		if err != nil {
 			return err
 		}
@@ -272,7 +273,7 @@ func listSystemRoles(c *cli.Context) error {
 		}
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -366,7 +367,7 @@ func revokeSystemRole(role libAuthz.Role) func(c *cli.Context) error {
 			roleAssignment.Scope = c.String(flagSource)
 		}
 
-		client, err := getClient(c)
+		client, err := getClient()
 		if err != nil {
 			return err
 		}

--- a/v2/cli/secret_commands.go
+++ b/v2/cli/secret_commands.go
@@ -41,6 +41,7 @@ var secretsCommand = &cli.Command{
 					Usage:    "Retrieve secrets for the specified project (required)",
 					Required: true,
 				},
+				nonInteractiveFlag,
 			},
 			Action: secretsList,
 		},
@@ -103,7 +104,7 @@ func secretsList(c *cli.Context) error {
 		return err
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -225,7 +226,7 @@ func secretsSet(c *cli.Context) error {
 		secrets[kvTokens[0]] = kvTokens[1]
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -252,7 +253,7 @@ func secretsUnset(c *cli.Context) error {
 	projectID := c.String(flagID)
 	keys := c.StringSlice(flagUnset)
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}

--- a/v2/cli/service_account_commands.go
+++ b/v2/cli/service_account_commands.go
@@ -68,6 +68,7 @@ var serviceAccountCommand = &cli.Command{
 						"previous command back to the server to access the next page " +
 						"of results",
 				},
+				nonInteractiveFlag,
 			},
 			Action: serviceAccountList,
 		},
@@ -104,7 +105,7 @@ func serviceAccountCreate(c *cli.Context) error {
 	description := c.String(flagDescription)
 	id := c.String(flagID)
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -139,7 +140,7 @@ func serviceAccountList(c *cli.Context) error {
 		return err
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -223,7 +224,7 @@ func serviceAccountGet(c *cli.Context) error {
 		return err
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -276,7 +277,7 @@ func serviceAccountGet(c *cli.Context) error {
 func serviceAccountLock(c *cli.Context) error {
 	id := c.String(flagID)
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -293,7 +294,7 @@ func serviceAccountLock(c *cli.Context) error {
 func serviceAccountUnlock(c *cli.Context) error {
 	id := c.String(flagID)
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}

--- a/v2/cli/user_commands.go
+++ b/v2/cli/user_commands.go
@@ -43,6 +43,7 @@ var userCommand = &cli.Command{
 						"previous command back to the server to access the next page " +
 						"of results",
 				},
+				nonInteractiveFlag,
 			},
 			Action: userList,
 		},
@@ -82,7 +83,7 @@ func userList(c *cli.Context) error {
 		return err
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -163,7 +164,7 @@ func userGet(c *cli.Context) error {
 		return err
 	}
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -212,7 +213,7 @@ func userGet(c *cli.Context) error {
 func userLock(c *cli.Context) error {
 	id := c.String(flagID)
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
@@ -229,7 +230,7 @@ func userLock(c *cli.Context) error {
 func userUnlock(c *cli.Context) error {
 	id := c.String(flagID)
 
-	client, err := getClient(c)
+	client, err := getClient()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #1336 

I explored switching from urfave/cli to spf13/cobra and found cobra to be much more onerous and have limitations I didn't care for.

This inspired me to find a totally different solution.

We only use two global flags-- one that is similar to `curl -k` for specifying that cert errors should be ignored, and another that disables interactive prompts-- useful for people who might be scripting against the CLI (even though I wish people would script against the API instead).

For the insecure flag, it seems we could stop having that as a global flag and make it a flag specific to the login command. Then we can just remember (in a local configuration file) whether cert errors are ignored or not, the same way we remember what server you're talking to and what token you're using.

For the non-interactive flag, despite being global, it's only useful for a small number of commands that potentially have an interactive component to them. It's easy enough to move this flag from the global level down to the few commands it's applicable to.

In the end, the CLI isn't, strictly speaking, any more forgiving about the positioning of flags than it was prior. Global flags still ave to precede subcommands and command-specific flags still must follow sub-commands-- except now we no long er _have_ any global flags, so we land in a spot where _all_ flags follow the subcommands, and that seems simple enough and not prone to generating any confusion.