### PR TITLE
feat(cli): add output flag to service account create cmd

### DIFF
--- a/v2/cli/flags.go
+++ b/v2/cli/flags.go
@@ -46,9 +46,10 @@ const (
 )
 
 const (
-	flagOutputJSON  = "json"
-	flagOutputTable = "table"
-	flagOutputYAML  = "yaml"
+	flagOutputJSON      = "json"
+	flagOutputTable     = "table"
+	flagOutputYAML      = "yaml"
+	flagOutputPlaintext = "plaintext"
 )
 
 var (

--- a/v2/cli/service_account_commands.go
+++ b/v2/cli/service_account_commands.go
@@ -116,6 +116,17 @@ func serviceAccountCreate(c *cli.Context) error {
 	description := c.String(flagDescription)
 	id := c.String(flagID)
 
+	// Validate output format
+	// Note: currently not using validateOutputFormat as this command supports
+	// plaintext as opposed to table output.
+	switch strings.ToLower(output) {
+	case flagOutputPlaintext:
+	case flagOutputYAML:
+	case flagOutputJSON:
+	default:
+		return errors.Errorf("unknown output format %q", output)
+	}
+
 	client, err := getClient()
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds an output format flag to the `brig service-acccount create` command.  This will be handy for automation to quickly/easily parse the returned token value.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
