### PR TITLE
brigade.ts: strip project name from check run name to find job name

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -258,7 +258,10 @@ events.on("brigade.sh/github", "check_suite:rerequested", runSuite)
 
 // This event indicates a specific job is to be re-run.
 events.on("brigade.sh/github", "check_run:rerequested", async event => {
-  const jobName = JSON.parse(event.payload).check_run.name
+  // Check run names are of the form <project name>:<job name>, so we strip
+  // event.project.id.length + 1 characters off the start of the check run name
+  // to find the job name.
+  const jobName = JSON.parse(event.payload).check_run.name.slice(event.project.id.length + 1)
   const job = jobs[jobName]
   if (job) {
     await job(event).run()


### PR DESCRIPTION
This fixes an issue with our handling of `check_run:rerequested` events from the next GitHub gateway.