### PR TITLE
add mocks for all clients in the sdk

### DIFF
--- a/sdk/v2/testing/authn/mock_api_client.go
+++ b/sdk/v2/testing/authn/mock_api_client.go
@@ -1,0 +1,21 @@
+package authn
+
+import "github.com/brigadecore/brigade/sdk/v2/authn"
+
+type MockAPIClient struct {
+	ServiceAccountsClient authn.ServiceAccountsClient
+	SessionsClient        authn.SessionsClient
+	UsersClient           authn.UsersClient
+}
+
+func (m *MockAPIClient) ServiceAccounts() authn.ServiceAccountsClient {
+	return m.ServiceAccountsClient
+}
+
+func (m *MockAPIClient) Sessions() authn.SessionsClient {
+	return m.SessionsClient
+}
+
+func (m *MockAPIClient) Users() authn.UsersClient {
+	return m.UsersClient
+}

--- a/sdk/v2/testing/authn/mock_api_client_test.go
+++ b/sdk/v2/testing/authn/mock_api_client_test.go
@@ -1,0 +1,12 @@
+package authn
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/authn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockAPIClient(t *testing.T) {
+	require.Implements(t, (*authn.APIClient)(nil), &MockAPIClient{})
+}

--- a/sdk/v2/testing/authn/mock_service_accounts_client.go
+++ b/sdk/v2/testing/authn/mock_service_accounts_client.go
@@ -1,0 +1,53 @@
+package authn
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/sdk/v2/authn"
+	"github.com/brigadecore/brigade/sdk/v2/meta"
+)
+
+type MockServiceAccountsClient struct {
+	CreateFn func(context.Context, authn.ServiceAccount) (authn.Token, error)
+	ListFn   func(
+		context.Context,
+		*authn.ServiceAccountsSelector,
+		*meta.ListOptions,
+	) (authn.ServiceAccountList, error)
+	GetFn    func(context.Context, string) (authn.ServiceAccount, error)
+	LockFn   func(context.Context, string) error
+	UnlockFn func(context.Context, string) (authn.Token, error)
+}
+
+func (m *MockServiceAccountsClient) Create(
+	ctx context.Context,
+	serviceAccount authn.ServiceAccount,
+) (authn.Token, error) {
+	return m.CreateFn(ctx, serviceAccount)
+}
+
+func (m *MockServiceAccountsClient) List(
+	ctx context.Context,
+	selector *authn.ServiceAccountsSelector,
+	opts *meta.ListOptions,
+) (authn.ServiceAccountList, error) {
+	return m.ListFn(ctx, selector, opts)
+}
+
+func (m *MockServiceAccountsClient) Get(
+	ctx context.Context,
+	id string,
+) (authn.ServiceAccount, error) {
+	return m.GetFn(ctx, id)
+}
+
+func (m *MockServiceAccountsClient) Lock(ctx context.Context, id string) error {
+	return m.LockFn(ctx, id)
+}
+
+func (m *MockServiceAccountsClient) Unlock(
+	ctx context.Context,
+	id string,
+) (authn.Token, error) {
+	return m.UnlockFn(ctx, id)
+}

--- a/sdk/v2/testing/authn/mock_service_accounts_client_test.go
+++ b/sdk/v2/testing/authn/mock_service_accounts_client_test.go
@@ -1,0 +1,16 @@
+package authn
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/authn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockServiceAccountClient(t *testing.T) {
+	require.Implements(
+		t,
+		(*authn.ServiceAccountsClient)(nil),
+		&MockServiceAccountsClient{},
+	)
+}

