### PR TITLE
Update to latest alpine because of EOL

### DIFF
--- a/git-sidecar/Dockerfile
+++ b/git-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.14
 
 RUN apk update && apk add --no-cache \
     ca-certificates \

--- a/git-sidecar/README.md
+++ b/git-sidecar/README.md
@@ -1,3 +1,3 @@
 # git-sidecar
 
-The gt-sidecar container fetches and checks out a specific commit from a git repository.
+The git-sidecar container fetches and checks out a specific commit from a git repository.


### PR DESCRIPTION
Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>

**What this PR does / why we need it**:
Alpine 3.8 is EOL since 2020-05-01.
https://alpinelinux.org/releases/
So, update to the latest supported release.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
