### PR TITLE
ref(jobs.ts): update brigadier-polyfill's Job.run() to use sdk

### DIFF
--- a/v2/brigadier-polyfill/package.json
+++ b/v2/brigadier-polyfill/package.json
@@ -27,9 +27,10 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
+    "@brigadecore/brigade-sdk": "^v2.0.0-alpha.5",
+    "@brigadecore/brigadier": "../brigadier",
     "@types/node": "^14.14.11",
     "axios": "^0.21.0",
-    "@brigadecore/brigadier": "../brigadier",
     "eventsource": "^1.0.7",
     "winston": "^3.3.3"
   }

--- a/v2/brigadier-polyfill/package.json
+++ b/v2/brigadier-polyfill/package.json
@@ -30,7 +30,6 @@
     "@brigadecore/brigade-sdk": "^v2.0.0-alpha.5",
     "@brigadecore/brigadier": "../brigadier",
     "@types/node": "^14.14.11",
-    "axios": "^0.21.0",
     "eventsource": "^1.0.7",
     "winston": "^3.3.3"
   }

--- a/v2/brigadier-polyfill/src/jobs.ts
+++ b/v2/brigadier-polyfill/src/jobs.ts
@@ -1,12 +1,11 @@
-import * as https from "https"
-
 // For some reason, EventSource NEEDS to be required this way.
 const EventSource = require("eventsource") // eslint-disable-line @typescript-eslint/no-var-requires
 
-import axios from "axios"
 import { Logger } from "winston" 
 
 import { Event, Job as BrigadierJob } from "@brigadecore/brigadier"
+
+import { core } from "@brigadecore/brigade-sdk"
 
 import { logger } from "./logger"
 