--- a/sdk/v2/testing/authn/mock_sessions_client.go
+++ b/sdk/v2/testing/authn/mock_sessions_client.go
@@ -1,0 +1,37 @@
+package authn
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/sdk/v2/authn"
+)
+
+type MockSessionsClient struct {
+	CreateRootSessionFn func(
+		ctx context.Context,
+		password string,
+	) (authn.Token, error)
+	CreateUserSessionFn func(
+		context.Context,
+		*authn.ThirdPartyAuthOptions,
+	) (authn.ThirdPartyAuthDetails, error)
+	DeleteFn func(context.Context) error
+}
+
+func (m *MockSessionsClient) CreateRootSession(
+	ctx context.Context,
+	password string,
+) (authn.Token, error) {
+	return m.CreateRootSessionFn(ctx, password)
+}
+
+func (m *MockSessionsClient) CreateUserSession(
+	ctx context.Context,
+	opts *authn.ThirdPartyAuthOptions,
+) (authn.ThirdPartyAuthDetails, error) {
+	return m.CreateUserSessionFn(ctx, opts)
+}
+
+func (m *MockSessionsClient) Delete(ctx context.Context) error {
+	return m.Delete(ctx)
+}

--- a/sdk/v2/testing/authn/mock_sessions_client_test.go
+++ b/sdk/v2/testing/authn/mock_sessions_client_test.go
@@ -1,0 +1,12 @@
+package authn
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/authn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockSessionsClient(t *testing.T) {
+	require.Implements(t, (*authn.SessionsClient)(nil), &MockSessionsClient{})
+}

--- a/sdk/v2/testing/authn/mock_users_client.go
+++ b/sdk/v2/testing/authn/mock_users_client.go
@@ -1,0 +1,42 @@
+package authn
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/sdk/v2/authn"
+	"github.com/brigadecore/brigade/sdk/v2/meta"
+)
+
+type MockUsersClient struct {
+	ListFn func(
+		context.Context,
+		*authn.UsersSelector,
+		*meta.ListOptions,
+	) (authn.UserList, error)
+	GetFn    func(context.Context, string) (authn.User, error)
+	LockFn   func(context.Context, string) error
+	UnlockFn func(context.Context, string) error
+}
+
+func (m *MockUsersClient) List(
+	ctx context.Context,
+	selector *authn.UsersSelector,
+	opts *meta.ListOptions,
+) (authn.UserList, error) {
+	return m.ListFn(ctx, selector, opts)
+}
+
+func (m *MockUsersClient) Get(
+	ctx context.Context,
+	id string,
+) (authn.User, error) {
+	return m.GetFn(ctx, id)
+}
+
+func (m *MockUsersClient) Lock(ctx context.Context, id string) error {
+	return m.LockFn(ctx, id)
+}
+
+func (m *MockUsersClient) Unlock(ctx context.Context, id string) error {
+	return m.UnlockFn(ctx, id)
+}

--- a/sdk/v2/testing/authn/mock_users_client_test.go
+++ b/sdk/v2/testing/authn/mock_users_client_test.go
@@ -1,0 +1,12 @@
+package authn
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/authn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockUsersClient(t *testing.T) {
+	require.Implements(t, (*authn.UsersClient)(nil), &MockUsersClient{})
+}

--- a/sdk/v2/testing/authz/mock_api_client.go
+++ b/sdk/v2/testing/authz/mock_api_client.go
@@ -1,0 +1,11 @@
+package authz
+
+import "github.com/brigadecore/brigade/sdk/v2/authz"
+
+type MockAPIClient struct {
+	RoleAssignmentsClient authz.RoleAssignmentsClient
+}
+
+func (m *MockAPIClient) RoleAssignments() authz.RoleAssignmentsClient {
+	return m.RoleAssignmentsClient
+}

--- a/sdk/v2/testing/authz/mock_api_client_test.go
+++ b/sdk/v2/testing/authz/mock_api_client_test.go
@@ -1,0 +1,12 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/authz"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockAPIClient(t *testing.T) {
+	require.Implements(t, (*authz.APIClient)(nil), &MockAPIClient{})
+}

