### PR TITLE
feat(errors.go): add Reason field to ErrNotFound; use in job logs scenario

### DIFF
--- a/sdk/v2/meta/errors.go
+++ b/sdk/v2/meta/errors.go
@@ -56,10 +56,15 @@ type ErrNotFound struct {
 }
 
 func (e *ErrNotFound) Error() string {
-	if e.Reason != "" {
+	if e.Type == "" && e.ID == "" && e.Reason != "" {
 		return e.Reason
 	}
-	return fmt.Sprintf("%s %q not found.", e.Type, e.ID)
+
+	msg := fmt.Sprintf("%s %q not found", e.Type, e.ID)
+	if e.Reason != "" {
+		return msg + fmt.Sprintf(": %s", e.Reason)
+	}
+	return msg + "."
 }
 
 // ErrConflict represents an error wherein a request cannot be completed because

--- a/sdk/v2/meta/errors.go
+++ b/sdk/v2/meta/errors.go
@@ -50,9 +50,15 @@ type ErrNotFound struct {
 	// ID is the identifier of the resource of type Type that could not be
 	// located.
 	ID string `json:"id,omitempty"`
+	// Reason is a natural language explanation around why the resource could not
+	// be located.
+	Reason string `json:"reason,omitempty"`
 }
 
 func (e *ErrNotFound) Error() string {
+	if e.Reason != "" {
+		return e.Reason
+	}
 	return fmt.Sprintf("%s %q not found.", e.Type, e.ID)
 }
 

--- a/v2/apiserver/internal/core/logs.go
+++ b/v2/apiserver/internal/core/logs.go
@@ -178,7 +178,13 @@ func (l *logsService) Stream(
 			if err != nil {
 				if _, ok := err.(*meta.ErrNotFound); ok {
 					return nil,
-						fmt.Errorf("error retrieving logs for job %q", job.Name)
+						&meta.ErrNotFound{
+							Reason: fmt.Sprintf(
+								"Unable to retrieve logs for job %q: the "+
+									"original logs inherited by this job no longer exist.",
+								job.Name,
+							),
+						}
 				}
 				return nil,
 					errors.Wrapf(

--- a/v2/apiserver/internal/meta/errors.go
+++ b/v2/apiserver/internal/meta/errors.go
@@ -113,9 +113,15 @@ type ErrNotFound struct {
 	// ID is the identifier of the resource of type Type that could not be
 	// located.
 	ID string `json:"id,omitempty"`
+	// Reason is a natural language explanation around why the resource could not
+	// be located.
+	Reason string `json:"reason,omitempty"`
 }
 
 func (e *ErrNotFound) Error() string {
+	if e.Reason != "" {
+		return e.Reason
+	}
 	return fmt.Sprintf("%s %q not found.", e.Type, e.ID)
 }
 

--- a/v2/apiserver/internal/meta/errors.go
+++ b/v2/apiserver/internal/meta/errors.go
@@ -119,10 +119,15 @@ type ErrNotFound struct {
 }
 
 func (e *ErrNotFound) Error() string {
-	if e.Reason != "" {
+	if e.Type == "" && e.ID == "" && e.Reason != "" {
 		return e.Reason
 	}
-	return fmt.Sprintf("%s %q not found.", e.Type, e.ID)
+
+	msg := fmt.Sprintf("%s %q not found", e.Type, e.ID)
+	if e.Reason != "" {
+		return msg + fmt.Sprintf(": %s", e.Reason)
+	}
+	return msg + "."
 }
 
 // MarshalJSON amends ErrNotFound instances with type metadata.


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds a `Reason` field to the `ErrNotFound` struct for instances where further context/explanation is helpful
* Use this new field in the scenario when inherited job logs cannot be found due to the original event no longer existing

Closes https://github.com/brigadecore/brigade/issues/1403

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