@@ -21,32 +20,22 @@ export class Job extends BrigadierJob {
   async run(): Promise<void> {
     this.logger.info(`Creating job ${this.name}`)
     try {
-      const response = await axios({
-        httpsAgent: new https.Agent(
-          {
-            rejectUnauthorized: false
-          }
-        ),
-        method: "post",
-        url: `${this.event.worker.apiAddress}/v2/events/${this.event.id}/worker/jobs`,
-        headers: {
-          Authorization: `Bearer ${this.event.worker.apiToken}`
-        },
-        data: {
-          apiVersion: "brigade.sh/v2-alpha.5",
-          kind: "Job",
-          name: this.name,
-          spec: {
-            primaryContainer: this.primaryContainer,
-            sidecarContainers: this.sidecarContainers,
-            timeoutDuration: this.timeoutSeconds + "s",
-            host: this.host
-          }
-        },
-      })
-      if (response.status != 201) {
-        throw new Error(`Received ${response.status} from the API server`)
+      const jobsClient = new core.JobsClient(
+        this.event.worker.apiAddress,
+        this.event.worker.apiToken,
+        {allowInsecureConnections: true},
+      )
+
+      let sdkJob: core.Job = {
+        name: this.name,
+        spec: {
+          primaryContainer: this.primaryContainer,
+          sidecarContainers: this.sidecarContainers,
+          timeoutDuration: this.timeoutSeconds + "s",
+          host: this.host
+        }
       }
+      await jobsClient.create(this.event.id, sdkJob)
     }
     catch(e) {
       throw new Error(`Error creating job "${this.name}": ${e.message}`)

--- a/v2/brigadier-polyfill/src/jobs.ts
+++ b/v2/brigadier-polyfill/src/jobs.ts
@@ -26,7 +26,7 @@ export class Job extends BrigadierJob {
         {allowInsecureConnections: true},
       )
 
-      let sdkJob: core.Job = {
+      const sdkJob: core.Job = {
         name: this.name,
         spec: {
           primaryContainer: this.primaryContainer,

--- a/v2/brigadier-polyfill/test/jobs.ts
+++ b/v2/brigadier-polyfill/test/jobs.ts
@@ -2,6 +2,7 @@ import "mocha"
 import { assert } from "chai"
 
 import { Container, Event, Job, JobHost } from "../src"
+import { ImagePullPolicy } from "../../brigadier/dist/jobs"
 
 describe("jobs", () => {
 
@@ -25,10 +26,11 @@ describe("jobs", () => {
       const job = new Job("my-name", "debian:latest", event)
       it("initializes fields properly", () => {
         assert.equal(job.name, "my-name")
-        assert.deepEqual(new Container("debian:latest"), job.primaryContainer)
-        assert.deepEqual({}, job.sidecarContainers)
-        assert.equal(60 * 15, job.timeoutSeconds)
-        assert.deepEqual(new JobHost(), job.host)
+        assert.deepEqual(job.primaryContainer, new Container("debian:latest"))
+        assert.deepEqual(job.primaryContainer.imagePullPolicy, ImagePullPolicy.IfNotPresent)
+        assert.deepEqual(job.sidecarContainers, {})
+        assert.equal(job.timeoutSeconds, 60 * 15)
+        assert.deepEqual(job.host, new JobHost())
         assert.isDefined(job.logger)
       })
     })

--- a/v2/brigadier-polyfill/yarn.lock
+++ b/v2/brigadier-polyfill/yarn.lock
@@ -23,8 +23,19 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@brigadecore/brigade-sdk@^v2.0.0-alpha.5":
+  version "2.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@brigadecore/brigade-sdk/-/brigade-sdk-2.0.0-alpha.5.tgz#1e7c6fb6fc64312f1aa67ecb193aaac1fe9a10c5"
+  integrity sha512-+g0CMmHrVbSuOlxPBKo3a4bRkXbq8TYqTsmNg9ts8HSSuAScTk5O/bnRi5Qvj/vdl7ZJhvlTAXD1m7HpRuyyAA==
+  dependencies:
+    axios "^0.21.0"
+    event-source-polyfill "^1.0.22"
+    eventsource "^1.0.7"
+    js-base64 "^3.6.0"
+    querystring "^0.2.0"
+
 "@brigadecore/brigadier@../brigadier":
-  version "0.0.1"
+  version "0.0.1-placeholder"
   dependencies:
     "@types/node" "^14.14.11"
 
@@ -650,6 +661,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+event-source-polyfill@^1.0.22:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.24.tgz#46045e9af2190fd51234de0075d71c909907f937"
+  integrity sha512-aEtMhrH5ww3X6RgbsNcwu0whw8zjOoeRnwPqRKqKuxWS5KlAZhCY+rTm6wMlHOXbxmLGn8lW6Xox7rfpBExzGA==
+
 eventsource@^1.0.7:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.1.0.tgz#00e8ca7c92109e94b0ddf32dac677d841028cfaf"
@@ -936,6 +952,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+js-base64@^3.6.0:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.6.1.tgz#555aae398b74694b4037af1f8a5a6209d170efbe"
+  integrity sha512-Frdq2+tRRGLQUIQOgsIGSCd1VePCS2fsddTG5dTCqR0JHgltXWfsxnY0gIXPoMeRmdom6Oyq+UMOFg5suduOjQ==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -1205,6 +1226,11 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+querystring@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"
+  integrity sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
 
 querystringify@^2.1.1:
   version "2.2.0"

--- a/v2/brigadier/src/jobs.ts
+++ b/v2/brigadier/src/jobs.ts
@@ -149,6 +149,25 @@ export class Job implements Runnable {
 }
 
 /**
+ * Represents a policy for whether container hosts already having a certain OCI
+ * image should attempt to re-pull that image prior to launching a new container
+ * based on that image.
+ */
+ export enum ImagePullPolicy {
+  /**
+   * Represents a policy wherein container hosts
+   * only attempt to pull an OCI image if that image does not already exist on
+   * the host
+   */
+  IfNotPresent = "IfNotPresent",
+  /**
+   * Represents a policy wherein container hosts will always attempt to re-pull
+   * an OCI image before launching a container based on that image
+   */
+  Always = "Always"
+}
+
+/**
  * A single OCI container in a Job.
  */
 export class Container {
@@ -159,7 +178,7 @@ export class Container {
    * that is already in its local cache. The permitted values are as IfNotPresent
    * (the default) and Always.
    */
-  public imagePullPolicy = "IfNotPresent"
+  public imagePullPolicy: ImagePullPolicy = ImagePullPolicy.IfNotPresent
   /** The working directory for the process running in the container. */
   public workingDirectory = ""
   /**

--- a/v2/brigadier/src/jobs.ts
+++ b/v2/brigadier/src/jobs.ts
@@ -153,7 +153,7 @@ export class Job implements Runnable {
  * image should attempt to re-pull that image prior to launching a new container
  * based on that image.
  */
- export enum ImagePullPolicy {
+export enum ImagePullPolicy {
   /**
    * Represents a policy wherein container hosts
    * only attempt to pull an OCI image if that image does not already exist on

--- a/v2/brigadier/test/jobs.ts
+++ b/v2/brigadier/test/jobs.ts
@@ -2,7 +2,7 @@ import "mocha"
 import { assert } from "chai"
 
 import { Event } from "../src/events"
-import { Job, Container, JobHost } from "../src/jobs"
+import { Job, Container, JobHost, ImagePullPolicy } from "../src/jobs"
 
 describe("jobs", () => {
 
@@ -26,10 +26,11 @@ describe("jobs", () => {
       const job = new Job("my-name", "debian:latest", event)
       it("initializes fields properly", () => {
         assert.equal(job.name, "my-name")
-        assert.deepEqual(new Container("debian:latest"), job.primaryContainer)
-        assert.deepEqual({}, job.sidecarContainers)
-        assert.equal(60 * 15, job.timeoutSeconds)
-        assert.deepEqual(new JobHost(), job.host)
+        assert.deepEqual(job.primaryContainer, new Container("debian:latest"))
+        assert.deepEqual(job.primaryContainer.imagePullPolicy, ImagePullPolicy.IfNotPresent)
+        assert.deepEqual(job.sidecarContainers, {})
+        assert.equal(job.timeoutSeconds, 60 * 15)
+        assert.deepEqual(job.host, new JobHost())
       })
     })
   })
@@ -38,11 +39,11 @@ describe("jobs", () => {
     describe("#constructor", () => {
       const container = new Container("debian:latest")
       it("initializes fields properly", () => {
-        assert.equal("debian:latest", container.image)
-        assert.equal("IfNotPresent", container.imagePullPolicy)
-        assert.deepEqual([], container.command)
-        assert.deepEqual([], container.arguments)
-        assert.deepEqual({}, container.environment)
+        assert.equal(container.image, "debian:latest")
+        assert.equal(container.imagePullPolicy, ImagePullPolicy.IfNotPresent)
+        assert.deepEqual(container.command, [])
+        assert.deepEqual(container.arguments, [])
+        assert.deepEqual(container.environment, {})
         assert.isEmpty(container.workspaceMountPath)
         assert.isEmpty(container.sourceMountPath)
         assert.isFalse(container.privileged)
@@ -57,7 +58,7 @@ describe("jobs", () => {
       it("initializes fields properly", () => {
         assert.isUndefined(jobHost.os)
         assert.isDefined(jobHost.nodeSelector)
-        assert.equal(0, Object.keys(jobHost.nodeSelector).length)
+        assert.equal(Object.keys(jobHost.nodeSelector).length, 0)
       })
     })
   })

--- a/v2/worker/yarn.lock
+++ b/v2/worker/yarn.lock
@@ -23,12 +23,23 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@brigadecore/brigade-sdk@^v2.0.0-alpha.5":
+  version "2.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@brigadecore/brigade-sdk/-/brigade-sdk-2.0.0-alpha.5.tgz#1e7c6fb6fc64312f1aa67ecb193aaac1fe9a10c5"
+  integrity sha512-+g0CMmHrVbSuOlxPBKo3a4bRkXbq8TYqTsmNg9ts8HSSuAScTk5O/bnRi5Qvj/vdl7ZJhvlTAXD1m7HpRuyyAA==
+  dependencies:
+    axios "^0.21.0"
+    event-source-polyfill "^1.0.22"
+    eventsource "^1.0.7"
+    js-base64 "^3.6.0"
+    querystring "^0.2.0"
+
 "@brigadecore/brigadier-polyfill@../brigadier-polyfill":
   version "0.0.1-placeholder"
   dependencies:
+    "@brigadecore/brigade-sdk" "^v2.0.0-alpha.5"
     "@brigadecore/brigadier" "../brigadier"
     "@types/node" "^14.14.11"
-    axios "^0.21.0"
     eventsource "^1.0.7"
     winston "^3.3.3"
 
@@ -661,6 +672,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+event-source-polyfill@^1.0.22:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.24.tgz#46045e9af2190fd51234de0075d71c909907f937"
+  integrity sha512-aEtMhrH5ww3X6RgbsNcwu0whw8zjOoeRnwPqRKqKuxWS5KlAZhCY+rTm6wMlHOXbxmLGn8lW6Xox7rfpBExzGA==
+
 eventsource@^1.0.7:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.1.0.tgz#00e8ca7c92109e94b0ddf32dac677d841028cfaf"
@@ -959,6 +975,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+js-base64@^3.6.0:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.6.1.tgz#555aae398b74694b4037af1f8a5a6209d170efbe"
+  integrity sha512-Frdq2+tRRGLQUIQOgsIGSCd1VePCS2fsddTG5dTCqR0JHgltXWfsxnY0gIXPoMeRmdom6Oyq+UMOFg5suduOjQ==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -1243,6 +1264,11 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+querystring@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"
+  integrity sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
 
 querystringify@^2.1.1:
   version "2.2.0"


### PR DESCRIPTION
**What this PR does / why we need it**:

* Updates Job.run() in brigadier-polyfill to use the [js/ts SDK](https://github.com/brigadecore/brigade-sdk-for-js)
* Had to update brigadier's `ImagePullPolicy` to match the SDK's, so that container specs could be compatible.

Fixes https://github.com/brigadecore/brigade/issues/1291

**Special notes for your reviewer**:

Willing to re-do the seemingly unrelated yarn.lock changes if y'all can point me how to _only_ add the brigade-sdk dependency :)  I just used `yarn install`.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