--- a/sdk/v2/testing/authz/mock_role_assignments_client.go
+++ b/sdk/v2/testing/authz/mock_role_assignments_client.go
@@ -1,0 +1,41 @@
+package authz
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/sdk/v2/authz"
+	libAuthz "github.com/brigadecore/brigade/sdk/v2/lib/authz"
+	"github.com/brigadecore/brigade/sdk/v2/meta"
+)
+
+type MockRoleAssignmentsClient struct {
+	GrantFn func(context.Context, libAuthz.RoleAssignment) error
+	ListFn  func(
+		context.Context,
+		*authz.RoleAssignmentsSelector,
+		*meta.ListOptions,
+	) (authz.RoleAssignmentList, error)
+	RevokeFn func(context.Context, libAuthz.RoleAssignment) error
+}
+
+func (m *MockRoleAssignmentsClient) Grant(
+	ctx context.Context,
+	roleAssignment libAuthz.RoleAssignment,
+) error {
+	return m.GrantFn(ctx, roleAssignment)
+}
+
+func (m *MockRoleAssignmentsClient) List(
+	ctx context.Context,
+	selector *authz.RoleAssignmentsSelector,
+	opts *meta.ListOptions,
+) (authz.RoleAssignmentList, error) {
+	return m.ListFn(ctx, selector, opts)
+}
+
+func (m *MockRoleAssignmentsClient) Revoke(
+	ctx context.Context,
+	roleAssignment libAuthz.RoleAssignment,
+) error {
+	return m.RevokeFn(ctx, roleAssignment)
+}

--- a/sdk/v2/testing/authz/mock_role_assignments_client_test.go
+++ b/sdk/v2/testing/authz/mock_role_assignments_client_test.go
@@ -1,0 +1,16 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/authz"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockRoleAssignmentsClient(t *testing.T) {
+	require.Implements(
+		t,
+		(*authz.RoleAssignmentsClient)(nil),
+		&MockRoleAssignmentsClient{},
+	)
+}

--- a/sdk/v2/testing/core/mock_api_client.go
+++ b/sdk/v2/testing/core/mock_api_client.go
@@ -1,0 +1,21 @@
+package core
+
+import "github.com/brigadecore/brigade/sdk/v2/core"
+
+type MockAPIClient struct {
+	EventsClient    core.EventsClient
+	ProjectsClient  core.ProjectsClient
+	SubstrateClient core.SubstrateClient
+}
+
+func (m *MockAPIClient) Events() core.EventsClient {
+	return m.EventsClient
+}
+
+func (m *MockAPIClient) Projects() core.ProjectsClient {
+	return m.ProjectsClient
+}
+
+func (m *MockAPIClient) Substrate() core.SubstrateClient {
+	return m.SubstrateClient
+}

--- a/sdk/v2/testing/core/mock_api_client_test.go
+++ b/sdk/v2/testing/core/mock_api_client_test.go
@@ -1,0 +1,12 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockAPIClient(t *testing.T) {
+	require.Implements(t, (*core.APIClient)(nil), &MockAPIClient{})
+}

--- a/sdk/v2/testing/core/mock_authz_client.go
+++ b/sdk/v2/testing/core/mock_authz_client.go
@@ -1,0 +1,11 @@
+package core
+
+import "github.com/brigadecore/brigade/sdk/v2/core"
+
+type MockAuthzClient struct {
+	RoleAssignmentsClient core.ProjectRoleAssignmentsClient
+}
+
+func (m *MockAuthzClient) RoleAssignments() core.ProjectRoleAssignmentsClient {
+	return m.RoleAssignmentsClient
+}

--- a/sdk/v2/testing/core/mock_authz_client_test.go
+++ b/sdk/v2/testing/core/mock_authz_client_test.go
@@ -1,0 +1,12 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockAuthzClient(t *testing.T) {
+	require.Implements(t, (*core.AuthzClient)(nil), &MockAuthzClient{})
+}

