### PR TITLE
feat(observer): enforce job timeout

### DIFF
--- a/v2/apiserver/internal/core/kubernetes/substrate.go
+++ b/v2/apiserver/internal/core/kubernetes/substrate.go
@@ -1172,6 +1172,9 @@ func (s *substrate) createJobPod(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      myk8s.JobPodName(event.ID, jobName),
 			Namespace: project.Kubernetes.Namespace,
+			Annotations: map[string]string{
+				myk8s.AnnotationTimeoutDuration: fmt.Sprint(jobSpec.TimeoutDuration),
+			},
 			Labels: map[string]string{
 				myk8s.LabelComponent: myk8s.LabelKeyJob,
 				myk8s.LabelProject:   event.ProjectID,

--- a/v2/apiserver/internal/core/rest/jobs_endpoints.go
+++ b/v2/apiserver/internal/core/rest/jobs_endpoints.go
@@ -56,6 +56,12 @@ func (j *JobsEndpoints) Register(router *mux.Router) {
 		"/v2/events/{eventID}/worker/jobs/{jobName}/cleanup",
 		j.AuthFilter.Decorate(j.cleanup),
 	).Methods(http.MethodPut)
+
+	// Timeout a job
+	router.HandleFunc(
+		"/v2/events/{eventID}/worker/jobs/{jobName}/timeout",
+		j.AuthFilter.Decorate(j.timeout),
+	).Methods(http.MethodPut)
 }
 
 func (j *JobsEndpoints) create(w http.ResponseWriter, r *http.Request) {
@@ -201,6 +207,26 @@ func (j *JobsEndpoints) cleanup(
 			R: r,
 			EndpointLogic: func() (interface{}, error) {
 				return nil, j.Service.Cleanup(
+					r.Context(),
+					mux.Vars(r)["eventID"],
+					mux.Vars(r)["jobName"],
+				)
+			},
+			SuccessCode: http.StatusOK,
+		},
+	)
+}
+
+func (j *JobsEndpoints) timeout(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	restmachinery.ServeRequest(
+		restmachinery.InboundRequest{
+			W: w,
+			R: r,
+			EndpointLogic: func() (interface{}, error) {
+				return nil, j.Service.Timeout(
 					r.Context(),
 					mux.Vars(r)["eventID"],
 					mux.Vars(r)["jobName"],

--- a/v2/apiserver/schemas/job.json
+++ b/v2/apiserver/schemas/job.json
@@ -120,9 +120,11 @@
 						"$ref": "#/definitions/containerSpec"
 					}
 				},
-				"timeoutSeconds": {
-					"type": "integer",
-					"description": "Job timeout in seconds"
+				"timeoutDuration": {
+					"type": "string",
+					"description": "Job timeout string expressed as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '3.14s' or '2h45m'",
+					"pattern": "^([0-9]+(\\.[0-9]*)?(ns|us|µs|ms|s|m|h))+$",
+					"minLength": 2
 				},
 				"host": {
 					"$ref": "#/definitions/host"

--- a/v2/brigadier-polyfill/src/jobs.ts
+++ b/v2/brigadier-polyfill/src/jobs.ts
@@ -39,7 +39,7 @@ export class Job extends BrigadierJob {
           spec: {
             primaryContainer: this.primaryContainer,
             sidecarContainers: this.sidecarContainers,
-            timeoutSeconds: this.timeout,
+            timeoutDuration: this.timeoutSeconds + "s",
             host: this.host
           }
         },

--- a/v2/brigadier-polyfill/test/jobs.ts
+++ b/v2/brigadier-polyfill/test/jobs.ts
@@ -27,7 +27,7 @@ describe("jobs", () => {
         assert.equal(job.name, "my-name")
         assert.deepEqual(new Container("debian:latest"), job.primaryContainer)
         assert.deepEqual({}, job.sidecarContainers)
-        assert.equal(1000 * 60 * 15, job.timeout)
+        assert.equal(60 * 15, job.timeoutSeconds)
         assert.deepEqual(new JobHost(), job.host)
         assert.isDefined(job.logger)
       })

--- a/v2/brigadier/src/jobs.ts
+++ b/v2/brigadier/src/jobs.ts
@@ -2,7 +2,7 @@ import { Event } from "./events"
 import { ConcurrentGroup, SerialGroup } from "./groups"
 import { Runnable } from "./runnables"
 
-const defaultTimeout: number = 1000 * 60 * 15
+const defaultTimeoutSeconds: number = 60 * 15
 
 /**
  * A Brigade job.
@@ -33,11 +33,11 @@ export class Job implements Runnable {
   public sidecarContainers: { [key: string]: Container } = {}
 
   /**
-   * The duration, in milliseconds, after which Brigade should automatically
+   * The duration, in seconds, after which Brigade should automatically
    * terminate and fail the job if it has not completed. The default is 15
    * minutes.
    */
-  public timeout: number = defaultTimeout
+  public timeoutSeconds: number = defaultTimeoutSeconds
 
   /** Specifies requirements for the job execution environment. */
   public host: JobHost = new JobHost()

--- a/v2/brigadier/test/jobs.ts
+++ b/v2/brigadier/test/jobs.ts
@@ -28,7 +28,7 @@ describe("jobs", () => {
         assert.equal(job.name, "my-name")
         assert.deepEqual(new Container("debian:latest"), job.primaryContainer)
         assert.deepEqual({}, job.sidecarContainers)
-        assert.equal(1000 * 60 * 15, job.timeout)
+        assert.equal(60 * 15, job.timeoutSeconds)
         assert.deepEqual(new JobHost(), job.host)
       })
     })

--- a/v2/internal/kubernetes/common.go
+++ b/v2/internal/kubernetes/common.go
@@ -7,6 +7,8 @@ import (
 )
 
 const (
+	AnnotationTimeoutDuration = "brigade.sh/timeoutDuration"
+
 	LabelComponent = "brigade.sh/component"
 	LabelEvent     = "brigade.sh/event"
 	LabelJob       = "brigade.sh/job"

--- a/v2/observer/jobs_test.go
+++ b/v2/observer/jobs_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -104,6 +105,8 @@ func TestSyncJobPod(t *testing.T) {
 				},
 			},
 			observer: &observer{
+				timedPodsSet:       map[string]context.CancelFunc{},
+				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
 				updateJobStatusFn: func(
 					ctx context.Context,
 					eventID string,
@@ -132,6 +135,8 @@ func TestSyncJobPod(t *testing.T) {
 				},
 			},
 			observer: &observer{
+				timedPodsSet:       map[string]context.CancelFunc{},
+				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
 				updateJobStatusFn: func(
 					ctx context.Context,
 					eventID string,
@@ -157,6 +162,8 @@ func TestSyncJobPod(t *testing.T) {
 				},
 			},
 			observer: &observer{
+				timedPodsSet:       map[string]context.CancelFunc{},
+				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
 				updateJobStatusFn: func(
 					ctx context.Context,
 					eventID string,
@@ -178,6 +185,10 @@ func TestSyncJobPod(t *testing.T) {
 		{
 			name: "pod phase is running and container[0] succeeded",
 			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nombre",
+					Namespace: "ns",
+				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{Name: "foo"}},
 				},
@@ -199,6 +210,10 @@ func TestSyncJobPod(t *testing.T) {
 				},
 			},
 			observer: &observer{
+				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
+				timedPodsSet: map[string]context.CancelFunc{
+					"ns:nombre": func() {},
+				},
 				updateJobStatusFn: func(
 					ctx context.Context,
 					eventID string,
@@ -221,6 +236,8 @@ func TestSyncJobPod(t *testing.T) {
 				},
 			},
 			observer: &observer{
+				timedPodsSet:       map[string]context.CancelFunc{},
+				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
 				updateJobStatusFn: func(
 					ctx context.Context,
 					eventID string,
@@ -239,6 +256,10 @@ func TestSyncJobPod(t *testing.T) {
 		{
 			name: "pod phase is running and container[0] failed",
 			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nombre",
+					Namespace: "ns",
+				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{Name: "foo"}},
 				},
@@ -260,6 +281,10 @@ func TestSyncJobPod(t *testing.T) {
 				},
 			},
 			observer: &observer{
+				timedPodsSet: map[string]context.CancelFunc{
+					"ns:nombre": func() {},
+				},
+				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
 				updateJobStatusFn: func(
 					ctx context.Context,
 					eventID string,
@@ -277,11 +302,19 @@ func TestSyncJobPod(t *testing.T) {
 		{
 			name: "pod phase is succeeded",
 			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nombre",
+					Namespace: "ns",
+				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodSucceeded,
 				},
 			},
 			observer: &observer{
+				timedPodsSet: map[string]context.CancelFunc{
+					"ns:nombre": func() {},
+				},
+				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
 				updateJobStatusFn: func(
 					ctx context.Context,
 					eventID string,
@@ -297,11 +330,19 @@ func TestSyncJobPod(t *testing.T) {
 		{
 			name: "pod phase is failed",
 			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nombre",
+					Namespace: "ns",
+				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodFailed,
 				},
 			},
 			observer: &observer{
+				timedPodsSet: map[string]context.CancelFunc{
+					"ns:nombre": func() {},
+				},
+				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
 				updateJobStatusFn: func(
 					ctx context.Context,
 					eventID string,
@@ -317,11 +358,19 @@ func TestSyncJobPod(t *testing.T) {
 		{
 			name: "pod phase is unknown",
 			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nombre",
+					Namespace: "ns",
+				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodUnknown,
 				},
 			},
 			observer: &observer{
+				timedPodsSet: map[string]context.CancelFunc{
+					"ns:nombre": func() {},
+				},
+				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
 				updateJobStatusFn: func(
 					ctx context.Context,
 					eventID string,
@@ -419,6 +468,191 @@ func TestDeleteJobResources(t *testing.T) {
 				testEventID,
 				testJobName,
 			)
+		})
+	}
+}
+
+func TestStartJobPodTimer(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pod      *corev1.Pod
+		observer *observer
+	}{
+		{
+			name: "pod already in terminal state",
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "nombre",
+					Namespace: "ns",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodSucceeded,
+				},
+			},
+			observer: &observer{
+				timedPodsSet: map[string]context.CancelFunc{
+					"ns:nombre": func() {},
+				},
+			},
+		},
+		{
+			name: "pod has no timeout annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "nombre",
+					Namespace: "ns",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			observer: &observer{
+				timedPodsSet: map[string]context.CancelFunc{
+					"ns:nombre": func() {},
+				},
+			},
+		},
+		{
+			name: "pod has invalid timeout annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "nombre",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						myk8s.AnnotationTimeoutDuration: "1",
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			observer: &observer{
+				timedPodsSet: map[string]context.CancelFunc{
+					"ns:nombre": func() {},
+				},
+				errFn: func(i ...interface{}) {
+					require.Len(t, i, 1)
+					err, ok := i[0].(error)
+					require.True(t, ok)
+					require.Contains(t, err.Error(), "unable to parse timeout duration")
+				},
+			},
+		},
+		{
+			name: "timed pod times out; api call fails",
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "nombre",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						myk8s.AnnotationTimeoutDuration: "1ms",
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			observer: &observer{
+				timedPodsSet: map[string]context.CancelFunc{
+					"ns:nombre": func() {},
+				},
+				timeoutJobFn: func(
+					ctx context.Context,
+					eventID string,
+					jobName string,
+				) error {
+					return errors.New("something went wrong")
+				},
+				errFn: func(i ...interface{}) {
+					require.Len(t, i, 1)
+					err, ok := i[0].(error)
+					require.True(t, ok)
+					require.Contains(t, err.Error(), "something went wrong")
+					require.Contains(t, err.Error(), "error timing out job")
+				},
+			},
+		},
+		{
+			name: "timed pod times out; success",
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "nombre",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						myk8s.AnnotationTimeoutDuration: "1ms",
+					},
+					Labels: map[string]string{
+						myk8s.LabelJob: "italian",
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			observer: &observer{
+				timedPodsSet: map[string]context.CancelFunc{
+					"ns:nombre": func() {},
+				},
+				timeoutJobFn: func(
+					ctx context.Context,
+					eventID string,
+					jobName string,
+				) error {
+					require.Equal(t, jobName, "italian")
+					return nil
+				},
+				errFn: func(i ...interface{}) {
+					require.Fail(
+						t,
+						"errFn should not have been called, but was",
+					)
+				},
+			},
+		},
+		{
+			name: "timed pod context canceled",
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "nombre",
+					Namespace: "ns",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			observer: &observer{
+				timedPodsSet: map[string]context.CancelFunc{
+					"ns:nombre": func() {},
+				},
+				timeoutJobFn: func(
+					ctx context.Context,
+					eventID string,
+					jobName string,
+				) error {
+					require.Fail(
+						t,
+						"timeoutJobFn should not have been called, but was",
+					)
+					return nil
+				},
+				errFn: func(i ...interface{}) {
+					require.Fail(
+						t,
+						"errFn should not have been called, but was",
+					)
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer func() {
+				cancel()
+				require.Empty(t, testCase.observer.timedPodsSet)
+			}()
+
+			testCase.observer.startJobPodTimer(ctx, testCase.pod)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds enforcement of timeout logic for jobs

This comprises the Job portion of https://github.com/brigadecore/brigade/issues/1378

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
