### PR TITLE
ref(*): projects only receive events if subscribed

### DIFF
--- a/examples/02-first-event/project.yaml
+++ b/examples/02-first-event/project.yaml
@@ -5,6 +5,10 @@ metadata:
   id: first-event
 description: Demonstrates responding to an event with brigadier
 spec:
+  eventSubscriptions:
+  - source: brigade.sh/cli
+    types:
+    - exec
   workerTemplate:
     logLevel: DEBUG
     defaultConfigFiles:

--- a/examples/03-first-job/project.yaml
+++ b/examples/03-first-job/project.yaml
@@ -5,6 +5,10 @@ metadata:
   id: first-job
 description: Demonstrates running a job with brigadier
 spec:
+  eventSubscriptions:
+  - source: brigade.sh/cli
+    types:
+    - exec
   workerTemplate:
     logLevel: DEBUG
     defaultConfigFiles:

--- a/examples/04-simple-pipeline/project.yaml
+++ b/examples/04-simple-pipeline/project.yaml
@@ -5,6 +5,10 @@ metadata:
   id: simple-pipeline
 description: Demonstrates a simple pipeline with brigadier
 spec:
+  eventSubscriptions:
+  - source: brigade.sh/cli
+    types:
+    - exec
   workerTemplate:
     logLevel: DEBUG
     defaultConfigFiles:

--- a/examples/05-groups/project.yaml
+++ b/examples/05-groups/project.yaml
@@ -5,6 +5,10 @@ metadata:
   id: groups
 description: Demonstrates a complex pipeline using groups
 spec:
+  eventSubscriptions:
+  - source: brigade.sh/cli
+    types:
+    - exec
   workerTemplate:
     logLevel: DEBUG
     defaultConfigFiles:

--- a/examples/10-shared-workspace/project.yaml
+++ b/examples/10-shared-workspace/project.yaml
@@ -5,6 +5,10 @@ metadata:
   id: shared-workspace
 description: Demonstrates a workspace shared across jobs
 spec:
+  eventSubscriptions:
+  - source: brigade.sh/cli
+    types:
+    - exec
   workerTemplate:
     logLevel: DEBUG
     useWorkspace: true

--- a/examples/11-kitchen-sink/project.yaml
+++ b/examples/11-kitchen-sink/project.yaml
@@ -5,6 +5,10 @@ metadata:
   id: kitchen-sink
 description: A project that demonstrates the kitchen sink!
 spec:
+  eventSubscriptions:
+  - source: brigade.sh/cli
+    types:
+    - exec
   workerTemplate:
     logLevel: DEBUG
     configFilesDirectory: examples/11-kitchen-sink/.brigade

--- a/v2/apiserver/internal/core/projects.go
+++ b/v2/apiserver/internal/core/projects.go
@@ -84,6 +84,21 @@ func (p ProjectList) MarshalJSON() ([]byte, error) {
 	)
 }
 
+// Contains returns a boolean value indicating whether the ProjectList contains
+// the provided Project
+func (p ProjectList) Contains(project Project) bool {
+	for _, proj := range p.Items {
+		if proj.ID == project.ID {
+			if proj.Kubernetes == nil && project.Kubernetes == nil ||
+				proj.Kubernetes != nil && project.Kubernetes != nil &&
+					proj.Kubernetes.Namespace == project.Kubernetes.Namespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ProjectSpec is the technical component of a Project. It pairs
 // EventSubscriptions with a prototypical WorkerSpec that is used as a template
 // for creating new Workers.

--- a/v2/apiserver/internal/core/projects_test.go
+++ b/v2/apiserver/internal/core/projects_test.go
@@ -19,6 +19,64 @@ func TestProjectListMarshalJSON(t *testing.T) {
 	metaTesting.RequireAPIVersionAndType(t, &ProjectList{}, "ProjectList")
 }
 
+func TestProjectListContains(t *testing.T) {
+	testProject := Project{
+		ObjectMeta: meta.ObjectMeta{
+			ID: "myproject",
+		},
+		Kubernetes: &KubernetesDetails{
+			Namespace: "mynamespace",
+		},
+	}
+
+	t.Run("empty list", func(t *testing.T) {
+		projectList := ProjectList{}
+		require.False(t, projectList.Contains(testProject))
+	})
+
+	t.Run("project not in list", func(t *testing.T) {
+		projectList := ProjectList{
+			Items: []Project{
+				{
+					ObjectMeta: meta.ObjectMeta{
+						ID: "diffproject",
+					},
+				},
+			},
+		}
+		require.False(t, projectList.Contains(testProject))
+	})
+
+	t.Run("name matches, namespace does not", func(t *testing.T) {
+		projectList := ProjectList{
+			Items: []Project{
+				{
+					ObjectMeta: meta.ObjectMeta{
+						ID: "myproject",
+					},
+				},
+			},
+		}
+		require.False(t, projectList.Contains(testProject))
+	})
+
+	t.Run("project matches", func(t *testing.T) {
+		projectList := ProjectList{
+			Items: []Project{
+				{
+					ObjectMeta: meta.ObjectMeta{
+						ID: "myproject",
+					},
+					Kubernetes: &KubernetesDetails{
+						Namespace: "mynamespace",
+					},
+				},
+			},
+		}
+		require.True(t, projectList.Contains(testProject))
+	})
+}
+
 func TestNewProjectsService(t *testing.T) {
 	projectsStore := &mockProjectsStore{}
 	eventsStore := &mockEventsStore{}

--- a/v2/cli/event_commands.go
+++ b/v2/cli/event_commands.go
@@ -423,6 +423,14 @@ func eventCreate(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	if len(events.Items) == 0 {
+		fmt.Printf(
+			"Project %q not subscribed to events of this type. No event created.",
+			projectID,
+		)
+		return nil
+	}
+
 	event = events.Items[0]
 	fmt.Printf("Created event %q.\n\n", event.ID)
 

--- a/v2/cli/event_commands.go
+++ b/v2/cli/event_commands.go
@@ -425,7 +425,7 @@ func eventCreate(c *cli.Context) error {
 	}
 	if len(events.Items) == 0 {
 		fmt.Printf(
-			"Project %q not subscribed to events of this type. No event created.",
+			"Project %q is not subscribed to events of this type. No event created.",
 			projectID,
 		)
 		return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

* Updates logic to ensure that a project only receives events according to their event subscriptions.  The main breaking change is thus: even if an event targets a particular project, it will only be delivered if that particular project is confirmed to be a subscriber.

Closes https://github.com/brigadecore/brigade/issues/1438

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