--- a/sdk/v2/testing/core/mock_events_client.go
+++ b/sdk/v2/testing/core/mock_events_client.go
@@ -1,0 +1,107 @@
+package core
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/sdk/v2/meta"
+)
+
+type MockEventsClient struct {
+	CreateFn func(context.Context, core.Event) (core.EventList, error)
+	ListFn   func(
+		context.Context,
+		*core.EventsSelector,
+		*meta.ListOptions,
+	) (core.EventList, error)
+	GetFn               func(context.Context, string) (core.Event, error)
+	CloneFn             func(context.Context, string) (core.Event, error)
+	UpdateSourceStateFn func(context.Context, string, core.SourceState) error
+	CancelFn            func(context.Context, string) error
+	CancelManyFn        func(
+		context.Context,
+		core.EventsSelector,
+	) (core.CancelManyEventsResult, error)
+	DeleteFn     func(context.Context, string) error
+	DeleteManyFn func(
+		context.Context,
+		core.EventsSelector,
+	) (core.DeleteManyEventsResult, error)
+	RetryFn       func(context.Context, string) (core.Event, error)
+	WorkersClient core.WorkersClient
+	LogsClient    core.LogsClient
+}
+
+func (m *MockEventsClient) Create(
+	ctx context.Context,
+	event core.Event,
+) (core.EventList, error) {
+	return m.CreateFn(ctx, event)
+}
+
+func (m *MockEventsClient) List(
+	ctx context.Context,
+	selector *core.EventsSelector,
+	opts *meta.ListOptions,
+) (core.EventList, error) {
+	return m.ListFn(ctx, selector, opts)
+}
+
+func (m *MockEventsClient) Get(
+	ctx context.Context,
+	id string,
+) (core.Event, error) {
+	return m.GetFn(ctx, id)
+}
+
+func (m *MockEventsClient) Clone(
+	ctx context.Context,
+	id string,
+) (core.Event, error) {
+	return m.CloneFn(ctx, id)
+}
+
+func (m *MockEventsClient) UpdateSourceState(
+	ctx context.Context,
+	id string,
+	state core.SourceState,
+) error {
+	return m.UpdateSourceStateFn(ctx, id, state)
+}
+
+func (m *MockEventsClient) Cancel(ctx context.Context, id string) error {
+	return m.CancelFn(ctx, id)
+}
+
+func (m *MockEventsClient) CancelMany(
+	ctx context.Context,
+	selector core.EventsSelector,
+) (core.CancelManyEventsResult, error) {
+	return m.CancelManyFn(ctx, selector)
+}
+
+func (m *MockEventsClient) Delete(ctx context.Context, id string) error {
+	return m.DeleteFn(ctx, id)
+}
+
+func (m *MockEventsClient) DeleteMany(
+	ctx context.Context,
+	selector core.EventsSelector,
+) (core.DeleteManyEventsResult, error) {
+	return m.DeleteManyFn(ctx, selector)
+}
+
+func (m *MockEventsClient) Retry(
+	ctx context.Context,
+	id string,
+) (core.Event, error) {
+	return m.RetryFn(ctx, id)
+}
+
+func (m *MockEventsClient) Workers() core.WorkersClient {
+	return m.WorkersClient
+}
+
+func (m *MockEventsClient) Logs() core.LogsClient {
+	return m.LogsClient
+}

--- a/sdk/v2/testing/core/mock_events_client_test.go
+++ b/sdk/v2/testing/core/mock_events_client_test.go
@@ -1,0 +1,12 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockEventsClient(t *testing.T) {
+	require.Implements(t, (*core.EventsClient)(nil), &MockEventsClient{})
+}

