### PR TITLE
subscribed our own brigade 2 project to push events

### DIFF
--- a/.brigade/project.yaml
+++ b/.brigade/project.yaml
@@ -13,6 +13,7 @@ spec:
     - check_run:rerequested
     - check_suite:requested
     - check_suite:rerequested
+    - push
   workerTemplate:
     git:
       cloneURL: https://github.com/brigadecore/brigade.git


### PR DESCRIPTION
This change has already been applied using:

```console
$ brig project update -f .brigade/project.yaml
```

This PR is only so we have an up-to-date copy of the project definition available as a contingency if we ever have to rebuild our dogfood cluster.