### PR TITLE
ref(jobs.go): re-create retry job if config differs

### DIFF
--- a/v2/apiserver/internal/core/jobs.go
+++ b/v2/apiserver/internal/core/jobs.go
@@ -279,24 +279,24 @@ func (j *jobsService) Create(
 		return errors.Wrapf(err, "error retrieving event %q from store", eventID)
 	}
 	if originalJob, ok := event.Worker.Job(job.Name); ok {
-		// If we're dealing with a job intended for retry, inspect to be sure the
-		// provided job configuration matches the original.  If so, we will skip
-		// re-scheduling and inherit the original's results.
-		if event.Labels != nil && event.Labels[RetryLabelKey] != "" {
-			if reflect.DeepEqual(originalJob, job) {
-				return nil
+		// If this is not a retry event, return ErrConflict.
+		if event.Labels == nil || event.Labels[RetryLabelKey] == "" {
+			return &meta.ErrConflict{
+				Type: JobKind,
+				ID:   job.Name,
+				Reason: fmt.Sprintf(
+					"Event %q already has a job named %q.",
+					eventID,
+					job.Name,
+				),
 			}
 		}
-		// We have a match and this isn't a retry or this is a retry and
-		// the job differs in some way, return an error.
-		return &meta.ErrConflict{
-			Type: JobKind,
-			ID:   job.Name,
-			Reason: fmt.Sprintf(
-				"Event %q already has a job named %q.",
-				eventID,
-				job.Name,
-			),
+
+		// Else, check to see if the job configurations match.
+		// If they do, return and inherit the original's results.
+		// Otherwise, proceed with the creation of the newer job.
+		if reflect.DeepEqual(originalJob, job) {
+			return nil
 		}
 	}
 

--- a/v2/apiserver/internal/core/jobs.go
+++ b/v2/apiserver/internal/core/jobs.go
@@ -279,9 +279,7 @@ func (j *jobsService) Create(
 		return errors.Wrapf(err, "error retrieving event %q from store", eventID)
 	}
 	if originalJob, ok := event.Worker.Job(job.Name); ok {
-		// If this is not a retry event or the original job hasn't been inherited
-		// (if it had, the LogsEventID field would be non-empty), return
-		// ErrConflict.
+		// If this is not a retry event, return ErrConflict.
 		if event.Labels == nil || event.Labels[RetryLabelKey] == "" {
 			return &meta.ErrConflict{
 				Type: JobKind,
@@ -299,7 +297,7 @@ func (j *jobsService) Create(
 		// Otherwise, proceed with the re-creation of the job *if* it has
 		// been inherited previously (LogsEventID field non-empty) -- return
 		// ErrConflict if it hasn't been inherited.
-		if reflect.DeepEqual(originalJob, job) {
+		if reflect.DeepEqual(originalJob.Spec, job.Spec) {
 			return nil
 		} else if originalJob.Status == nil ||
 			originalJob.Status.LogsEventID == "" {

--- a/v2/apiserver/internal/core/jobs_test.go
+++ b/v2/apiserver/internal/core/jobs_test.go
@@ -487,11 +487,34 @@ func TestJobsServiceCreateRetry(t *testing.T) {
 						}, nil
 					},
 				},
+				projectsStore: &mockProjectsStore{
+					GetFn: func(context.Context, string) (Project, error) {
+						return Project{}, nil
+					},
+				},
+				jobsStore: &mockJobsStore{
+					CreateFn: func(context.Context, string, Job) error {
+						return nil
+					},
+				},
+				substrate: &mockSubstrate{
+					StoreJobEnvironmentFn: func(
+						_ context.Context,
+						_ Project,
+						_ string,
+						_ string,
+						jobSpec JobSpec,
+					) error {
+						return nil
+					},
+					ScheduleJobFn: func(context.Context, Project, Event, string) error {
+						return nil
+					},
+				},
 			},
 			workspaceMountPath: "",
 			assertions: func(err error) {
-				require.Error(t, err)
-				require.IsType(t, &meta.ErrConflict{}, err)
+				require.NoError(t, err)
 			},
 		},
 		{

--- a/v2/apiserver/internal/core/jobs_test.go
+++ b/v2/apiserver/internal/core/jobs_test.go
@@ -454,7 +454,60 @@ func TestJobsServiceCreateRetry(t *testing.T) {
 		assertions         func(error)
 	}{
 		{
-			name: "job retry - not equivalent",
+			name: "not a retry; same name",
+			service: &jobsService{
+				authorize: libAuthz.AlwaysAuthorize,
+				eventsStore: &mockEventsStore{
+					GetFn: func(context.Context, string) (Event, error) {
+						return Event{
+							Worker: Worker{
+								Jobs: []Job{
+									{
+										Name: testJobName,
+									},
+								},
+							},
+						}, nil
+					},
+				},
+			},
+			workspaceMountPath: "",
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrConflict{}, err)
+				require.Contains(t, err.Error(), "already has a job")
+			},
+		},
+		{
+			name: "is a retry; same name; job not inherited",
+			service: &jobsService{
+				authorize: libAuthz.AlwaysAuthorize,
+				eventsStore: &mockEventsStore{
+					GetFn: func(context.Context, string) (Event, error) {
+						return Event{
+							Labels: map[string]string{
+								RetryLabelKey: testEventID,
+							},
+							Worker: Worker{
+								Jobs: []Job{
+									{
+										Name: testJobName,
+									},
+								},
+							},
+						}, nil
+					},
+				},
+			},
+			workspaceMountPath: "",
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrConflict{}, err)
+				require.Contains(t, err.Error(), "already has a non-inherited job")
+			},
+		},
+		{
+			name: "inherited job retry - not equivalent",
 			service: &jobsService{
 				authorize: libAuthz.AlwaysAuthorize,
 				eventsStore: &mockEventsStore{
@@ -479,7 +532,8 @@ func TestJobsServiceCreateRetry(t *testing.T) {
 											},
 										},
 										Status: &JobStatus{
-											Phase: JobPhaseSucceeded,
+											LogsEventID: "abc123",
+											Phase:       JobPhaseSucceeded,
 										},
 									},
 								},


### PR DESCRIPTION
**What this PR does / why we need it**:

* Add logic to re-create a job on a retried event if the configuration has changed.

There's one outstanding corner case that would remain.  Currently, this would allow multiple jobs with the same name but differing configuration to be re-created (on a retry event).  I'm wondering if we remove this possibility by putting the responsibility of ensuring there are no duplicate entries in the Worker.Jobs list to the underlying data store.  Currently, we use mongodb and utilize a [$push](https://github.com/brigadecore/brigade/blob/v2/v2/apiserver/internal/core/mongodb/jobs_store.go#L37) directive to add a job to a worker in the store (which allows duplicates).  We could instead change to [$addToSet](https://docs.mongodb.com/manual/reference/operator/update/addToSet/) to ensure only one is ever added (first one wins).  WDYT @krancour ?

Closes https://github.com/brigadecore/brigade/issues/1402

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
