### PR TITLE
make scheduler and observer use new sdk mock clients

### DIFF
--- a/v2/observer/healthcheck.go
+++ b/v2/observer/healthcheck.go
@@ -21,7 +21,7 @@ func (o *observer) runHealthcheckLoop(ctx context.Context) {
 			// Check Observer -> API Server
 			// Not actually capturing response; just want to verify our API call
 			// is successful
-			if _, err := o.pingAPIServerFn(ctx); err != nil {
+			if _, err := o.systemClient.Ping(ctx); err != nil {
 				o.errCh <- errors.Wrap(
 					err,
 					"error checking Brigade API server connectivity",

--- a/v2/observer/healthcheck_test.go
+++ b/v2/observer/healthcheck_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/brigadecore/brigade/sdk/v2/system"
+	systemTesting "github.com/brigadecore/brigade/sdk/v2/testing/system"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,8 +20,10 @@ func TestRunHealthcheckLoop(t *testing.T) {
 		{
 			name: "error pinging API Server",
 			observer: &observer{
-				pingAPIServerFn: func(context.Context) (system.PingResponse, error) {
-					return system.PingResponse{}, errors.New("something went wrong")
+				systemClient: &systemTesting.MockAPIClient{
+					PingFn: func(context.Context) (system.PingResponse, error) {
+						return system.PingResponse{}, errors.New("something went wrong")
+					},
 				},
 				checkK8sAPIServer: func(context.Context) ([]byte, error) {
 					return []byte{}, nil
@@ -39,8 +42,10 @@ func TestRunHealthcheckLoop(t *testing.T) {
 		{
 			name: "error pinging K8s API Server",
 			observer: &observer{
-				pingAPIServerFn: func(context.Context) (system.PingResponse, error) {
-					return system.PingResponse{}, nil
+				systemClient: &systemTesting.MockAPIClient{
+					PingFn: func(context.Context) (system.PingResponse, error) {
+						return system.PingResponse{}, nil
+					},
 				},
 				checkK8sAPIServer: func(context.Context) ([]byte, error) {
 					return []byte{}, errors.New("something went wrong")
@@ -59,8 +64,10 @@ func TestRunHealthcheckLoop(t *testing.T) {
 		{
 			name: "success",
 			observer: &observer{
-				pingAPIServerFn: func(context.Context) (system.PingResponse, error) {
-					return system.PingResponse{}, nil
+				systemClient: &systemTesting.MockAPIClient{
+					PingFn: func(context.Context) (system.PingResponse, error) {
+						return system.PingResponse{}, nil
+					},
 				},
 				checkK8sAPIServer: func(context.Context) ([]byte, error) {
 					return []byte{}, nil

--- a/v2/observer/jobs.go
+++ b/v2/observer/jobs.go
@@ -133,7 +133,7 @@ func (o *observer) syncJobPod(obj interface{}) {
 	jobName := pod.Labels[myk8s.LabelJob]
 	ctx, cancel := context.WithTimeout(context.Background(), apiRequestTimeout)
 	defer cancel()
-	if err := o.updateJobStatusFn(
+	if err := o.jobsClient.UpdateStatus(
 		ctx,
 		eventID,
 		jobName,
@@ -179,7 +179,7 @@ func (o *observer) deleteJobResources(
 
 	ctx, cancel := context.WithTimeout(context.Background(), apiRequestTimeout)
 	defer cancel()
-	if err := o.cleanupJobFn(ctx, eventID, jobName); err != nil {
+	if err := o.jobsClient.Cleanup(ctx, eventID, jobName); err != nil {
 		o.errFn(
 			fmt.Sprintf(
 				"error cleaning up after event %q job %q: %s",
@@ -224,7 +224,7 @@ func (o *observer) startJobPodTimer(ctx context.Context, pod *corev1.Pod) {
 		case <-timer.C:
 			eventID := pod.Labels[myk8s.LabelEvent]
 			jobName := pod.Labels[myk8s.LabelJob]
-			if err := o.timeoutJobFn(ctx, eventID, jobName); err != nil {
+			if err := o.jobsClient.Timeout(ctx, eventID, jobName); err != nil {
 				o.errFn(
 					errors.Wrapf(
 						err,

--- a/v2/observer/jobs_test.go
+++ b/v2/observer/jobs_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/brigadecore/brigade/sdk/v2/core"
+	coreTesting "github.com/brigadecore/brigade/sdk/v2/testing/core"
 	myk8s "github.com/brigadecore/brigade/v2/internal/kubernetes"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -107,17 +108,19 @@ func TestSyncJobPod(t *testing.T) {
 			observer: &observer{
 				timedPodsSet:       map[string]context.CancelFunc{},
 				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
-				updateJobStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					jobName string,
-					status core.JobStatus,
-				) error {
-					require.Fail(
-						t,
-						"updateJobStatusFn should not have been called, but was",
-					)
-					return nil
+				jobsClient: &coreTesting.MockJobsClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						jobName string,
+						status core.JobStatus,
+					) error {
+						require.Fail(
+							t,
+							"updateJobStatusFn should not have been called, but was",
+						)
+						return nil
+					},
 				},
 				deleteJobResourcesFn: func(_, _, _, _ string) {
 					require.Fail(
@@ -137,14 +140,16 @@ func TestSyncJobPod(t *testing.T) {
 			observer: &observer{
 				timedPodsSet:       map[string]context.CancelFunc{},
 				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
-				updateJobStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					jobName string,
-					status core.JobStatus,
-				) error {
-					require.Equal(t, core.JobPhaseRunning, status.Phase)
-					return nil
+				jobsClient: &coreTesting.MockJobsClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						jobName string,
+						status core.JobStatus,
+					) error {
+						require.Equal(t, core.JobPhaseRunning, status.Phase)
+						return nil
+					},
 				},
 				deleteJobResourcesFn: func(_, _, _, _ string) {
 					require.Fail(
@@ -164,15 +169,17 @@ func TestSyncJobPod(t *testing.T) {
 			observer: &observer{
 				timedPodsSet:       map[string]context.CancelFunc{},
 				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
-				updateJobStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					jobName string,
-					status core.JobStatus,
-				) error {
-					require.Equal(t, core.JobPhaseRunning, status.Phase)
-					require.Nil(t, status.Ended)
-					return nil
+				jobsClient: &coreTesting.MockJobsClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						jobName string,
+						status core.JobStatus,
+					) error {
+						require.Equal(t, core.JobPhaseRunning, status.Phase)
+						require.Nil(t, status.Ended)
+						return nil
+					},
 				},
 				deleteJobResourcesFn: func(_, _, _, _ string) {
 					require.Fail(
@@ -214,16 +221,18 @@ func TestSyncJobPod(t *testing.T) {
 				timedPodsSet: map[string]context.CancelFunc{
 					"ns:nombre": func() {},
 				},
-				updateJobStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					jobName string,
-					status core.JobStatus,
-				) error {
-					require.Equal(t, core.JobPhaseSucceeded, status.Phase)
-					require.NotNil(t, status.Ended)
-					require.Equal(t, now, *status.Ended)
-					return nil
+				jobsClient: &coreTesting.MockJobsClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						jobName string,
+						status core.JobStatus,
+					) error {
+						require.Equal(t, core.JobPhaseSucceeded, status.Phase)
+						require.NotNil(t, status.Ended)
+						require.Equal(t, now, *status.Ended)
+						return nil
+					},
 				},
 				deleteJobResourcesFn: func(_, _, _, _ string) {},
 			},
@@ -238,13 +247,15 @@ func TestSyncJobPod(t *testing.T) {
 			observer: &observer{
 				timedPodsSet:       map[string]context.CancelFunc{},
 				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
-				updateJobStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					jobName string,
-					status core.JobStatus,
-				) error {
-					return errors.New("something went wrong")
+				jobsClient: &coreTesting.MockJobsClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						jobName string,
+						status core.JobStatus,
+					) error {
+						return errors.New("something went wrong")
+					},
 				},
 				errFn: func(i ...interface{}) {
 					require.Len(t, i, 1)
@@ -285,16 +296,18 @@ func TestSyncJobPod(t *testing.T) {
 					"ns:nombre": func() {},
 				},
 				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
-				updateJobStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					jobName string,
-					status core.JobStatus,
-				) error {
-					require.Equal(t, core.JobPhaseFailed, status.Phase)
-					require.NotNil(t, status.Ended)
-					require.Equal(t, now, *status.Ended)
-					return nil
+				jobsClient: &coreTesting.MockJobsClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						jobName string,
+						status core.JobStatus,
+					) error {
+						require.Equal(t, core.JobPhaseFailed, status.Phase)
+						require.NotNil(t, status.Ended)
+						require.Equal(t, now, *status.Ended)
+						return nil
+					},
 				},
 				deleteJobResourcesFn: func(_, _, _, _ string) {},
 			},
@@ -315,14 +328,16 @@ func TestSyncJobPod(t *testing.T) {
 					"ns:nombre": func() {},
 				},
 				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
-				updateJobStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					jobName string,
-					status core.JobStatus,
-				) error {
-					require.Equal(t, core.JobPhaseSucceeded, status.Phase)
-					return nil
+				jobsClient: &coreTesting.MockJobsClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						jobName string,
+						status core.JobStatus,
+					) error {
+						require.Equal(t, core.JobPhaseSucceeded, status.Phase)
+						return nil
+					},
 				},
 				deleteJobResourcesFn: func(_, _, _, _ string) {},
 			},
@@ -343,14 +358,16 @@ func TestSyncJobPod(t *testing.T) {
 					"ns:nombre": func() {},
 				},
 				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
-				updateJobStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					jobName string,
-					status core.JobStatus,
-				) error {
-					require.Equal(t, core.JobPhaseFailed, status.Phase)
-					return nil
+				jobsClient: &coreTesting.MockJobsClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						jobName string,
+						status core.JobStatus,
+					) error {
+						require.Equal(t, core.JobPhaseFailed, status.Phase)
+						return nil
+					},
 				},
 				deleteJobResourcesFn: func(_, _, _, _ string) {},
 			},
@@ -371,14 +388,16 @@ func TestSyncJobPod(t *testing.T) {
 					"ns:nombre": func() {},
 				},
 				startJobPodTimerFn: func(context.Context, *corev1.Pod) {},
-				updateJobStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					jobName string,
-					status core.JobStatus,
-				) error {
-					require.Equal(t, core.JobPhaseUnknown, status.Phase)
-					return nil
+				jobsClient: &coreTesting.MockJobsClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						jobName string,
+						status core.JobStatus,
+					) error {
+						require.Equal(t, core.JobPhaseUnknown, status.Phase)
+						return nil
+					},
 				},
 				deleteJobResourcesFn: func(_, _, _, _ string) {
 					require.Fail(
@@ -428,8 +447,10 @@ func TestDeleteJobResources(t *testing.T) {
 				},
 				deletingPodsSet: map[string]struct{}{},
 				syncMu:          &sync.Mutex{},
-				cleanupJobFn: func(context.Context, string, string) error {
-					return errors.New("something went wrong")
+				jobsClient: &coreTesting.MockJobsClient{
+					CleanupFn: func(context.Context, string, string) error {
+						return errors.New("something went wrong")
+					},
 				},
 				errFn: func(i ...interface{}) {
 					require.Len(t, i, 1)
@@ -448,8 +469,10 @@ func TestDeleteJobResources(t *testing.T) {
 				},
 				deletingPodsSet: map[string]struct{}{},
 				syncMu:          &sync.Mutex{},
-				cleanupJobFn: func(context.Context, string, string) error {
-					return nil
+				jobsClient: &coreTesting.MockJobsClient{
+					CleanupFn: func(context.Context, string, string) error {
+						return nil
+					},
 				},
 				errFn: func(i ...interface{}) {
 					require.Fail(
@@ -556,12 +579,14 @@ func TestStartJobPodTimer(t *testing.T) {
 				timedPodsSet: map[string]context.CancelFunc{
 					"ns:nombre": func() {},
 				},
-				timeoutJobFn: func(
-					ctx context.Context,
-					eventID string,
-					jobName string,
-				) error {
-					return errors.New("something went wrong")
+				jobsClient: &coreTesting.MockJobsClient{
+					TimeoutFn: func(
+						ctx context.Context,
+						eventID string,
+						jobName string,
+					) error {
+						return errors.New("something went wrong")
+					},
 				},
 				errFn: func(i ...interface{}) {
 					require.Len(t, i, 1)
@@ -593,13 +618,15 @@ func TestStartJobPodTimer(t *testing.T) {
 				timedPodsSet: map[string]context.CancelFunc{
 					"ns:nombre": func() {},
 				},
-				timeoutJobFn: func(
-					ctx context.Context,
-					eventID string,
-					jobName string,
-				) error {
-					require.Equal(t, jobName, "italian")
-					return nil
+				jobsClient: &coreTesting.MockJobsClient{
+					TimeoutFn: func(
+						ctx context.Context,
+						eventID string,
+						jobName string,
+					) error {
+						require.Equal(t, jobName, "italian")
+						return nil
+					},
 				},
 				errFn: func(i ...interface{}) {
 					require.Fail(
@@ -624,16 +651,18 @@ func TestStartJobPodTimer(t *testing.T) {
 				timedPodsSet: map[string]context.CancelFunc{
 					"ns:nombre": func() {},
 				},
-				timeoutJobFn: func(
-					ctx context.Context,
-					eventID string,
-					jobName string,
-				) error {
-					require.Fail(
-						t,
-						"timeoutJobFn should not have been called, but was",
-					)
-					return nil
+				jobsClient: &coreTesting.MockJobsClient{
+					TimeoutFn: func(
+						ctx context.Context,
+						eventID string,
+						jobName string,
+					) error {
+						require.Fail(
+							t,
+							"timeoutJobFn should not have been called, but was",
+						)
+						return nil
+					},
 				},
 				errFn: func(i ...interface{}) {
 					require.Fail(

--- a/v2/observer/observer_test.go
+++ b/v2/observer/observer_test.go
@@ -71,7 +71,7 @@ func TestNewObserver(t *testing.T) {
 		apiToken,
 		apiClientOpts,
 	)
-	workerClient := core.NewWorkersClient(
+	workersClient := core.NewWorkersClient(
 		apiAddress,
 		apiToken,
 		apiClientOpts,
@@ -80,8 +80,11 @@ func TestNewObserver(t *testing.T) {
 	config := observerConfig{
 		delayBeforeCleanup: time.Minute,
 	}
-	observer := newObserver(systemClient, workerClient, kubeClient, config)
+	observer := newObserver(systemClient, workersClient, kubeClient, config)
 	require.Same(t, kubeClient, observer.kubeClient)
+	require.NotNil(t, observer.systemClient)
+	require.NotNil(t, observer.workersClient)
+	require.NotNil(t, observer.jobsClient)
 	require.NotNil(t, observer.deletingPodsSet)
 	require.NotNil(t, observer.syncMu)
 	require.NotNil(t, observer.errCh)
@@ -90,10 +93,6 @@ func TestNewObserver(t *testing.T) {
 	require.NotNil(t, observer.syncJobPodsFn)
 	require.NotNil(t, observer.syncJobPodFn)
 	require.NotNil(t, observer.syncDeletedPodFn)
-	require.NotNil(t, observer.updateWorkerStatusFn)
-	require.NotNil(t, observer.cleanupWorkerFn)
-	require.NotNil(t, observer.updateJobStatusFn)
-	require.NotNil(t, observer.cleanupJobFn)
 }
 
 func TestObserverRun(t *testing.T) {

--- a/v2/observer/workers.go
+++ b/v2/observer/workers.go
@@ -98,7 +98,7 @@ func (o *observer) syncWorkerPod(obj interface{}) {
 	eventID := pod.Labels[myk8s.LabelEvent]
 	ctx, cancel := context.WithTimeout(context.Background(), apiRequestTimeout)
 	defer cancel()
-	if err := o.updateWorkerStatusFn(
+	if err := o.workersClient.UpdateStatus(
 		ctx,
 		eventID,
 		status,
@@ -137,7 +137,7 @@ func (o *observer) deleteWorkerResources(namespace, podName, eventID string) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), apiRequestTimeout)
 	defer cancel()
-	if err := o.cleanupWorkerFn(ctx, eventID); err != nil {
+	if err := o.workersClient.Cleanup(ctx, eventID); err != nil {
 		o.errFn(
 			fmt.Sprintf(
 				"error cleaning up after worker for event %q: %s",

--- a/v2/observer/workers_test.go
+++ b/v2/observer/workers_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/brigadecore/brigade/sdk/v2/core"
+	coreTesting "github.com/brigadecore/brigade/sdk/v2/testing/core"
 	myk8s "github.com/brigadecore/brigade/v2/internal/kubernetes"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -104,16 +105,18 @@ func TestSyncWorkerPod(t *testing.T) {
 				},
 			},
 			observer: &observer{
-				updateWorkerStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					status core.WorkerStatus,
-				) error {
-					require.Fail(
-						t,
-						"updateWorkerStatusFn should not have been called, but was",
-					)
-					return nil
+				workersClient: &coreTesting.MockWorkersClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						status core.WorkerStatus,
+					) error {
+						require.Fail(
+							t,
+							"updateWorkerStatusFn should not have been called, but was",
+						)
+						return nil
+					},
 				},
 				deleteWorkerResourcesFn: func(_, _, _ string) {
 					require.Fail(
@@ -131,13 +134,15 @@ func TestSyncWorkerPod(t *testing.T) {
 				},
 			},
 			observer: &observer{
-				updateWorkerStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					status core.WorkerStatus,
-				) error {
-					require.Equal(t, core.WorkerPhaseRunning, status.Phase)
-					return nil
+				workersClient: &coreTesting.MockWorkersClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						status core.WorkerStatus,
+					) error {
+						require.Equal(t, core.WorkerPhaseRunning, status.Phase)
+						return nil
+					},
 				},
 				deleteWorkerResourcesFn: func(_, _, _ string) {
 					require.Fail(
@@ -158,15 +163,17 @@ func TestSyncWorkerPod(t *testing.T) {
 				},
 			},
 			observer: &observer{
-				updateWorkerStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					status core.WorkerStatus,
-				) error {
-					require.Equal(t, core.WorkerPhaseRunning, status.Phase)
-					require.NotNil(t, now, status.Started)
-					require.Equal(t, now, *status.Started)
-					return nil
+				workersClient: &coreTesting.MockWorkersClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						status core.WorkerStatus,
+					) error {
+						require.Equal(t, core.WorkerPhaseRunning, status.Phase)
+						require.NotNil(t, now, status.Started)
+						require.Equal(t, now, *status.Started)
+						return nil
+					},
 				},
 				deleteWorkerResourcesFn: func(_, _, _ string) {
 					require.Fail(
@@ -206,17 +213,19 @@ func TestSyncWorkerPod(t *testing.T) {
 				},
 			},
 			observer: &observer{
-				updateWorkerStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					status core.WorkerStatus,
-				) error {
-					require.Equal(t, core.WorkerPhaseSucceeded, status.Phase)
-					require.NotNil(t, now, status.Started)
-					require.Equal(t, now, *status.Started)
-					require.NotNil(t, now, status.Ended)
-					require.Equal(t, now, *status.Ended)
-					return nil
+				workersClient: &coreTesting.MockWorkersClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						status core.WorkerStatus,
+					) error {
+						require.Equal(t, core.WorkerPhaseSucceeded, status.Phase)
+						require.NotNil(t, now, status.Started)
+						require.Equal(t, now, *status.Started)
+						require.NotNil(t, now, status.Ended)
+						require.Equal(t, now, *status.Ended)
+						return nil
+					},
 				},
 				deleteWorkerResourcesFn: func(_, _, _ string) {},
 			},
@@ -251,17 +260,19 @@ func TestSyncWorkerPod(t *testing.T) {
 				},
 			},
 			observer: &observer{
-				updateWorkerStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					status core.WorkerStatus,
-				) error {
-					require.Equal(t, core.WorkerPhaseFailed, status.Phase)
-					require.NotNil(t, now, status.Started)
-					require.Equal(t, now, *status.Started)
-					require.NotNil(t, now, status.Ended)
-					require.Equal(t, now, *status.Ended)
-					return nil
+				workersClient: &coreTesting.MockWorkersClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						status core.WorkerStatus,
+					) error {
+						require.Equal(t, core.WorkerPhaseFailed, status.Phase)
+						require.NotNil(t, now, status.Started)
+						require.Equal(t, now, *status.Started)
+						require.NotNil(t, now, status.Ended)
+						require.Equal(t, now, *status.Ended)
+						return nil
+					},
 				},
 				deleteWorkerResourcesFn: func(_, _, _ string) {},
 			},
@@ -274,13 +285,15 @@ func TestSyncWorkerPod(t *testing.T) {
 				},
 			},
 			observer: &observer{
-				updateWorkerStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					status core.WorkerStatus,
-				) error {
-					require.Equal(t, core.WorkerPhaseUnknown, status.Phase)
-					return nil
+				workersClient: &coreTesting.MockWorkersClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						status core.WorkerStatus,
+					) error {
+						require.Equal(t, core.WorkerPhaseUnknown, status.Phase)
+						return nil
+					},
 				},
 				deleteWorkerResourcesFn: func(_, _, _ string) {
 					require.Fail(
@@ -298,12 +311,14 @@ func TestSyncWorkerPod(t *testing.T) {
 				},
 			},
 			observer: &observer{
-				updateWorkerStatusFn: func(
-					ctx context.Context,
-					eventID string,
-					status core.WorkerStatus,
-				) error {
-					return errors.New("something went wrong")
+				workersClient: &coreTesting.MockWorkersClient{
+					UpdateStatusFn: func(
+						ctx context.Context,
+						eventID string,
+						status core.WorkerStatus,
+					) error {
+						return errors.New("something went wrong")
+					},
 				},
 				errFn: func(i ...interface{}) {
 					require.Len(t, i, 1)
@@ -351,8 +366,10 @@ func TestDeleteWorkerResources(t *testing.T) {
 				},
 				deletingPodsSet: map[string]struct{}{},
 				syncMu:          &sync.Mutex{},
-				cleanupWorkerFn: func(context.Context, string) error {
-					return errors.New("something went wrong")
+				workersClient: &coreTesting.MockWorkersClient{
+					CleanupFn: func(context.Context, string) error {
+						return errors.New("something went wrong")
+					},
 				},
 				errFn: func(i ...interface{}) {
 					require.Len(t, i, 1)
@@ -371,8 +388,10 @@ func TestDeleteWorkerResources(t *testing.T) {
 				},
 				deletingPodsSet: map[string]struct{}{},
 				syncMu:          &sync.Mutex{},
-				cleanupWorkerFn: func(context.Context, string) error {
-					return nil
+				workersClient: &coreTesting.MockWorkersClient{
+					CleanupFn: func(context.Context, string) error {
+						return nil
+					},
 				},
 				errFn: func(i ...interface{}) {
 					require.Fail(

--- a/v2/scheduler/jobs.go
+++ b/v2/scheduler/jobs.go
@@ -30,7 +30,7 @@ func (s *scheduler) manageJobCapacity(ctx context.Context) {
 					return false, nil // Stop looking
 				default:
 				}
-				substrateJobCount, err := s.countRunningJobsFn(ctx)
+				substrateJobCount, err := s.substrateClient.CountRunningJobs(ctx)
 				if err != nil {
 					return false, err // Real error; stop retrying
 				}
@@ -133,11 +133,11 @@ outerLoop:
 			eventID := messageTokens[0]
 			jobName := messageTokens[1]
 
-			event, err := s.getEventFn(ctx, eventID)
+			event, err := s.eventsClient.Get(ctx, eventID)
 			if err != nil {
 				s.jobLoopErrFn(err)
 
-				if err := s.updateJobStatusFn(
+				if err := s.jobsClient.UpdateStatus(
 					ctx,
 					eventID,
 					jobName,
@@ -192,7 +192,7 @@ outerLoop:
 
 			// Now use the API to start the Job...
 
-			if err := s.startJobFn(ctx, event.ID, jobName); err != nil {
+			if err := s.jobsClient.Start(ctx, event.ID, jobName); err != nil {
 				s.jobLoopErrFn(err)
 			}
 

--- a/v2/scheduler/projects.go
+++ b/v2/scheduler/projects.go
@@ -23,7 +23,7 @@ func (s *scheduler) manageProjects(ctx context.Context) {
 		currentProjects := map[string]struct{}{}
 		listOpts := &meta.ListOptions{Limit: 100}
 		for {
-			projects, err := s.listProjectsFn(ctx, nil, listOpts)
+			projects, err := s.projectsClient.List(ctx, nil, listOpts)
 			if err != nil {
 				select {
 				case s.errCh <- errors.Wrap(err, "error listing projects"):

--- a/v2/scheduler/projects_test.go
+++ b/v2/scheduler/projects_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/brigadecore/brigade/sdk/v2/core"
 	"github.com/brigadecore/brigade/sdk/v2/meta"
+	coreTesting "github.com/brigadecore/brigade/sdk/v2/testing/core"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,12 +25,14 @@ func TestManageProjects(t *testing.T) {
 					config: schedulerConfig{
 						addAndRemoveProjectsInterval: time.Second,
 					},
-					listProjectsFn: func(
-						context.Context,
-						*core.ProjectsSelector,
-						*meta.ListOptions,
-					) (core.ProjectList, error) {
-						return core.ProjectList{}, errors.New("something went wrong")
+					projectsClient: &coreTesting.MockProjectsClient{
+						ListFn: func(
+							context.Context,
+							*core.ProjectsSelector,
+							*meta.ListOptions,
+						) (core.ProjectList, error) {
+							return core.ProjectList{}, errors.New("something went wrong")
+						},
 					},
 				}
 			},
@@ -46,20 +49,22 @@ func TestManageProjects(t *testing.T) {
 					config: schedulerConfig{
 						addAndRemoveProjectsInterval: time.Second,
 					},
-					listProjectsFn: func(
-						context.Context,
-						*core.ProjectsSelector,
-						*meta.ListOptions,
-					) (core.ProjectList, error) {
-						return core.ProjectList{
-							Items: []core.Project{
-								{
-									ObjectMeta: meta.ObjectMeta{
-										ID: "blue-book",
+					projectsClient: &coreTesting.MockProjectsClient{
+						ListFn: func(
+							context.Context,
+							*core.ProjectsSelector,
+							*meta.ListOptions,
+						) (core.ProjectList, error) {
+							return core.ProjectList{
+								Items: []core.Project{
+									{
+										ObjectMeta: meta.ObjectMeta{
+											ID: "blue-book",
+										},
 									},
 								},
-							},
-						}, nil
+							}, nil
+						},
 					},
 					runWorkerLoopFn: func(context.Context, string) {},
 					runJobLoopFn:    func(context.Context, string) {},

--- a/v2/scheduler/scheduler_test.go
+++ b/v2/scheduler/scheduler_test.go
@@ -98,6 +98,11 @@ func TestNewScheduler(t *testing.T) {
 	}
 	scheduler := newScheduler(coreClient, queueReaderFactory, config)
 	require.Same(t, queueReaderFactory, scheduler.queueReaderFactory)
+	require.NotNil(t, scheduler.projectsClient)
+	require.NotNil(t, scheduler.substrateClient)
+	require.NotNil(t, scheduler.eventsClient)
+	require.NotNil(t, scheduler.workersClient)
+	require.NotNil(t, scheduler.jobsClient)
 	require.Equal(t, config, scheduler.config)
 	require.NotNil(t, scheduler.workerAvailabilityCh)
 	require.NotNil(t, scheduler.jobAvailabilityCh)

--- a/v2/scheduler/workers.go
+++ b/v2/scheduler/workers.go
@@ -28,7 +28,7 @@ func (s *scheduler) manageWorkerCapacity(ctx context.Context) {
 					return false, nil // Stop looking
 				default:
 				}
-				substrateWorkerCount, err := s.countRunningWorkersFn(ctx)
+				substrateWorkerCount, err := s.substrateClient.CountRunningWorkers(ctx)
 				if err != nil {
 					return false, err // Real error; stop retrying
 				}
@@ -117,11 +117,11 @@ outerLoop:
 
 			eventID := msg.Message
 
-			event, err := s.getEventFn(ctx, eventID)
+			event, err := s.eventsClient.Get(ctx, eventID)
 			if err != nil {
 				s.workerLoopErrFn(err)
 
-				if err := s.updateWorkerStatusFn(
+				if err := s.workersClient.UpdateStatus(
 					ctx,
 					eventID,
 					core.WorkerStatus{
@@ -160,7 +160,7 @@ outerLoop:
 
 			// Now use the API to start the Worker...
 
-			if err := s.startWorkerFn(ctx, event.ID); err != nil {
+			if err := s.workersClient.Start(ctx, event.ID); err != nil {
 				s.workerLoopErrFn(err)
 			}
 


### PR DESCRIPTION
Follows up on #1440 to make use of the SDK's new mock clients.

This is a modest increase in LOC, but imho, improves the clarity of the scheduler and observer code quite a bit because it requires a lot less thought about the indirection that is taking place.