### PR TITLE
add creation date/time stamp to jobs

### DIFF
--- a/sdk/v2/core/jobs.go
+++ b/sdk/v2/core/jobs.go
@@ -79,6 +79,10 @@ func (j JobPhase) IsTerminal() bool {
 type Job struct {
 	// Name is the Job's name. It should be unique among a given Worker's Jobs.
 	Name string `json:"name"`
+	// Created indicates the time at which a Job was created. This is recorded by
+	// the system. Clients must leave the value of this field set to nil when
+	// using the API to create a Job.
+	Created *time.Time `json:"created,omitempty"`
 	// Spec is the technical blueprint for the Job.
 	Spec JobSpec `json:"spec"`
 	// Status contains details of the Job's current state.

--- a/v2/apiserver/internal/core/jobs.go
+++ b/v2/apiserver/internal/core/jobs.go
@@ -79,6 +79,8 @@ func (j JobPhase) IsTerminal() bool {
 type Job struct {
 	// Name is the Job's name. It should be unique among a given Worker's Jobs.
 	Name string `json:"name" bson:"name"`
+	// Created indicates the time at which a Job was created.
+	Created *time.Time `json:"created,omitempty"`
 	// Spec is the technical blueprint for the Job.
 	Spec JobSpec `json:"spec" bson:"spec"`
 	// Status contains details of the Job's current state.
@@ -361,6 +363,9 @@ func (j *jobsService) Create(
 				"configuration has not enabled this feature.",
 		}
 	}
+
+	now := time.Now().UTC()
+	job.Created = &now
 
 	// Set the initial status
 	job.Status = &JobStatus{


### PR DESCRIPTION
In Kubernetes terms (since our API is heavily inspired by theirs), jobs are "synthetic resources" because they aren't their own thing than can exist independently of something else-- namely an event. This quirk means they're not composed of an `ObjectMeta` and as such were lacking a `Created` date/time stamp field. This info turns out to be useful, however, so this PR adds it.