### PR TITLE
docs(*): align prev/next pagination according to config.toml layout

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -58,134 +58,134 @@ relativeURLs = "true"
     [[menu.index]]
     name = "Operators"
     url = "/topics/operators/"
-    weight = 45
+    weight = 50
     identifier = "operators"
     parent = "topics"
     [[menu.index]]
     name = "Deployment"
     url = "/topics/operators/deploy/"
-    weight = 46
+    weight = 51
     parent = "operators"
     [[menu.index]]
     name = "Securing Brigade"
     url = "/topics/operators/security/"
-    weight = 47
+    weight = 52
     parent = "operators"
     [[menu.index]]
     name = "Storage"
     url = "/topics/operators/storage/"
-    weight = 48
+    weight = 53
     parent = "operators"
     [[menu.index]]
     name = "Gateways"
     url = "/topics/operators/gateways/"
-    weight = 49
+    weight = 54
     parent = "operators"
 
     # Administrators
     [[menu.index]]
     name = "Administrators"
     url = "/topics/administrators/"
-    weight = 50
+    weight = 60
     identifier = "administrators"
     parent = "topics"
     [[menu.index]]
     name = "Authentication"
     url = "/topics/administrators/authentication/"
-    weight = 51
+    weight = 61
     parent = "administrators"
     [[menu.index]]
     name = "Authorization"
     url = "/topics/administrators/authorization/"
-    weight = 52
+    weight = 62
     parent = "administrators"
 
     # Project Developers
     [[menu.index]]
     name = "Project Developers"
     url = "/topics/project-developers/"
-    weight = 55
+    weight = 70
     identifier = "project-developers"
     parent = "topics"
     [[menu.index]]
     name = "Projects"
     url = "/topics/project-developers/projects/"
-    weight = 56
+    weight = 71
     parent = "project-developers"
     [[menu.index]]
     name = "Events"
     url = "/topics/project-developers/events/"
-    weight = 57
+    weight = 72
     parent = "project-developers"
     [[menu.index]]
     name = "Secrets"
     url = "/topics/project-developers/secrets/"
-    weight = 58
+    weight = 73
     parent = "project-developers"
     [[menu.index]]
     name = "Using the brig CLI"
     url = "/topics/project-developers/brig/"
-    weight = 59
+    weight = 74
     parent = "project-developers"
     [[menu.index]]
     name = "Brigterm"
     url = "/topics/project-developers/brigterm/"
-    weight = 60
+    weight = 75
     parent = "project-developers"
 
     # Scripting
     [[menu.index]]
     name = "Scripting"
     url = "/topics/scripting/"
-    weight = 65
+    weight = 80
     identifier = "scripting"
     parent = "topics"
     [[menu.index]]
     name = "Scripting Guide"
     url = "/topics/scripting/guide/"
-    weight = 66
+    weight = 81
     parent = "scripting"
     [[menu.index]]
     name = "The Brigadier Library"
     url = "/topics/scripting/brigadier/"
-    weight = 67
+    weight = 82
     parent = "scripting"
     [[menu.index]]
     name = "Advanced Scripting Guide"
     url = "/topics/scripting/advanced/"
-    weight = 68
+    weight = 83
     parent = "scripting"
     [[menu.index]]
     name = "Dependencies"
     url = "/topics/scripting/dependencies/"
-    weight = 69
+    weight = 84
     parent = "scripting"
     [[menu.index]]
     name = "Workers"
     url = "/topics/scripting/workers/"
-    weight = 70
+    weight = 85
     parent = "scripting"
 
     # Other Topics
     [[menu.index]]
     name = "Developer Guide"
     url = "/topics/developers/"
-    weight = 75
+    weight = 90
     parent = "topics"
     [[menu.index]]
     name = "Examples"
     url = "/topics/examples/"
-    weight = 76
+    weight = 91
     parent = "topics"
     [[menu.index]]
     name = "Releasing Brigade"
     url = "/topics/releasing/"
-    weight = 80
+    weight = 92
     parent = "topics"
     [[menu.index]]
     name = "Contributing"
     url = "/topics/contributing/"
