### PR TITLE
Update examples

### DIFF
--- a/examples/07-npm/.brigade/package-lock.json
+++ b/examples/07-npm/.brigade/package-lock.json
@@ -5,14 +5,15 @@
   "packages": {
     "": {
       "dependencies": {
-        "@brigadecore/brigadier": "2.0.0-alpha.5",
+        "@brigadecore/brigadier": "2.0.0-beta.1",
         "unique-names-generator": "4.4.0"
       }
     },
     "node_modules/@brigadecore/brigadier": {
-      "version": "2.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@brigadecore/brigadier/-/brigadier-2.0.0-alpha.5.tgz",
-      "integrity": "sha512-XGWanIOpiiRi46n+yD0B+1hkpnEEPoHEwEn7Ut2gP1i0dK6xC6aWq90flM4Np/k365qjS1CLkLtQIkplVPyVag==",
+      "version": "2.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@brigadecore/brigadier/-/brigadier-2.0.0-beta.1.tgz",
+      "integrity": "sha512-PoDfSAYMpqXyhTP+DBE7B1xHXtCxuW7SCLcH9/yQyr4kgeKxsAyYvy1baQx1G5ujpWcKX4ULmxf7dsJdHPX+3w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^14.14.11"
       }
@@ -34,9 +35,9 @@
   },
   "dependencies": {
     "@brigadecore/brigadier": {
-      "version": "2.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@brigadecore/brigadier/-/brigadier-2.0.0-alpha.5.tgz",
-      "integrity": "sha512-XGWanIOpiiRi46n+yD0B+1hkpnEEPoHEwEn7Ut2gP1i0dK6xC6aWq90flM4Np/k365qjS1CLkLtQIkplVPyVag==",
+      "version": "2.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@brigadecore/brigadier/-/brigadier-2.0.0-beta.1.tgz",
+      "integrity": "sha512-PoDfSAYMpqXyhTP+DBE7B1xHXtCxuW7SCLcH9/yQyr4kgeKxsAyYvy1baQx1G5ujpWcKX4ULmxf7dsJdHPX+3w==",
       "requires": {
         "@types/node": "^14.14.11"
       }

--- a/examples/07-npm/.brigade/package.json
+++ b/examples/07-npm/.brigade/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@brigadecore/brigadier": "2.0.0-alpha.5",
+    "@brigadecore/brigadier": "2.0.0-beta.1",
     "unique-names-generator": "4.4.0"
   }
 }

--- a/examples/08-yarn/.brigade/package.json
+++ b/examples/08-yarn/.brigade/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@brigadecore/brigadier": "2.0.0-alpha.5",
+    "@brigadecore/brigadier": "2.0.0-beta.1",
     "unique-names-generator": "4.4.0"
   }
 }

--- a/examples/08-yarn/.brigade/yarn.lock
+++ b/examples/08-yarn/.brigade/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@brigadecore/brigadier@2.0.0-alpha.5":
-  version "2.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@brigadecore/brigadier/-/brigadier-2.0.0-alpha.5.tgz#d053d3db78e1828c9b992eadf15eac7ed916943e"
-  integrity sha512-XGWanIOpiiRi46n+yD0B+1hkpnEEPoHEwEn7Ut2gP1i0dK6xC6aWq90flM4Np/k365qjS1CLkLtQIkplVPyVag==
+"@brigadecore/brigadier@2.0.0-beta.1":
+  version "2.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@brigadecore/brigadier/-/brigadier-2.0.0-beta.1.tgz#8abd9461d445d1d13c83404cec22c16f3cbc2104"
+  integrity sha512-PoDfSAYMpqXyhTP+DBE7B1xHXtCxuW7SCLcH9/yQyr4kgeKxsAyYvy1baQx1G5ujpWcKX4ULmxf7dsJdHPX+3w==
   dependencies:
     "@types/node" "^14.14.11"
 

--- a/examples/11-kitchen-sink/.brigade/package.json
+++ b/examples/11-kitchen-sink/.brigade/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@brigadecore/brigadier": "2.0.0-alpha.5",
+    "@brigadecore/brigadier": "2.0.0-beta.1",
     "unique-names-generator": "4.4.0"
   }
 }

--- a/examples/11-kitchen-sink/.brigade/yarn.lock
+++ b/examples/11-kitchen-sink/.brigade/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@brigadecore/brigadier@2.0.0-alpha.5":
-  version "2.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@brigadecore/brigadier/-/brigadier-2.0.0-alpha.5.tgz#d053d3db78e1828c9b992eadf15eac7ed916943e"
-  integrity sha512-XGWanIOpiiRi46n+yD0B+1hkpnEEPoHEwEn7Ut2gP1i0dK6xC6aWq90flM4Np/k365qjS1CLkLtQIkplVPyVag==
+"@brigadecore/brigadier@2.0.0-beta.1":
+  version "2.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@brigadecore/brigadier/-/brigadier-2.0.0-beta.1.tgz#8abd9461d445d1d13c83404cec22c16f3cbc2104"
+  integrity sha512-PoDfSAYMpqXyhTP+DBE7B1xHXtCxuW7SCLcH9/yQyr4kgeKxsAyYvy1baQx1G5ujpWcKX4ULmxf7dsJdHPX+3w==
   dependencies:
     "@types/node" "^14.14.11"
 


### PR DESCRIPTION
This is not strictly necessary since workers will always swap in their own brigadier polyfill at runtime, but just for the sake of keeping our example nice and clean and up to date, this updates them to use the beta.1 release of Brigadier.