--- a/sdk/v2/testing/core/mock_jobs_client.go
+++ b/sdk/v2/testing/core/mock_jobs_client.go
@@ -1,0 +1,91 @@
+package core
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+)
+
+type MockJobsClient struct {
+	CreateFn func(ctx context.Context, eventID string, job core.Job) error
+	StartFn  func(
+		ctx context.Context,
+		eventID string,
+		jobName string,
+	) error
+	GetStatusFn func(
+		ctx context.Context,
+		eventID string,
+		jobName string,
+	) (core.JobStatus, error)
+	WatchStatusFn func(
+		ctx context.Context,
+		eventID string,
+		jobName string,
+	) (<-chan core.JobStatus, <-chan error, error)
+	UpdateStatusFn func(
+		ctx context.Context,
+		eventID string,
+		jobName string,
+		status core.JobStatus,
+	) error
+	CleanupFn func(ctx context.Context, eventID, jobName string) error
+	TimeoutFn func(ctx context.Context, eventID, jobName string) error
+}
+
+func (m *MockJobsClient) Create(
+	ctx context.Context,
+	eventID string,
+	job core.Job,
+) error {
+	return m.CreateFn(ctx, eventID, job)
+}
+
+func (m *MockJobsClient) Start(
+	ctx context.Context,
+	eventID string,
+	jobName string,
+) error {
+	return m.StartFn(ctx, eventID, jobName)
+}
+
+func (m *MockJobsClient) GetStatus(
+	ctx context.Context,
+	eventID string,
+	jobName string,
+) (core.JobStatus, error) {
+	return m.GetStatusFn(ctx, eventID, jobName)
+}
+
+func (m *MockJobsClient) WatchStatus(
+	ctx context.Context,
+	eventID string,
+	jobName string,
+) (<-chan core.JobStatus, <-chan error, error) {
+	return m.WatchStatusFn(ctx, eventID, jobName)
+}
+
+func (m *MockJobsClient) UpdateStatus(
+	ctx context.Context,
+	eventID string,
+	jobName string,
+	status core.JobStatus,
+) error {
+	return m.UpdateStatusFn(ctx, eventID, jobName, status)
+}
+
+func (m *MockJobsClient) Cleanup(
+	ctx context.Context,
+	eventID string,
+	jobName string,
+) error {
+	return m.CleanupFn(ctx, eventID, jobName)
+}
+
+func (m *MockJobsClient) Timeout(
+	ctx context.Context,
+	eventID string,
+	jobName string,
+) error {
+	return m.TimeoutFn(ctx, eventID, jobName)
+}

--- a/sdk/v2/testing/core/mock_jobs_client_test.go
+++ b/sdk/v2/testing/core/mock_jobs_client_test.go
@@ -1,0 +1,12 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockJobsClient(t *testing.T) {
+	require.Implements(t, (*core.JobsClient)(nil), &MockJobsClient{})
+}

--- a/sdk/v2/testing/core/mock_logs_client.go
+++ b/sdk/v2/testing/core/mock_logs_client.go
@@ -1,0 +1,25 @@
+package core
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+)
+
+type MockLogsClient struct {
+	StreamFn func(
+		ctx context.Context,
+		eventID string,
+		selector *core.LogsSelector,
+		opts *core.LogStreamOptions,
+	) (<-chan core.LogEntry, <-chan error, error)
+}
+
+func (m *MockLogsClient) Stream(
+	ctx context.Context,
+	eventID string,
+	selector *core.LogsSelector,
+	opts *core.LogStreamOptions,
+) (<-chan core.LogEntry, <-chan error, error) {
+	return m.StreamFn(ctx, eventID, selector, opts)
+}

--- a/sdk/v2/testing/core/mock_logs_client_test.go
+++ b/sdk/v2/testing/core/mock_logs_client_test.go
@@ -1,0 +1,12 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockLogsClient(t *testing.T) {
+	require.Implements(t, (*core.LogsClient)(nil), &MockLogsClient{})
+}

