### PR TITLE
Refresh quickstart and installation instructions for v2

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -24,7 +24,7 @@ relativeURLs = "true"
     weight = 21
     parent = "intro"
     [[menu.index]]
-    name = "Quickstart"
+    name = "QuickStart"
     url = "/intro/quickstart/"
     weight = 22
     parent = "intro"

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,16 +1,26 @@
 ---
-title: Brigade Documentation
+title: Brigade 2.0 Documentation
 description: Homepage of the Brigade Documentation
 ---
 
 # Brigade Documentation
 
-Everything you need to know about Brigade.  
+Everything you need to know about Brigade.
+
+If you haven't used Brigade before, welcome! 🎉
+Brigade 2.0 has a new design that makes learning and interacting with Brigade easier than ever before.
+It is now a first-class experience that doesn't require familiarity with Kubernetes, so you can quickly be productive without a steep learning curve.
+
+For those who are migrating from Brigade 1.0, while there are some breaking changes, overall it should feel familiar.
+Migration instructions will be forthcoming in the coming weeks, so watch our [blog] or join us on the [#brigade channel][channel] on the [Kubernetes Slack][slack] for when that's available.
 
 ### First Steps
 
-Are you new to Brigade or to testing applications on Kubernetes? [This is the place to start!](intro/index.md)
+Try our [QuickStart] to install Brigade and walk through setting up your first project.
 
+<!-- Commenting out content that we have not migrated to v2 yet -->
+
+<!--
 ### Topic Guides
 
 Learn about alternative methods of installation, integration with other tools, and
@@ -45,3 +55,9 @@ Brigade-related projects and tools.
 - [bit-brigade](https://bitbucket.org/lukepatrick/bit-brigade) provides an example project using 
   BitBucket as a source repository
 - [minio-brigade](https://github.com/lukepatrick/minio-brigade) examples of storing artifacts in object storage (minio)
+-->
+
+[blog]: https://blog.brigade.sh/
+[channel]: https://kubernetes.slack.com/messages/C87MF1RFD
+[slack]: https://slack.k8s.io/ 
+[QuickStart]: /intro/quickstart/

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -9,7 +9,8 @@ Everything you need to know about Brigade.
 
 If you haven't used Brigade before, welcome! 🎉
 Brigade 2.0 has a new design that makes learning and interacting with Brigade easier than ever before.
-It is now a first-class experience that doesn't require familiarity with Kubernetes, so you can quickly be productive without a steep learning curve.
+Brigade now has a first-class end-user experience that doesn't require familiarity with Kubernetes, so you can quickly be productive without a steep learning curve.
+Since it is still an application installed on Kubernetes, administrators, and those installing Brigade, will still need to know how to install and configure applications on Kubernetes.
 
 For those who are migrating from Brigade 1.0, while there are some breaking changes, overall it should feel familiar.
 Migration instructions will be forthcoming in the coming weeks, so watch our [blog] or join us on the [#brigade channel][channel] on the [Kubernetes Slack][slack] for when that's available.

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,27 +1,16 @@
 ---
-title: Brigade 2.0 Documentation
+title: Brigade Documentation
 description: Homepage of the Brigade Documentation
 ---
 
 # Brigade Documentation
 
-Everything you need to know about Brigade.
-
-If you haven't used Brigade before, welcome! 🎉
-Brigade 2.0 has a new design that makes learning and interacting with Brigade easier than ever before.
-Brigade now has a first-class end-user experience that doesn't require familiarity with Kubernetes, so you can quickly be productive without a steep learning curve.
-Since it is still an application installed on Kubernetes, administrators, and those installing Brigade, will still need to know how to install and configure applications on Kubernetes.
-
-For those who are migrating from Brigade 1.0, while there are some breaking changes, overall it should feel familiar.
-Migration instructions will be forthcoming in the coming weeks, so watch our [blog] or join us on the [#brigade channel][channel] on the [Kubernetes Slack][slack] for when that's available.
+Everything you need to know about Brigade.  
 
 ### First Steps
 
-Try our [QuickStart] to install Brigade and walk through setting up your first project.
+Are you new to Brigade or to testing applications on Kubernetes? [This is the place to start!](intro/index.md)
 
-<!-- Commenting out content that we have not migrated to v2 yet -->
-
-<!--
 ### Topic Guides
 
 Learn about alternative methods of installation, integration with other tools, and
@@ -56,9 +45,3 @@ Brigade-related projects and tools.
 - [bit-brigade](https://bitbucket.org/lukepatrick/bit-brigade) provides an example project using 
   BitBucket as a source repository
 - [minio-brigade](https://github.com/lukepatrick/minio-brigade) examples of storing artifacts in object storage (minio)
--->
-
-[blog]: https://blog.brigade.sh/
-[channel]: https://kubernetes.slack.com/messages/C87MF1RFD
-[slack]: https://slack.k8s.io/ 
-[QuickStart]: /intro/quickstart/

--- a/docs/content/intro/_index.md
+++ b/docs/content/intro/_index.md
@@ -6,6 +6,7 @@ aliases:
   - /index.md
   - /intro/index.md
   - /intro/index/
+weight: 10
 ---
 
 # Getting Started
@@ -15,7 +16,8 @@ New to Brigade or to CI systems in general? Well, you came to the right place: r
 ## Table of Contents
 
 - [Brigade at a glance](overview)
-- [Quick Install Guide](install)
+- [QuickStart](quickstart)  
+- [Installation Guide](install)
 - [Writing your first CI pipeline, part 1](tutorial01)
 - [Writing your first CI pipeline, part 2](tutorial02)
 - [Writing your first CI pipeline, part 3](tutorial03)

--- a/docs/content/intro/install.md
+++ b/docs/content/intro/install.md
@@ -24,8 +24,8 @@ Before you can install Brigade, ensure that you have the [prerequisites](#prereq
   If you are using Brigade in a local development environment, the [QuickStart] demonstrates how to access a local KinD or Minikube cluster.
 * [Helm] CLI v3+ installed.
 * [kubectl] CLI installed.
-* Free disk space.  
-  The installation requires sufficient free disk space and will fail if your disk is nearly full.
+* Free disk space on the cluster nodes.  
+  The installation requires sufficient free disk space and will fail if a cluster node disk is nearly full.
 
 [Kubernetes cluster]: https://kubernetes.io/docs/setup/
 [Helm]: https://helm.sh/docs/intro/install/
@@ -157,11 +157,11 @@ Note that this is just one way of configuring Brigade to receive inbound connect
 
 ## Troubleshooting
 
-### Brigade Installation does not Finish Successfully
+### Brigade installation does not finish successfully
 
-A common cause for failed Brigade deployments is either low disk space on your computer, or the amount of disk space allocated to Docker Desktop is nearly full.
+A common cause for failed Brigade deployments is either low disk space on the cluster node, or the amount of disk space allocated to Docker Desktop is nearly full.
 
-Check if that is the problem by looking at the logs for Brigade's monogdb and artemis pods.
+Check if that is the problem by looking at the logs for Brigade's mongodb and artemis pods.
 If the logs include "No space left on device" or "Disk Full!", then you need to free up disk space and retry the installation.
 Running `docker system prune` is one way to recover disk space for Docker.
 

--- a/docs/content/intro/install.md
+++ b/docs/content/intro/install.md
@@ -65,7 +65,7 @@ $env:PATH+=";$env:USERPROFILE\bin"
 
 1. Enable Helm's experimental OCI support by setting the HELM_EXPERIMENTAL_OCI environment variable to 1.
 
-    **bash**
+    **posix**
     ```bash
     export HELM_EXPERIMENTAL_OCI=1
     ```
@@ -77,7 +77,7 @@ $env:PATH+=";$env:USERPROFILE\bin"
 
 1. Create a directory to store the Brigade Helm charts.
 
-    **bash**
+    **posix**
     ```bash
     mkdir -p ~/charts
     ```
@@ -92,8 +92,7 @@ $env:PATH+=";$env:USERPROFILE\bin"
     ```
     helm chart pull ghcr.io/brigadecore/brigade:v2.0.0-alpha.5
     helm chart export ghcr.io/brigadecore/brigade:v2.0.0-alpha.5 -d ~/charts
-    kubectl create namespace brigade2
-    helm install brigade2 ~/charts/brigade --namespace brigade2
+    helm install brigade2 ~/charts/brigade --namespace brigade2 --create-namespace
     kubectl rollout status deployment brigade2-apiserver -n brigade2 --timeout 5m
     ```
    

--- a/docs/content/intro/install.md
+++ b/docs/content/intro/install.md
@@ -6,24 +6,128 @@ aliases:
   - /install.md
   - /intro/install.md
   - /topics/intro/install.md
+weight: 23
 ---
 
-The Brigade server is deployed via its [Helm](https://github.com/helm/helm) chart and
-Brigade projects are managed via [brig](#brig). Here are the steps:
+Brigade is composed of a server, and a command-line tool, brig.
+Before you can install Brigade, ensure that you have the [prerequisites](#prerequisites) installed.
 
-1. Make sure `helm` is installed, and `helm version` returns the correct server.
-2. Add the Brigade repo: `helm repo add brigade https://brigadecore.github.io/charts`
-3. Install Brigade: `helm install brigade-server brigade/brigade` (or `helm install brigade/brigade --name brigade-server` if using Helm 2)
-4. Create a Brigade project: `brig project create`
+* [Install the Brigade CLI](#install-the-brigade-cli)
+* [Install the Brigade Server](#install-the-brigade-server)
+* [Install Brigade Gateways](#install-brigade-gateways)
 
-At this point, you have a running Brigade service. You can use `helm get brigade-server` and other Helm tools to examine your running Brigade server.
+## Prerequisites
 
-## Cluster Ingress
+* A [Kubernetes cluster].  
+  Your cluster should be accessible to the source of your event triggers.
+  For example, if you want to trigger events from GitHub, the cluster should have a public ip address, and a domain name that resolves to the cluster.
+  If you are using Brigade in a local development environment, the [QuickStart] demonstrates how to access a local KinD or Minikube cluster.
+* [Helm] CLI v3+ installed.
+* [kubectl] CLI installed.
+* Free disk space.  
+  The installation requires sufficient free disk space and will fail if your disk is nearly full.
 
-By default, Brigade is not configured with a load balancer service for incoming requests.  Rather, cluster ingress
-comes in the form of one or more [Gateways](../topics/gateways.md) that provide configurable services, usually in tandem
-with ingress resources.
+[Kubernetes cluster]: https://kubernetes.io/docs/setup/
+[Helm]: https://helm.sh/docs/intro/install/
+[kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl
 
+## Install the Brigade CLI
+
+Install the Brigade CLI, brig, by copying the appropriate binary from our releases page into a directory on your machine that is included in your PATH environment variable.
+
+**linux**
+```bash
+curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.0.0-alpha.5/brig-linux-amd64
+chmod +x /usr/local/bin/brig
+```
+
+**macos**
+```bash
+curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.0.0-alpha.5/brig-darwin-amd64
+chmod +x /usr/local/bin/brig
+```
+
+**windows**
+```powershell
+mkdir -force $env:USERPROFILE\bin
+(New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.0.0-alpha.5/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
+$env:PATH+=";$env:USERPROFILE\bin"
+```
+
+The script above downloads brig.exe and adds it to your PATH for the current session.
+Add the following line to your [PowerShell Profile](https://www.howtogeek.com/126469/how-to-create-a-powershell-profile/) to make the change permanent.
+
+```powershell
+$env:PATH+=";$env:USERPROFILE\bin"
+```
+
+## Install the Brigade Server
+
+1. Enable Helm's experimental OCI support by setting the HELM_EXPERIMENTAL_OCI environment variable to 1.
+
+    **bash**
+    ```bash
+    export HELM_EXPERIMENTAL_OCI=1
+    ```
+
+    **powershell**
+    ```powershell
+    $env:HELM_EXPERIMENTAL_OCI=1
+    ```
+
+1. Create a directory to store the Brigade Helm charts.
+
+    **bash**
+    ```bash
+    mkdir -p ~/charts
+    ```
+
+    **powershell**
+    ```powershell
+    mkdir -force $env:USERPROFILE/charts
+    ```
+
+1. Run the following commands to install Brigade and wait for it to finish installing.
+
+    ```
+    helm chart pull ghcr.io/brigadecore/brigade:v2.0.0-alpha.5
+    helm chart export ghcr.io/brigadecore/brigade:v2.0.0-alpha.5 -d ~/charts
+    kubectl create namespace brigade2
+    helm install brigade2 ~/charts/brigade --namespace brigade2
+    kubectl rollout status deployment brigade2-apiserver -n brigade2 --timeout 5m
+    ```
+   
+    If the deployment fails, proceed to the [troubleshooting](#troubleshooting) section.
+
+Now that you have the Brigade server installed, the next step is to [install a Brigade Gateway](#install-brigade-gateways).
+
+### Notes for Azure Kubernetes Services (AKS)
+
+Brigade is well-tested on [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/). We recommend using at least Kubernetes 1.6.
+
+- It is recommended to use a Service with type LoadBalancer on AKS, which will generate an Azure load balancer for you.
+- For caching and storage, we recommend creating an Azure Storage instance and creating a Persistent Volume and Storage Class that use the `AzureFile` driver.
+  For an example, see the `Azure File Setup` section in the [storage document](../../topics/storage/#azure-file-setup).
+- You can use Azure Container Registry for private images, provided that you add the ACR instance to the same Resource Group that AKS belongs to.
+- ACR's webhooks can be used to trigger events, as they follow the DockerHub webhook format.
+- When configuring webhooks, it is recommended that you map a domain via Azure's DNS service, or another DNS service, to your Load Balancer IP.
+  GitHub and other webhook services seem to work better with DNS names than with IP addresses.
+
+[QuickStart]: /intro/quickstart/
+
+## Install Brigade Gateways
+
+A Brigade [Gateway] generates events in Brigade in response to external triggers, for example a git push to repository.
+Brigade does not install gateways by default, so to complete your Brigade installation, install one or more gateways:
+
+* [Github Gateway](/topics/github/)
+* [Container Registry Gateway](/topics/dockerhub/)
+* [Generic Gateway](/topics/genericgateway/)
+
+[Gateway]: ../topics/gateways.md
+
+<!--
+TODO: Use this in the gateway quickstart
 ### Brigade Github App Gateway with External IP
 
 Let's take the example of enabling the [GitHub App Gateway](../topics/github.md).
@@ -50,38 +154,33 @@ There will be more configuration needed for the `brigade-github-app` sub-chart f
 See more at [GitHub App Gateway](../topics/github.md).
 
 Note that this is just one way of configuring Brigade to receive inbound connections. Brigade itself does not care how traffic is routed to it. Those with operational knowledge of Kubernetes may wish to use another method of ingress routing.  See the [Ingress](../topics/ingress.md) doc for more information.
+-->
 
-## Brig
+## Troubleshooting
 
-We recommend using [Brig](https://github.com/brigadecore/brigade/tree/master/brig), a command line tool for interacting with Brigade. Read the [Brig guide](../topics/brig.md) for installation and usage docs.
+### Brigade Installation does not Finish Successfully
 
-## Notes for Minikube
+A common cause for failed Brigade deployments is either low disk space on your computer, or the amount of disk space allocated to Docker Desktop is nearly full.
 
-You can run Brigade on [Minikube](https://github.com/kubernetes/minikube) for easy testing
-and development. Minikube provides built-in support for caching and sharing files during
-builds. However, there are a few things that are much harder to do when running locally:
+Check if that is the problem by looking at the logs for Brigade's monogdb and artemis pods.
+If the logs include "No space left on device" or "Disk Full!", then you need to free up disk space and retry the installation.
+Running `docker system prune` is one way to recover disk space for Docker.
 
-- Listening for GitHub webhooks requires you to route inbound traffic from the internet
-  to your Minikube cluster. We do not recommend doing this unless you really understand
-  what you are doing.
-- Other inbound services may also be limited by the same restriction.
+```console
+$ kubectl logs brigade2-mongodb-0
+...
+mkdir: cannot create directory '/bitnami/mongodb/data': No space left on device
+```
 
-## Notes for Azure Container Services (AKS)
+```console
+$ kubectl logs brigade2-artemis-0
+...
+2021-05-26 17:20:17,865 WARN  [org.apache.activemq.artemis.core.server] AMQ222212: Disk Full! Blocking message production on address 'healthz'. Clients will report blocked.
+```
 
-Brigade is well-tested on [AKS Kubernetes](https://docs.microsoft.com/en-us/azure/aks/). We recommend using at least Kubernetes 1.6.
+After you have freed up disk space, remove the bad installation, and then retry the installation using the following commands:
 
-- It is recommended to use a Service with type LoadBalancer on AKS, which will generate
-  an Azure load balancer for you.
-- For caching and storage, we recommend creating an Azure Storage instance and
-  creating a Persistent Volume and Storage Class that use the `AzureFile` driver.
-  (For an example, see the `Azure File Setup` section in the [storage document](../../topics/storage/#azure-file-setup).)
-- You can use Azure Container Registry for private images, provided that you
-  add the ACR instance to the same Resource Group that AKS belongs to.
-- ACR's webhooks can be used to trigger events, as they follow the DockerHub
-  webhook format.
-- When configuring webhooks, it is recommended that you map a domain (via Azure's
-  DNS service or another DNS service) to your Load Balancer IP. GitHub and other
-  webhook services seem to work better with DNS names than with IP addresses.
-
-[overview]: ../overview
-[part1]: ../tutorial01
+```
+helm uninstall brigade2 -n brigade2
+helm install brigade2 ~/charts/brigade --namespace brigade2
+```

--- a/docs/content/intro/overview.md
+++ b/docs/content/intro/overview.md
@@ -3,6 +3,7 @@ title: Brigade Overview
 description: High level view of the Brigade tool.
 section: intro
 aliases: /intro/
+weight: 21
 ---
 
 Brigade is a Kubernetes-native tool for doing event-driven scripting. Here's what that means:

--- a/docs/content/intro/quickstart.md
+++ b/docs/content/intro/quickstart.md
@@ -112,7 +112,7 @@ Install Brigade on your local development cluster. See our [Installation] instru
 
 1. Enable Helm's experimental OCI support by setting the `HELM_EXPERIMENTAL_OCI` environment variable to 1.
 
-    **bash**
+    **posix**
     ```bash
     export HELM_EXPERIMENTAL_OCI=1
     ```
@@ -124,7 +124,7 @@ Install Brigade on your local development cluster. See our [Installation] instru
 
 1. Create a directory to store the Brigade Helm charts.
 
-    **bash**
+    **posix**
     ```bash
     mkdir -p ~/charts
     ```
@@ -139,8 +139,7 @@ Install Brigade on your local development cluster. See our [Installation] instru
     ```
     helm chart pull ghcr.io/brigadecore/brigade:v2.0.0-alpha.5
     helm chart export ghcr.io/brigadecore/brigade:v2.0.0-alpha.5 -d ~/charts
-    kubectl create namespace brigade2
-    helm install brigade2 ~/charts/brigade --namespace brigade2
+    helm install brigade2 ~/charts/brigade --namespace brigade2 --create-namespace
     kubectl rollout status deployment brigade2-apiserver -n brigade2 --timeout 5m
     ```
     
@@ -149,7 +148,7 @@ Install Brigade on your local development cluster. See our [Installation] instru
 
 1. Make the Brigade API server available using port forwarding. This is necessary only for development clusters that do not have a public IP address.
 
-    **bash**
+    **posix**
     ```
     kubectl --namespace brigade2 port-forward service/brigade2-apiserver 8443:443 &>/dev/null &
     ```
@@ -166,7 +165,7 @@ Install Brigade on your local development cluster. See our [Installation] instru
 Authenticate to Brigade as the root user using demo password `F00Bar!!!`. The -k flag instructs Brigade to ignore the self-signed certificate used by our local installation of Brigade.
 
 ```
-brig -k login --server https://localhost:8443 --root
+brig login -k --server https://localhost:8443 --root
 ```
 
 If the address https://localhost:8443 does not resolve, double-check that the brigade2-apiserver service was successfully forwarded from the previous section.
@@ -178,7 +177,7 @@ In this example project, the handler prints a message using a string passed in t
 
 1. Download the example project to the current directory.
 
-    **bash**
+    **posix**
     ```bash
     curl -o project.yaml https://raw.githubusercontent.com/brigadecore/brigade/v2/examples/12-first-payload/project.yaml
     ```
@@ -196,13 +195,13 @@ In this example project, the handler prints a message using a string passed in t
 1. Create the project in Brigade with the following command.
 
     ```
-    brig -k project create --file payload.yaml
+    brig project create --file project.yaml
     ```
 
 1. List the defined projects to see our new project "first-payload":
 
     ```console
-    $ brig -k project list
+    $ brig project list
     ID           	DESCRIPTION                         	AGE
     first-payload	Demonstrates using the event payload	49m
     ```
@@ -214,7 +213,7 @@ In this example project, the handler prints a message using a string passed in t
 With our project defined, we are now ready to trigger an event and watch our handler execute.
 
 ```
-$ brig -k event create --project first-payload --payload Dolly --follow
+$ brig event create --project first-payload --payload Dolly --follow
 
 Created event "7a5234d6-e2aa-402f-acb9-c620dfc20003".
 
@@ -234,7 +233,7 @@ Hello, Dolly!
 If you want to keep your Brigade installation, run the following command to remove the example project created in this QuickStart:
 
 ```
-brig -k project delete first-payload
+brig project delete first-payload
 ```
 
 Otherwise, you can remove ALL resources created in this QuickStart by either:
@@ -251,13 +250,12 @@ Brigade with our [CI pipeline tutorial](/intro/tutorial01/).
 ## Troubleshooting
 
 * [Brigade Installation does not Finish Successfully](/intro/install/#troubleshooting)
-* [Brig Command Hangs](#brig-command-hangs)
+* [Login Command Hangs](#login-command-hangs)
 
-### Brig Command Hangs
+### Login Command Hangs
 
-If a brig command hangs, check that you included the -k flag.
-For example, `brig -k project list`.
-The -k flag is required because our local development installation of Brigade is using a self-signed certificate.
+If the brig login command hangs, check that you included the -k flag.
+This flag is required because our local development installation of Brigade is using a self-signed certificate.
 
 
 <!--

--- a/docs/content/intro/quickstart.md
+++ b/docs/content/intro/quickstart.md
@@ -2,6 +2,7 @@
 title: A Brigade Quickstart
 description: A Brigade Quickstart.
 section: intro
+weight: 22
 ---
 
 In this QuickStart, you will install Brigade, create a project and execute it.
@@ -17,6 +18,7 @@ In this QuickStart, you will install Brigade, create a project and execute it.
 * [A development Kubernetes cluster](#create-a-cluster).
 * [Brigade CLI](#install-the-brigade-cli) installed.
 * [Helm] CLI v3+ installed.
+* [kubectl] CLI installed.
 * Free disk space. The installation requires sufficient free disk space and will fail if your disk is nearly full.
 
 > Please take note that the default configuration is not secure and is not appropriate for any shared cluster.
@@ -138,10 +140,11 @@ Install Brigade on your local development cluster. See our [Installation] instru
     helm chart pull ghcr.io/brigadecore/brigade:v2.0.0-alpha.5
     helm chart export ghcr.io/brigadecore/brigade:v2.0.0-alpha.5 -d ~/charts
     kubectl create namespace brigade2
-    helm install brigade2 ~/charts/brigade --namespace brigade2 --wait --timeout 5m
+    helm install brigade2 ~/charts/brigade --namespace brigade2
+    kubectl rollout status deployment brigade2-apiserver -n brigade2 --timeout 5m
     ```
     
-    Wait for the brigade2-apiserver deployment to be ready.
+    Wait for the Brigade deployment to be ready.
     If the deployment fails, proceed to the [installation troubleshooting](/intro/install/#troubleshooting) section.
 
 1. Make the Brigade API server available using port forwarding. This is necessary only for development clusters that do not have a public IP address.
@@ -241,8 +244,9 @@ Otherwise, you can remove ALL resources created in this QuickStart by either:
 
 ## Next Steps
 
-You now know how to install Brigade, define a project, and trigger an event for the project.
-Next learn how to [create a CI pipeline with Brigade](/intro/tutorial01/).
+You now know how to install Brigade on a local development cluster, define a project, and trigger an event for the project.
+Next learn how to [install and configure Brigade](/intro/install/) on a production cluster, or continue learning about
+Brigade with our [CI pipeline tutorial](/intro/tutorial01/).
 
 ## Troubleshooting
 

--- a/docs/content/topics/github.md
+++ b/docs/content/topics/github.md
@@ -21,7 +21,8 @@ This App can then be used across one or more repositories, as opposed to the old
 Next, to enable this gateway for a Brigade installation, set the `brigade-github-app.enabled` to `true`:
 
 ```
-$ helm install -n brigade brigade/brigade -f brigade-values.yaml --set brigade-github-app.enabled=true
+helm upgrade brigade2 ~/charts/brigade --namespace brigade2 --set brigade-github-app.enabled=true
+kubectl rollout status deployment brigade2-apiserver -n brigade2 --timeout 1m
 ```
 
 The rest of the `brigade-github-app` chart values can either be placed under the key of the same

--- a/examples/12-first-payload/project.yaml
+++ b/examples/12-first-payload/project.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
+apiVersion: brigade.sh/v2-alpha.5
+kind: Project
+metadata:
+  id: first-payload
+description: Demonstrates using the event payload
+spec:
+  workerTemplate:
+    logLevel: DEBUG
+    defaultConfigFiles:
+      brigade.js: | 
+        const { events } = require("@brigadecore/brigadier");
+
+        events.on("brigade.sh/cli", "exec", async event => {
+          console.log("Hello, " + event.payload + "!");
+        });
+
+        events.process();


### PR DESCRIPTION
**What this PR does / why we need it**:
This refreshes the quickstart and installation instructions for v2.

Affected pages:
* https://deploy-preview-1435--brigade-docs.netlify.app/
* https://deploy-preview-1435--brigade-docs.netlify.app/intro/quickstart/
* https://deploy-preview-1435--brigade-docs.netlify.app/intro/install/

This keeps the quickstart simple. We get installed, define a project, and trigger an event. There is some content commented out currently that I am going to split into a separate page that explains gateways and gets you set up.

One big change in the quickstart is that we don't link you off to another page, for example when installing brigade. QuickStarts lose people (i.e. they drop off and stop, or get lost) when they navigate to another page and then have to go back and resume where they left off. The goal for the quickstart (not all content) is to have a single page that covers everything they need to know.

The installation is also specific to a dev cluster, whereas the installation page will focus on a suitable production cluster.

I have also added corresponding instructions in powershell, so that regardless of OS, people can follow along.

In the installation guide, I have commented out the section for the brigade gateway. Instead I am linking to the gateway guides. The commented out section will be used as another tutorial.

**Special notes for your reviewer**:
* All of this is draft content, and will only be available on our preview site for v2 docs. I expect to iterate on these a bit as I shuffle the content around a bit.
* I am waiting to hear back on how to configure the back/next links at the bottom of the docs pages. So they aren't the right content links yet.

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
