### PR TITLE
feat(operator):  add max worker + job lifetime configurability

### DIFF
--- a/charts/brigade/templates/observer/deployment.yaml
+++ b/charts/brigade/templates/observer/deployment.yaml
@@ -40,6 +40,12 @@ spec:
               key: api-token
         - name: API_IGNORE_CERT_WARNINGS
           value: {{ quote (and .Values.apiserver.tls.enabled .Values.observer.tls.ignoreCertWarnings) }}
+        {{- if .Values.observer.config }}
+        - name: MAX_WORKER_LIFETIME
+          value: {{ .Values.observer.config.maxWorkerLifetime }}
+        - name: MAX_JOB_LIFETIME
+          value: {{ .Values.observer.config.maxJobLifetime }}
+        {{- end }}
       {{- with .Values.observer.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -210,6 +210,20 @@ observer:
   tls:
     ignoreCertWarnings: true
 
+  config:
+    ## maxWorkerLifetime dictates the maximum amount of time that a worker
+    ## is permitted to run, assuming no timeout has been set on the worker itself.
+    ## (Default is 24 hours)
+    ## Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    ## For example, "60s", "2h45m", "168h" (1 week)
+    # maxWorkerLifetime:
+    ## maxJobLifetime dictates the maximum amount of time that a job
+    ## is permitted to run, assuming no timeout has been set on the job itself.
+    ## (Default is 24 hours)
+    ## Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    ## For example, "60s", "2h45m", "168h" (1 week)
+    # maxJobLifetime:
+
 gitInitializer:
 
   image:

--- a/v2/observer/common.go
+++ b/v2/observer/common.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"time"
 
+	myk8s "github.com/brigadecore/brigade/v2/internal/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -17,4 +19,44 @@ func (o *observer) syncDeletedPod(obj interface{}) {
 	// Remove this pod from the set of pods we were tracking for deletion.
 	// Managing this set is essential to not leaking memory.
 	delete(o.deletingPodsSet, namespacedPodName(pod.Namespace, pod.Name))
+}
+
+func (o *observer) getPodTimeoutDuration(
+	pod *corev1.Pod,
+	max time.Duration,
+) time.Duration {
+	rawDuration := pod.Annotations[myk8s.AnnotationTimeoutDuration]
+	if rawDuration == "" {
+		return max
+	}
+
+	// Attempt to set the timeout per the annotation on the pod itself
+	timeout, err := time.ParseDuration(rawDuration)
+	// Fallback to the max if we are unable to parse timeout value
+	if err != nil {
+		o.errFn(
+			fmt.Errorf(
+				"unable to parse timeout duration %q for pod %q; "+
+					"using configured maximum of %q",
+				rawDuration,
+				pod.Name,
+				max,
+			),
+		)
+		return max
+	}
+	// ... or if the parsed duration exceeds the max
+	if timeout > max {
+		o.errFn(
+			fmt.Errorf(
+				"timeout duration %q for pod %q exceeds the configured maximum; "+
+					"using configured maximum of %q",
+				timeout,
+				pod.Name,
+				max,
+			),
+		)
+		return max
+	}
+	return timeout
 }

--- a/v2/observer/common_test.go
+++ b/v2/observer/common_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"sync"
 	"testing"
+	"time"
 
+	myk8s "github.com/brigadecore/brigade/v2/internal/kubernetes"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,4 +29,96 @@ func TestSyncDeletedPod(t *testing.T) {
 		},
 	)
 	require.Empty(t, observer.deletingPodsSet)