--- a/sdk/v2/testing/core/mock_project_role_assignments_client.go
+++ b/sdk/v2/testing/core/mock_project_role_assignments_client.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/sdk/v2/meta"
+)
+
+type MockProjectRoleAssignmentsClient struct {
+	GrantFn func(
+		ctx context.Context,
+		projectID string,
+		projectRoleAssignment core.ProjectRoleAssignment,
+	) error
+	ListFn func(
+		ctx context.Context,
+		projectID string,
+		selector *core.ProjectRoleAssignmentsSelector,
+		opts *meta.ListOptions,
+	) (core.ProjectRoleAssignmentList, error)
+	RevokeFn func(
+		ctx context.Context,
+		projectID string,
+		projectRoleAssignment core.ProjectRoleAssignment,
+	) error
+}
+
+func (m *MockProjectRoleAssignmentsClient) Grant(
+	ctx context.Context,
+	projectID string,
+	projectRoleAssignment core.ProjectRoleAssignment,
+) error {
+	return m.GrantFn(ctx, projectID, projectRoleAssignment)
+}
+
+func (m *MockProjectRoleAssignmentsClient) List(
+	ctx context.Context,
+	projectID string,
+	selector *core.ProjectRoleAssignmentsSelector,
+	opts *meta.ListOptions,
+) (core.ProjectRoleAssignmentList, error) {
+	return m.ListFn(ctx, projectID, selector, opts)
+}
+
+func (m *MockProjectRoleAssignmentsClient) Revoke(
+	ctx context.Context,
+	projectID string,
+	projectRoleAssignment core.ProjectRoleAssignment,
+) error {
+	return m.RevokeFn(ctx, projectID, projectRoleAssignment)
+}

--- a/sdk/v2/testing/core/mock_project_role_assignments_client_test.go
+++ b/sdk/v2/testing/core/mock_project_role_assignments_client_test.go
@@ -1,0 +1,16 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockProjectRoleAssignmentsClient(t *testing.T) {
+	require.Implements(
+		t,
+		(*core.ProjectRoleAssignmentsClient)(nil),
+		&MockProjectRoleAssignmentsClient{},
+	)
+}

--- a/sdk/v2/testing/core/mock_projects_client.go
+++ b/sdk/v2/testing/core/mock_projects_client.go
@@ -1,0 +1,80 @@
+package core
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/sdk/v2/meta"
+)
+
+type MockProjectsClient struct {
+	CreateFn          func(context.Context, core.Project) (core.Project, error)
+	CreateFromBytesFn func(context.Context, []byte) (core.Project, error)
+	ListFn            func(
+		context.Context,
+		*core.ProjectsSelector,
+		*meta.ListOptions,
+	) (core.ProjectList, error)
+	GetFn             func(context.Context, string) (core.Project, error)
+	UpdateFn          func(context.Context, core.Project) (core.Project, error)
+	UpdateFromBytesFn func(context.Context, string, []byte) (core.Project, error)
+	DeleteFn          func(context.Context, string) error
+	AuthzClient       core.AuthzClient
+	SecretsClient     core.SecretsClient
+}
+
+func (m *MockProjectsClient) Create(
+	ctx context.Context,
+	project core.Project,
+) (core.Project, error) {
+	return m.CreateFn(ctx, project)
+}
+
+func (m *MockProjectsClient) CreateFromBytes(
+	ctx context.Context,
+	bytes []byte,
+) (core.Project, error) {
+	return m.CreateFromBytesFn(ctx, bytes)
+}
+
+func (m *MockProjectsClient) List(
+	ctx context.Context,
+	selector *core.ProjectsSelector,
+	opts *meta.ListOptions,
+) (core.ProjectList, error) {
+	return m.ListFn(ctx, selector, opts)
+}
+
+func (m *MockProjectsClient) Get(
+	ctx context.Context,
+	id string,
+) (core.Project, error) {
+	return m.GetFn(ctx, id)
+}
+
+func (m *MockProjectsClient) Update(
+	ctx context.Context,
+	project core.Project,
+) (core.Project, error) {
+	return m.UpdateFn(ctx, project)
+}
+
+func (m *MockProjectsClient) UpdateFromBytes(
+	ctx context.Context,
+	id string,
+	bytes []byte,
+) (core.Project, error) {
+	return m.UpdateFromBytesFn(ctx, id, bytes)
+}
+
+func (m *MockProjectsClient) Delete(ctx context.Context, id string) error {
+	return m.DeleteFn(ctx, id)
+}
+
+func (m *MockProjectsClient) Authz() core.AuthzClient {
+	return m.AuthzClient
+}
+
+func (m *MockProjectsClient) Secrets() core.SecretsClient {
+	return m.SecretsClient
+}