-    weight = 81
+    weight = 93
     parent = "topics"
 
 # top navigation - project links

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -53,6 +53,8 @@ relativeURLs = "true"
     url = "/topics/roles/"
     weight = 42
     parent = "topics"
+
+    # Operators
     [[menu.index]]
     name = "Operators"
     url = "/topics/operators/"
@@ -79,6 +81,8 @@ relativeURLs = "true"
     url = "/topics/operators/gateways/"
     weight = 49
     parent = "operators"
+
+    # Administrators
     [[menu.index]]
     name = "Administrators"
     url = "/topics/administrators/"
@@ -95,6 +99,8 @@ relativeURLs = "true"
     url = "/topics/administrators/authorization/"
     weight = 52
     parent = "administrators"
+
+    # Project Developers
     [[menu.index]]
     name = "Project Developers"
     url = "/topics/project-developers/"
@@ -126,6 +132,8 @@ relativeURLs = "true"
     url = "/topics/project-developers/brigterm/"
     weight = 60
     parent = "project-developers"
+
+    # Scripting
     [[menu.index]]
     name = "Scripting"
     url = "/topics/scripting/"
@@ -157,6 +165,8 @@ relativeURLs = "true"
     url = "/topics/scripting/workers/"
     weight = 70
     parent = "scripting"
+
+    # Other Topics
     [[menu.index]]
     name = "Developer Guide"
     url = "/topics/developers/"
@@ -167,15 +177,16 @@ relativeURLs = "true"
     url = "/topics/examples/"
     weight = 76
     parent = "topics"
-[[menu.index]]
+    [[menu.index]]
     name = "Releasing Brigade"
-    url = "/releasing/"
+    url = "/topics/releasing/"
     weight = 80
+    parent = "topics"
     [[menu.index]]
     name = "Contributing"
-    url = "/contributing/"
+    url = "/topics/contributing/"
     weight = 81