+}
+
+func TestGetPodTimeoutDuration(t *testing.T) {
+	const maxTimeout = time.Duration(2)
+	testCases := []struct {
+		name     string
+		pod      *corev1.Pod
+		observer *observer
+		expected time.Duration
+	}{
+		{
+			name: "no duration annotation on pod",
+			pod:  &corev1.Pod{},
+			observer: &observer{
+				errFn: func(i ...interface{}) {
+					require.Fail(
+						t,
+						"errFn should not have been called, but was",
+					)
+				},
+			},
+			expected: maxTimeout,
+		},
+		{
+			name: "duration annotation cannot be parsed",
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						myk8s.AnnotationTimeoutDuration: "1",
+					},
+				},
+			},
+			observer: &observer{
+				errFn: func(i ...interface{}) {
+					require.Len(t, i, 1)
+					err, ok := i[0].(error)
+					require.True(t, ok)
+					require.Contains(t, err.Error(), "unable to parse timeout duration")
+					require.Contains(t, err.Error(), "using configured maximum")
+				},
+			},
+			expected: maxTimeout,
+		},
+		{
+			name: "parsed duration exceeds the max",
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						myk8s.AnnotationTimeoutDuration: "3ns",
+					},
+				},
+			},
+			observer: &observer{
+				errFn: func(i ...interface{}) {
+					require.Len(t, i, 1)
+					err, ok := i[0].(error)
+					require.True(t, ok)
+					require.Contains(t, err.Error(), "exceeds the configured maximum")
+					require.Contains(t, err.Error(), "using configured maximum")
+				},
+			},
+			expected: maxTimeout,
+		},
+		{
+			name: "parsed duration does not exceed the max",
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: map[string]string{
+						myk8s.AnnotationTimeoutDuration: "1ns",
+					},
+				},
+			},
+			observer: &observer{
+				errFn: func(i ...interface{}) {
+					require.Fail(
+						t,
+						"errFn should not have been called, but was",
+					)
+				},
+			},
+			expected: time.Duration(1),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(
+				t,
+				testCase.expected,
+				testCase.observer.getPodTimeoutDuration(testCase.pod, maxTimeout),
+			)
+		})
+	}
 }

--- a/v2/observer/jobs.go
+++ b/v2/observer/jobs.go
@@ -204,26 +204,10 @@ func (o *observer) startJobPodTimer(ctx context.Context, pod *corev1.Pod) {
 		return
 	}
 
