### PR TITLE
fix edge publishing

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -233,7 +233,7 @@ async function runSuite(event: Event): Promise<void> {
       buildCLIJob(event)
     )
   ).run()
-  if (event.worker?.git?.ref == "/refs/heads/v2") {
+  if (event.worker?.git?.ref == "v2") {
     // Push "edge" images.
     //
     // npm packages MUST be semantically versioned, so we DON'T publish an


### PR DESCRIPTION
This fixes a mistake in the `brigade.ts` script. It was looking for ref `/refs/heads/v2` as evidence that the check suite was triggered by a merge to v2, but the value it _should_ be checking for is simply `v2`.