--- a/sdk/v2/testing/core/mock_projects_client_test.go
+++ b/sdk/v2/testing/core/mock_projects_client_test.go
@@ -1,0 +1,12 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockProjectsClient(t *testing.T) {
+	require.Implements(t, (*core.ProjectsClient)(nil), &MockProjectsClient{})
+}

--- a/sdk/v2/testing/core/mock_secrets_client.go
+++ b/sdk/v2/testing/core/mock_secrets_client.go
@@ -1,0 +1,42 @@
+package core
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/sdk/v2/meta"
+)
+
+type MockSecretsClient struct {
+	ListFn func(
+		ctx context.Context,
+		projectID string,
+		opts *meta.ListOptions,
+	) (core.SecretList, error)
+	SetFn   func(ctx context.Context, projectID string, secret core.Secret) error
+	UnsetFn func(ctx context.Context, projectID string, key string) error
+}
+
+func (m *MockSecretsClient) List(
+	ctx context.Context,
+	projectID string,
+	opts *meta.ListOptions,
+) (core.SecretList, error) {
+	return m.ListFn(ctx, projectID, opts)
+}
+
+func (m *MockSecretsClient) Set(
+	ctx context.Context,
+	projectID string,
+	secret core.Secret,
+) error {
+	return m.SetFn(ctx, projectID, secret)
+}
+
+func (m *MockSecretsClient) Unset(
+	ctx context.Context,
+	projectID string,
+	key string,
+) error {
+	return m.UnsetFn(ctx, projectID, key)
+}

--- a/sdk/v2/testing/core/mock_secrets_client_test.go
+++ b/sdk/v2/testing/core/mock_secrets_client_test.go
@@ -1,0 +1,12 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockSecretsClient(t *testing.T) {
+	require.Implements(t, (*core.SecretsClient)(nil), &MockSecretsClient{})
+}

--- a/sdk/v2/testing/core/mock_substrate_client.go
+++ b/sdk/v2/testing/core/mock_substrate_client.go
@@ -1,0 +1,24 @@
+package core
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+)
+
+type MockSubstrateClient struct {
+	CountRunningWorkersFn func(context.Context) (core.SubstrateWorkerCount, error)
+	CountRunningJobsFn    func(context.Context) (core.SubstrateJobCount, error)
+}
+
+func (m *MockSubstrateClient) CountRunningWorkers(
+	ctx context.Context,
+) (core.SubstrateWorkerCount, error) {
+	return m.CountRunningWorkersFn(ctx)
+}
+
+func (m *MockSubstrateClient) CountRunningJobs(
+	ctx context.Context,
+) (core.SubstrateJobCount, error) {
+	return m.CountRunningJobsFn(ctx)
+}

--- a/sdk/v2/testing/core/mock_substrate_client_test.go
+++ b/sdk/v2/testing/core/mock_substrate_client_test.go
@@ -1,0 +1,12 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockSubstrateClient(t *testing.T) {
+	require.Implements(t, (*core.SubstrateClient)(nil), &MockSubstrateClient{})
+}

--- a/sdk/v2/testing/core/mock_workers_client.go
+++ b/sdk/v2/testing/core/mock_workers_client.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+)
+
+type MockWorkersClient struct {
+	StartFn     func(ctx context.Context, eventID string) error
+	GetStatusFn func(
+		ctx context.Context,
+		eventID string,
+	) (core.WorkerStatus, error)
+	WatchStatusFn func(
+		ctx context.Context,
+		eventID string,
+	) (<-chan core.WorkerStatus, <-chan error, error)
+	UpdateStatusFn func(
+		ctx context.Context,
+		eventID string,
+		status core.WorkerStatus,
+	) error
+	CleanupFn  func(ctx context.Context, eventID string) error
+	JobsClient core.JobsClient
+}
+
+func (m *MockWorkersClient) Start(ctx context.Context, eventID string) error {
+	return m.StartFn(ctx, eventID)
+}
+
+func (m *MockWorkersClient) GetStatus(
+	ctx context.Context,
+	eventID string,
+) (core.WorkerStatus, error) {
+	return m.GetStatusFn(ctx, eventID)
+}
+
+func (m *MockWorkersClient) WatchStatus(
+	ctx context.Context,
+	eventID string,
+) (<-chan core.WorkerStatus, <-chan error, error) {
+	return m.WatchStatusFn(ctx, eventID)
+}
+
+func (m *MockWorkersClient) UpdateStatus(
+	ctx context.Context,
+	eventID string,
+	status core.WorkerStatus,
+) error {
+	return m.UpdateStatusFn(ctx, eventID, status)
+}
+
+func (m *MockWorkersClient) Cleanup(ctx context.Context, eventID string) error {
+	return m.CleanupFn(ctx, eventID)
+}
+
+func (m *MockWorkersClient) Jobs() core.JobsClient {
+	return m.JobsClient
+}

