### PR TITLE
fix(.github): use action env stanza for env vars

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    env:
+      DOCKER_ORG: brigadecore
     steps:
       - uses: actions/checkout@v2
       - name: Build Windows logger agent
@@ -20,4 +22,4 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push Windows logger agent
-        run: DOCKER_ORG=brigadecore make push-logger-windows
+        run: make push-logger-windows

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    env:
+      DOCKER_ORG: brigadecore
     steps:
       - uses: actions/checkout@v2
       - name: Build Windows logger agent


### PR DESCRIPTION
We set it at the job level so that the built images will have the correct org as well.