-
+    parent = "topics"
 
 # top navigation - project links
 [[menu.main]]

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -18,7 +18,7 @@ writing advanced Brigade scripts. [Dive deep into what makes Brigade, Brigade](t
 
 ### Releasing Brigade
 
-For maintainers of this project, steps on cutting a new release of Brigade can be found [here](releasing).
+For maintainers of this project, steps on cutting a new release of Brigade can be found [here](topics/releasing).
 
 ### Related Resources
 

--- a/docs/content/intro/install.md
+++ b/docs/content/intro/install.md
@@ -2,6 +2,7 @@
 title: Installing Brigade
 description: 'Quick install guide for Brigade'
 section: intro
+weight: 3
 aliases:
   - /install.md
   - /intro/install.md

--- a/docs/content/intro/overview.md
+++ b/docs/content/intro/overview.md
@@ -2,6 +2,7 @@
 title: Brigade Overview
 description: High-level view of Brigade.
 section: intro
+weight: 1
 aliases: 
   - /overview.md
   - /intro/overview.md

--- a/docs/content/intro/quickstart.md
+++ b/docs/content/intro/quickstart.md
@@ -2,6 +2,7 @@
 title: A Brigade Quickstart
 description: A Brigade Quickstart.
 section: intro
+weight: 2
 aliases:
   - /quickstart.md
   - /intro/quickstart.md

--- a/docs/content/intro/readnext.md
+++ b/docs/content/intro/readnext.md
@@ -1,6 +1,8 @@
 ---
 title: What to Read Next
 description: Additional steps and tips for learning Brigade
+section: intro
+weight: 4
 aliases:
   - /readnext.md
   - /intro/readnext.md

--- a/docs/content/topics/administrators/_index.md
+++ b/docs/content/topics/administrators/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Administrators
 description: Brigade system administrators
+section: topics
+weight: 4
 aliases:
   - /index.md
   - /topics/administrators/index.md

--- a/docs/content/topics/administrators/authentication.md
+++ b/docs/content/topics/administrators/authentication.md
@@ -1,6 +1,8 @@
 ---
 title: Authentication
 description: Authentication configuration for Brigade
+section: administrators
+weight: 1
 ---
 
 # Brigade Authentication

--- a/docs/content/topics/administrators/authorization.md
+++ b/docs/content/topics/administrators/authorization.md
@@ -1,6 +1,8 @@
 ---
 title: Authorization
 description: Authorization setup for Brigade
+section: administrators
+weight: 2
 ---
 
 # Brigade Authorization

--- a/docs/content/topics/contributing.md
+++ b/docs/content/topics/contributing.md
@@ -1,6 +1,8 @@
 ---
 title: Contributing
 description: 'Contributing Guide'
+section: topics
+weight: 10
 ---
 # Contributing Guide
 

--- a/docs/content/topics/design.md
+++ b/docs/content/topics/design.md
@@ -1,6 +1,8 @@
 ---
 title: Design
 description: How Brigade is designed
+section: topics
+weight: 1
 aliases:
   - /design.md
   - /topics/design.md

--- a/docs/content/topics/developers.md
+++ b/docs/content/topics/developers.md
@@ -1,6 +1,8 @@
 ---
 title: Developer Guide
 description: How to get started developing Brigade
+section: topics
+weight: 7
 aliases:
   - /developers.md
   - /topics/developers.md

--- a/docs/content/topics/examples.md
+++ b/docs/content/topics/examples.md
@@ -1,6 +1,8 @@
 ---
 title: Examples
 description: Brigade examples
+section: topics
+weight: 8
 aliases:
   - /examples.md
   - /topics/examples.md

--- a/docs/content/topics/operators/_index.md
+++ b/docs/content/topics/operators/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Operators
 description: Brigade system operators
+section: topics
+weight: 3
 aliases:
   - /index.md
   - /topics/operators/index.md

--- a/docs/content/topics/operators/deploy.md
+++ b/docs/content/topics/operators/deploy.md
@@ -1,6 +1,8 @@
 ---
 title: Deployment
 description: How to deploy and manage Brigade
+section: operators
+weight: 1
 aliases:
   - /deploy.md
   - /topics/deploy.md

--- a/docs/content/topics/operators/gateways.md
+++ b/docs/content/topics/operators/gateways.md
@@ -1,6 +1,8 @@
 ---
 title: Gateways
 description: How gateways work and how to create your own.
+section: operators
+weight: 4
 aliases:
   - /gateways.md
   - /topics/gateways.md

--- a/docs/content/topics/operators/security.md
+++ b/docs/content/topics/operators/security.md
@@ -1,6 +1,8 @@
 ---
 title: Securing Brigade
 description: 'How to configure security for Brigade.'
+section: operators
+weight: 2
 aliases:
   - /security.md
   - /intro/security.md

--- a/docs/content/topics/operators/storage.md
+++ b/docs/content/topics/operators/storage.md
@@ -1,6 +1,8 @@
 ---
 title: Storage
 description: 'How Brigade uses Kubernetes Persistent Storage.'
+section: operators
+weight: 3
 aliases:
   - /storage.md
   - /intro/storage.md

--- a/docs/content/topics/project-developers/_index.md
+++ b/docs/content/topics/project-developers/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Project Developers
 description: Brigade project developers
+section: topics
+weight: 5
 aliases:
   - /index.md
   - /topics/project-developers/index.md

--- a/docs/content/topics/project-developers/brigterm.md
+++ b/docs/content/topics/project-developers/brigterm.md
@@ -1,6 +1,8 @@
 ---
 title: Brigterm
 description: Using the Brigterm visualization utility
+section: project-developers
+weight: 5
 aliases:
   - /brigterm.md
   - /topics/brigterm.md

--- a/docs/content/topics/project-developers/events.md
+++ b/docs/content/topics/project-developers/events.md
@@ -1,6 +1,8 @@
 ---
 title: Events
 description: Handling Events in Brigade
+section: project-developers
+weight: 2
 aliases:
   - /events.md
   - /topics/events.md

--- a/docs/content/topics/project-developers/projects.md
+++ b/docs/content/topics/project-developers/projects.md
@@ -1,6 +1,8 @@
 ---
 title: Projects
 description: How to manage Brigade Projects
+section: project-developers
+weight: 1
 aliases:
   - /projects.md
   - /topics/projects.md

--- a/docs/content/topics/project-developers/secrets.md
+++ b/docs/content/topics/project-developers/secrets.md
@@ -1,6 +1,8 @@
 ---
 title: Secret Management
 description: How to use and manage secrets in Brigade
+section: project-developers
+weight: 3
 aliases:
   - /secrets.md
   - /topics/secrets.md

--- a/docs/content/topics/releasing.md
+++ b/docs/content/topics/releasing.md
@@ -1,6 +1,8 @@
 ---
 title: Releasing Brigade 2
 description: How to cut a new release of Brigade 2
+section: topics
+weight: 9
 aliases:
   - /releasing.md
   - /intro/releasing.md

--- a/docs/content/topics/roles.md
+++ b/docs/content/topics/roles.md
@@ -1,6 +1,8 @@
 ---
 title: Brigade Roles
 description: An overview of the roles in Brigade
+section: topics
+weight: 2
 aliases:
   - /roles.md
   - /topics/roles.md

--- a/docs/content/topics/scripting/_index.md
+++ b/docs/content/topics/scripting/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Scripting
 description: Writing Brigade project scripts
+section: topics
+weight: 6
 aliases:
   - /index.md
   - /topics/scripting/index.md

--- a/docs/content/topics/scripting/advanced.md
+++ b/docs/content/topics/scripting/advanced.md
@@ -1,6 +1,8 @@
 ---
 title: Advanced Scripting Guide
 description: 'This guide provides some tips and ideas for advanced scripting.'
+section: scripting
+weight: 3
 aliases:
   - /advanced.md
   - /topics/advanced.md

--- a/docs/content/topics/scripting/brigadier.md
+++ b/docs/content/topics/scripting/brigadier.md
@@ -1,6 +1,8 @@
 ---
 title: The Brigade.js API
 description: Describing the public APIs typically used for writing Brigade.js
+section: scripting
+weight: 2
 aliases:
   - /brigadier.md
   - /topics/brigadier.md

--- a/docs/content/topics/scripting/dependencies.md
+++ b/docs/content/topics/scripting/dependencies.md
@@ -1,6 +1,8 @@
 ---
 title: Dependencies
 description: How dependencies work in Brigade
+section: scripting
+weight: 4
 aliases:
   - /dependencies.md
   - /topics/dependencies.md

--- a/docs/content/topics/scripting/guide.md
+++ b/docs/content/topics/scripting/guide.md
@@ -1,6 +1,8 @@
 ---
 title: Scripting Guide
 description: 'How to create and structure `brigade.js` files.'
+section: scripting
+weight: 1
 aliases:
   - /guide.md
   - /topics/guide.md

--- a/docs/content/topics/scripting/workers.md
+++ b/docs/content/topics/scripting/workers.md
@@ -1,6 +1,8 @@
 ---
 title: 'Workers'
 description: 'How to add custom libraries to a Brigade worker'
+section: scripting
+weight: 5
 aliases:
   - /workers.md
   - /topics/workers.md

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -10,3 +10,11 @@
 The docs site is rendered using the [Hugo](https://gohugo.io/) static site generator, and a custom theme which borrows from the [Porter](https://github.com/getporter/porter) and [Helm](https://github.com/helm/helm-www) projects.
 
 Commits to the v2 branch are auto deployed to the staging site via Netlify.
+
+## Weights
+
+Currently, the weights configured in the `config.toml` file specify ordering of each section in the main sidebar menu.
+
+Weight values on individual documents are meant to specify ordering of pagination (previous and next navigation) within each doc's section.
+
+This is fairly unwieldy, so if any docs/Hugo pros have knowledge on how to simplify, we'd love the contribution!


### PR DESCRIPTION
* Aligns the prev/next pagination with the layout prescribed in the config.toml

Basically, if a `weight` isn't declared in a doc, the pagination will fall back to alphabetical ordering.

Fixes https://github.com/brigadecore/brigade/issues/1498