--- a/sdk/v2/testing/core/mock_workers_client_test.go
+++ b/sdk/v2/testing/core/mock_workers_client_test.go
@@ -1,0 +1,12 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockWorkersClient(t *testing.T) {
+	require.Implements(t, (*core.WorkersClient)(nil), &MockWorkersClient{})
+}

--- a/sdk/v2/testing/mock_api_client.go
+++ b/sdk/v2/testing/mock_api_client.go
@@ -1,0 +1,31 @@
+package testing
+
+import (
+	"github.com/brigadecore/brigade/sdk/v2/authn"
+	"github.com/brigadecore/brigade/sdk/v2/authz"
+	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/sdk/v2/system"
+)
+
+type MockAPIClient struct {
+	AuthnClient  authn.APIClient
+	AuthzClient  authz.APIClient
+	CoreClient   core.APIClient
+	SystemClient system.APIClient
+}
+
+func (m *MockAPIClient) Authn() authn.APIClient {
+	return m.AuthnClient
+}
+
+func (m *MockAPIClient) Authz() authz.APIClient {
+	return m.AuthzClient
+}
+
+func (m *MockAPIClient) Core() core.APIClient {
+	return m.CoreClient
+}
+
+func (m *MockAPIClient) System() system.APIClient {
+	return m.SystemClient
+}

--- a/sdk/v2/testing/mock_api_client_test.go
+++ b/sdk/v2/testing/mock_api_client_test.go
@@ -1,0 +1,12 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockAPIClient(t *testing.T) {
+	require.Implements(t, (*sdk.APIClient)(nil), &MockAPIClient{})
+}

--- a/sdk/v2/testing/system/mock_api_client.go
+++ b/sdk/v2/testing/system/mock_api_client.go
@@ -1,0 +1,20 @@
+package system
+
+import (
+	"context"
+
+	"github.com/brigadecore/brigade/sdk/v2/system"
+)
+
+type MockAPIClient struct {
+	PingFn            func(ctx context.Context) (system.PingResponse, error)
+	UnversionedPingFn func(ctx context.Context) ([]byte, error)
+}
+
+func (m *MockAPIClient) Ping(ctx context.Context) (system.PingResponse, error) {
+	return m.PingFn(ctx)
+}
+
+func (m *MockAPIClient) UnversionedPing(ctx context.Context) ([]byte, error) {
+	return m.UnversionedPingFn(ctx)
+}

--- a/sdk/v2/testing/system/mock_api_client_test.go
+++ b/sdk/v2/testing/system/mock_api_client_test.go
@@ -1,0 +1,12 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/brigadecore/brigade/sdk/v2/system"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockAPIClient(t *testing.T) {
+	require.Implements(t, (*system.APIClient)(nil), &MockAPIClient{})
+}


### PR DESCRIPTION
This may be a lot of lines, but it's very straightforward-- nothing more than mock implementations of all the SDK's client interfaces. These fulfill the interfaces in question, but leave behavior _entirely_ user-defined.

This is useful for anyone who wants to unit test something that ordinarily talks to the Brigade API. There are spots in Brigade itself (like the scheduler and observer) that could take advantage of these, but they'll also be useful for people implementing things like gateways or custom workers in Go.