### PR TITLE
fix(server_test.go): use different ports for ListenAndServe test variants

### DIFF
--- a/v2/apiserver/internal/lib/restmachinery/server_test.go
+++ b/v2/apiserver/internal/lib/restmachinery/server_test.go
@@ -145,6 +145,7 @@ func TestListenAndServe(t *testing.T) {
 				keyFile, err := ioutil.TempFile("", "tls-*.key")
 				require.NoError(t, err)
 				return &ServerConfig{
+					Port:        8082,
 					TLSEnabled:  true,
 					TLSCertPath: certFile.Name(),
 					TLSKeyPath:  keyFile.Name(),
@@ -177,6 +178,7 @@ func TestListenAndServe(t *testing.T) {
 				require.NoError(t, err)
 
 				return &ServerConfig{
+					Port:        8081,
 					TLSEnabled:  true,
 					TLSCertPath: certFile.Name(),
 					TLSKeyPath:  keyFile.Name(),
@@ -187,19 +189,16 @@ func TestListenAndServe(t *testing.T) {
 				require.Equal(t, ctx.Err(), err)
 			},
 		},
-		// TODO: re-enable if/when we can fix its tendency for intermittent failure
-		// https://github.com/brigadecore/brigade/issues/1137
-		//
-		// {
-		// 	name: "TLS not enabled",
-		// 	setup: func() *ServerConfig {
-		// 		return nil
-		// 	},
-		// 	assertions: func(ctx context.Context, err error) {
-		// 		require.Error(t, err)
-		// 		require.Equal(t, ctx.Err(), err)
-		// 	},
-		// },
+		{
+			name: "TLS not enabled",
+			setup: func() *ServerConfig {
+				return nil
+			},
+			assertions: func(ctx context.Context, err error) {
+				require.Error(t, err)
+				require.Equal(t, ctx.Err(), err)
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
**Update:** thanks to @krancour's suggestion of just using different ports for the test variants in question, this is what I've done.  These 808x ports seem to always be available in a test context and the race condition of one being in use when the next test runs is thus averted.


~~* Adds allowance for "address already in use" errors to pop up in the ListenAndServe tests~~

~~I figured this would be acceptable as it doesn't commonly occur and we ensure any other type of error does fail the test. Thoughts?~~

~~We'll know when it pops up:~~
```
2021/07/08 21:29:01 API server is listening with TLS enabled on 0.0.0.0:8080
=== RUN   TestListenAndServe/TLS_enabled
2021/07/08 21:29:10 API server is listening with TLS enabled on 0.0.0.0:8080
=== RUN   TestListenAndServe/TLS_not_enabled
2021/07/08 21:29:10 API server is listening without TLS on 0.0.0.0:8080
    server_test.go:217: Received error "address already in use"
--- PASS: TestListenAndServe (9.52s)
```

~~I also figured it wasn't worth the hassle to add in logic to try to rerun the test when we hit this, since most of the test runs in CI/locally will not encounter this behavior.  But open to ways to do so if we wish!~~

Closes https://github.com/brigadecore/brigade/issues/1137