### PR TITLE
3rd party authn: fix how we check for github org membership

### DIFF
--- a/v2/apiserver/internal/authn/github/third_party_auth_helper_test.go
+++ b/v2/apiserver/internal/authn/github/third_party_auth_helper_test.go
@@ -21,7 +21,7 @@ func TestAuthURL(t *testing.T) {
 	const testClientID = "foo"
 	const testState = "foo"
 	testAuthURL := fmt.Sprintf(
-		"https://github.com/login/oauth/authorize?client_id=%s&state=%s",
+		"https://github.com/login/oauth/authorize?client_id=%s&state=%s&scope=read%%3Aorg", // nolint: lll
 		testClientID,
 		testState,
 	)


### PR DESCRIPTION
Fixes #1504 

We're already running this in our dogfood cluster and it's working as expected.