-	// Attempt to set the timeout per the annotation on the pod itself
-	duration := pod.Annotations[myk8s.AnnotationTimeoutDuration]
-	timeout, err := time.ParseDuration(duration)
-	// Fallback to the max if we are unable to parse timeout value or if it
-	// exceeds the max.
-	if err != nil || timeout > o.config.maxJobLifetime {
-		o.errFn(
-			fmt.Errorf(
-				"unable to parse timeout duration %q for pod %q; "+
-					"using configured maximum of %q",
-				duration,
-				pod.Name,
-				o.config.maxJobLifetime,
-			),
-		)
-		timeout = o.config.maxJobLifetime
-	}
-
 	go func() {
-		timer := time.NewTimer(timeout)
+		timer := time.NewTimer(
+			o.getPodTimeoutDuration(pod, o.config.maxJobLifetime),
+		)
 		defer timer.Stop()
 
 		select {

--- a/v2/observer/jobs.go
+++ b/v2/observer/jobs.go
@@ -203,22 +203,25 @@ func (o *observer) startJobPodTimer(ctx context.Context, pod *corev1.Pod) {
 		pod.Status.Phase != corev1.PodRunning {
 		return
 	}
-	if pod.Annotations[myk8s.AnnotationTimeoutDuration] == "" {
-		return
-	}
 
-	duration := pod.Annotations[myk8s.AnnotationTimeoutDuration]
-	timeout, err := time.ParseDuration(duration)
-	if err != nil {
-		o.errFn(
-			errors.Wrapf(
-				err,
-				"unable to parse timeout duration %q for pod %q",
-				duration,
-				pod.Name,
-			),
-		)
-		return
+	// Default the timeout value based on the Observer's config
+	timeout := o.config.maxJobLifetime
+	// Else, use the value set on the pod itself
+	if pod.Annotations[myk8s.AnnotationTimeoutDuration] != "" {
+		var err error
+		duration := pod.Annotations[myk8s.AnnotationTimeoutDuration]
+		timeout, err = time.ParseDuration(duration)
+		if err != nil {
+			o.errFn(
+				errors.Wrapf(
+					err,
+					"unable to parse timeout duration %q for pod %q",
+					duration,
+					pod.Name,
+				),
+			)
+			return
+		}
 	}
 
 	go func() {

--- a/v2/observer/jobs.go
+++ b/v2/observer/jobs.go
@@ -204,35 +204,22 @@ func (o *observer) startJobPodTimer(ctx context.Context, pod *corev1.Pod) {
 		return
 	}
 
-	// Default the timeout value based on the Observer's config
-	timeout := o.config.maxJobLifetime
-	// Else, use the value set on the pod itself
-	if pod.Annotations[myk8s.AnnotationTimeoutDuration] != "" {
-		var err error
-		duration := pod.Annotations[myk8s.AnnotationTimeoutDuration]
-		timeout, err = time.ParseDuration(duration)
-		if err != nil {
-			o.errFn(
-				errors.Wrapf(
-					err,
-					"unable to parse timeout duration %q for pod %q",
-					duration,
-					pod.Name,
-				),
-			)
-			return
-		}
-		if timeout > o.config.maxJobLifetime {
-			o.errFn(
-				fmt.Errorf(
-					"timeout %q for pod %q exceeds the configured maximum %q",
-					duration,
-					pod.Name,
-					o.config.maxJobLifetime,
-				),
-			)
-			return
-		}
+	// Attempt to set the timeout per the annotation on the pod itself
+	duration := pod.Annotations[myk8s.AnnotationTimeoutDuration]
+	timeout, err := time.ParseDuration(duration)
+	// Fallback to the max if we are unable to parse timeout value or if it
+	// exceeds the max.
+	if err != nil || timeout > o.config.maxJobLifetime {
+		o.errFn(
+			fmt.Errorf(
+				"unable to parse timeout duration %q for pod %q; "+
+					"using configured maximum of %q",
+				duration,
+				pod.Name,
+				o.config.maxJobLifetime,
+			),
+		)
+		timeout = o.config.maxJobLifetime
 	}
 
 	go func() {

--- a/v2/observer/jobs.go
+++ b/v2/observer/jobs.go
@@ -222,6 +222,17 @@ func (o *observer) startJobPodTimer(ctx context.Context, pod *corev1.Pod) {
 			)
 			return
 		}
+		if timeout > o.config.maxJobLifetime {
+			o.errFn(
+				fmt.Errorf(
+					"timeout %q for pod %q exceeds the configured maximum %q",
+					duration,
+					pod.Name,
+					o.config.maxJobLifetime,
+				),
+			)
+			return
+		}
 	}
 
 	go func() {

--- a/v2/observer/jobs_test.go
+++ b/v2/observer/jobs_test.go
@@ -519,83 +519,6 @@ func TestStartJobPodTimer(t *testing.T) {
 			},
 		},
 		{
-			name: "pod has timeout annotation exceeding the configured max",
-			pod: &corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "nombre",
-					Namespace: "ns",
-					Annotations: map[string]string{
-						myk8s.AnnotationTimeoutDuration: "2ms",
-					},
-				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodPending,
-				},
-			},
-			observer: &observer{
-				config: observerConfig{
-					maxJobLifetime: time.Duration(1000000), // 1ms
-				},
-				timedPodsSet: map[string]context.CancelFunc{
-					"ns:nombre": func() {},
-				},
-				jobsClient: &coreTesting.MockJobsClient{
-					TimeoutFn: func(
-						ctx context.Context,
-						eventID string,
-						jobName string,
-					) error {
-						require.Equal(t, jobName, "italian")
-						return nil
-					},
-				},
-				errFn: func(i ...interface{}) {
-					require.Len(t, i, 1)
-					err, ok := i[0].(error)
-					require.True(t, ok)
-					require.Contains(t, err.Error(), "unable to parse timeout duration")
-					require.Contains(t, err.Error(), "using configured maximum")
-				},
-			},
-		},
-		{
-			name: "pod has invalid timeout annotation",
-			pod: &corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "nombre",
-					Namespace: "ns",
-					Annotations: map[string]string{
-						myk8s.AnnotationTimeoutDuration: "1",
-					},
-				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodPending,
-				},
-			},
-			observer: &observer{
-				timedPodsSet: map[string]context.CancelFunc{
-					"ns:nombre": func() {},
-				},
-				jobsClient: &coreTesting.MockJobsClient{
-					TimeoutFn: func(
-						ctx context.Context,
-						eventID string,
-						jobName string,
-					) error {
-						require.Equal(t, jobName, "italian")
-						return nil
-					},
-				},
-				errFn: func(i ...interface{}) {
-					require.Len(t, i, 1)
-					err, ok := i[0].(error)
-					require.True(t, ok)
-					require.Contains(t, err.Error(), "unable to parse timeout duration")
-					require.Contains(t, err.Error(), "using configured maximum")
-				},
-			},
-		},
-		{
 			name: "timed pod times out; api call fails",
 			pod: &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
@@ -682,9 +605,6 @@ func TestStartJobPodTimer(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "nombre",
 					Namespace: "ns",
-					Annotations: map[string]string{
-						myk8s.AnnotationTimeoutDuration: "5ms",
-					},
 				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodPending,

--- a/v2/observer/jobs_test.go
+++ b/v2/observer/jobs_test.go
@@ -549,6 +549,35 @@ func TestStartJobPodTimer(t *testing.T) {
 			},
 		},
 		{
+			name: "pod has timeout annotation exceeding the configured max",
+			pod: &corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "nombre",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						myk8s.AnnotationTimeoutDuration: "2ms",
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			observer: &observer{
+				config: observerConfig{
+					maxJobLifetime: time.Duration(1000000), // 1ms
+				},
+				timedPodsSet: map[string]context.CancelFunc{
+					"ns:nombre": func() {},
+				},
+				errFn: func(i ...interface{}) {
+					require.Len(t, i, 1)
+					err, ok := i[0].(error)
+					require.True(t, ok)
+					require.Contains(t, err.Error(), "exceeds the configured maximum")
+				},
+			},
+		},
+		{
 			name: "pod has invalid timeout annotation",
 			pod: &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
@@ -589,6 +618,9 @@ func TestStartJobPodTimer(t *testing.T) {
 				},
 			},
 			observer: &observer{
+				config: observerConfig{
+					maxJobLifetime: time.Duration(2000000), // 2ms
+				},
 				timedPodsSet: map[string]context.CancelFunc{
 					"ns:nombre": func() {},
 				},
@@ -628,6 +660,9 @@ func TestStartJobPodTimer(t *testing.T) {
 				},
 			},
 			observer: &observer{
+				config: observerConfig{
+					maxJobLifetime: time.Duration(2000000), // 2ms
+				},
 				timedPodsSet: map[string]context.CancelFunc{
 					"ns:nombre": func() {},
 				},

--- a/v2/observer/observer.go
+++ b/v2/observer/observer.go
@@ -17,14 +17,24 @@ import (
 type observerConfig struct {
 	delayBeforeCleanup  time.Duration
 	healthcheckInterval time.Duration
+	maxWorkerLifetime   time.Duration
+	maxJobLifetime      time.Duration
 }
 
 func getObserverConfig() (observerConfig, error) {
 	config := observerConfig{}
 	var err error
 	config.healthcheckInterval = 30 * time.Second
-	config.delayBeforeCleanup, err =
-		os.GetDurationFromEnvVar("DELAY_BEFORE_CLEANUP", time.Minute)
+	if config.delayBeforeCleanup, err =
+		os.GetDurationFromEnvVar("DELAY_BEFORE_CLEANUP", time.Minute); err != nil {
+		return config, err
+	}
+	if config.maxWorkerLifetime, err =
+		os.GetDurationFromEnvVar("MAX_WORKER_LIFETIME", time.Hour*24); err != nil {
+		return config, err
+	}
+	config.maxJobLifetime, err =
+		os.GetDurationFromEnvVar("MAX_JOB_LIFETIME", time.Hour*24)
 	return config, err
 }
 

--- a/v2/observer/observer_test.go
+++ b/v2/observer/observer_test.go
@@ -43,9 +43,33 @@ func TestGetObserverConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "success with overrides",
+			name: "MAX_WORKER_LIFETIME not parsable as duration",
 			setup: func() {
 				os.Setenv("DELAY_BEFORE_CLEANUP", "2m")
+				os.Setenv("MAX_WORKER_LIFETIME", "foo")
+			},
+			assertions: func(config observerConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "was not parsable as a duration")
+				require.Contains(t, err.Error(), "MAX_WORKER_LIFETIME")
+			},
+		},
+		{
+			name: "MAX_JOB_LIFETIME not parsable as duration",
+			setup: func() {
+				os.Setenv("MAX_WORKER_LIFETIME", "2m")
+				os.Setenv("MAX_JOB_LIFETIME", "foo")
+			},
+			assertions: func(config observerConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "was not parsable as a duration")
+				require.Contains(t, err.Error(), "MAX_JOB_LIFETIME")
+			},
+		},
+		{
+			name: "success with overrides",
+			setup: func() {
+				os.Setenv("MAX_JOB_LIFETIME", "2m")
 			},
 			assertions: func(config observerConfig, err error) {
 				require.Equal(t, 2*time.Minute, config.delayBeforeCleanup)

--- a/v2/observer/workers.go
+++ b/v2/observer/workers.go
@@ -193,6 +193,17 @@ func (o *observer) startWorkerPodTimer(ctx context.Context, pod *corev1.Pod) {
 			)
 			return
 		}
+		if timeout > o.config.maxWorkerLifetime {
+			o.errFn(
+				fmt.Errorf(
+					"timeout %q for pod %q exceeds the configured maximum %q",
+					duration,
+					pod.Name,
+					o.config.maxWorkerLifetime,
+				),
+			)
+			return
+		}
 	}
 
 	go func() {

--- a/v2/observer/workers.go
+++ b/v2/observer/workers.go
@@ -196,11 +196,11 @@ func (o *observer) startWorkerPodTimer(ctx context.Context, pod *corev1.Pod) {
 	}
 
 	go func() {
-		ticker := time.NewTimer(timeout)
-		defer ticker.Stop()
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
 
 		select {
-		case <-ticker.C:
+		case <-timer.C:
 			eventID := pod.Labels[myk8s.LabelEvent]
 			if err := o.workersClient.Timeout(ctx, eventID); err != nil {
 				o.errFn(

--- a/v2/observer/workers_test.go
+++ b/v2/observer/workers_test.go
@@ -470,79 +470,6 @@ func TestStartWorkerPodTimer(t *testing.T) {
 			},
 		},
 		{
-			name: "pod has timeout annotation exceeding the configured max",
-			pod: &corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "nombre",
-					Namespace: "ns",
-					Annotations: map[string]string{
-						myk8s.AnnotationTimeoutDuration: "2ms",
-					},
-				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodPending,
-				},
-			},
-			observer: &observer{
-				config: observerConfig{
-					maxWorkerLifetime: time.Duration(1000000), // 1ms
-				},
-				timedPodsSet: map[string]context.CancelFunc{
-					"ns:nombre": func() {},
-				},
-				workersClient: &coreTesting.MockWorkersClient{
-					TimeoutFn: func(
-						ctx context.Context,
-						eventID string,
-					) error {
-						return errors.New("something went wrong")
-					},
-				},
-				errFn: func(i ...interface{}) {
-					require.Len(t, i, 1)
-					err, ok := i[0].(error)
-					require.True(t, ok)
-					require.Contains(t, err.Error(), "unable to parse timeout duration")
-					require.Contains(t, err.Error(), "using configured maximum")
-				},
-			},
-		},
-		{
-			name: "pod has invalid timeout annotation",
-			pod: &corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "nombre",
-					Namespace: "ns",
-					Annotations: map[string]string{
-						myk8s.AnnotationTimeoutDuration: "1",
-					},
-				},
-				Status: corev1.PodStatus{
-					Phase: corev1.PodPending,
-				},
-			},
-			observer: &observer{
-				timedPodsSet: map[string]context.CancelFunc{
-					"ns:nombre": func() {},
-				},
-				workersClient: &coreTesting.MockWorkersClient{
-					TimeoutFn: func(
-						ctx context.Context,
-						eventID string,
-					) error {
-						return errors.New("something went wrong")
-					},
-				},
-				errFn: func(i ...interface{}) {
-					require.Len(t, i, 1)
-					err, ok := i[0].(error)
-					require.True(t, ok)
-					require.Contains(t, err.Error(), "unable to parse timeout duration")
-					require.Contains(t, err.Error(), "using configured maximum")
-				},
-			},
-		},
-		{
 			name: "timed pod times out; api call fails",
 			pod: &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
@@ -623,9 +550,6 @@ func TestStartWorkerPodTimer(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "nombre",
 					Namespace: "ns",
-					Annotations: map[string]string{
-						myk8s.AnnotationTimeoutDuration: "5ms",
-					},
 				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodPending,

--- a/v2/observer/workers_test.go
+++ b/v2/observer/workers_test.go
@@ -470,7 +470,7 @@ func TestStartWorkerPodTimer(t *testing.T) {
 			},
 		},
 		{
-			name: "pod has no timeout annotation",
+			name: "pod has no timeout annotation; uses observer config",
 			pod: &corev1.Pod{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "nombre",
@@ -481,8 +481,19 @@ func TestStartWorkerPodTimer(t *testing.T) {
 				},
 			},
 			observer: &observer{
+				config: observerConfig{
+					maxWorkerLifetime: time.Duration(1000000), // 1ms
+				},
 				timedPodsSet: map[string]context.CancelFunc{
 					"ns:nombre": func() {},
+				},
+				workersClient: &coreTesting.MockWorkersClient{
+					TimeoutFn: func(
+						ctx context.Context,
+						eventID string,
+					) error {
+						return nil
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds the ability for Brigade operators to specify a max lifetime for workers and jobs

Last bit of work for https://github.com/brigadecore/brigade/issues/1378

~~Relies on https://github.com/brigadecore/brigade/pull/1419 and can rebase once 1419 is merged.  Meanwhile, all of the changes specific to this feature are currently in https://github.com/brigadecore/brigade/commit/d8397fa38e91d77816c302e545d8fbc08fb2aae0~~

**Special notes for your reviewer**:

I've added a default of 24 hours for max lifetime for both workers and jobs -- should we even have a default if left unspecified?

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
