### PR TITLE
fix slice index out of bounds in k8s log stream

### DIFF
--- a/v2/apiserver/internal/core/kubernetes/logs_store.go
+++ b/v2/apiserver/internal/core/kubernetes/logs_store.go
@@ -117,6 +117,9 @@ func (l *logsStore) StreamLogs(
 			if err == io.EOF {
 				break
 			}
+			if len(logLine) == 0 {
+				continue
+			}
 			// The last character should be a newline that we don't want, so let's
 			// remove that
 			logLine = logLine[:len(logLine)-1]


### PR DESCRIPTION
Fixes #1462 