### PR TITLE
update link in readme for brigade-bitbucket-gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ integrations already exist!
 Gateways receive events from upstream systems (the "outside world") and convert
 them to Brigade events that are emitted into Brigade's event bus.
 
-* [Brigade Bitbucket Gateway](https://github.com/brigadecore/brigade-bitbucket-gateway)
+* [Brigade Bitbucket Gateway](https://github.com/brigadecore/brigade-bitbucket-gateway/tree/v2)
 * [Brigade CloudEvents Gateway](https://github.com/brigadecore/brigade-cloudevents-gateway)
 * [Brigade GitHub Gateway](https://github.com/brigadecore/brigade-github-gateway)
 


### PR DESCRIPTION
Realized that because the brigade-bitbucket-gateway has a master branch (Brigade v1.x compatible) and a new v2 branch (Brigade 2 compatible) it is probably a good idea to link directly to that repo's v2 branch instead of the master branch.