### PR TITLE
update examples so all subscribe to events from cli

### DIFF
--- a/examples/01-hello-world/project.yaml
+++ b/examples/01-hello-world/project.yaml
@@ -5,6 +5,10 @@ metadata:
   id: hello-world
 description: The simplest possible example
 spec:
+  eventSubscriptions:
+  - source: brigade.sh/cli
+    types:
+    - exec
   workerTemplate:
     logLevel: DEBUG
     defaultConfigFiles:

--- a/examples/06-git/project.yaml
+++ b/examples/06-git/project.yaml
@@ -5,6 +5,10 @@ metadata:
   id: git
 description: A project with whose script is stored in a git repository
 spec:
+  eventSubscriptions:
+  - source: brigade.sh/cli
+    types:
+    - exec
   workerTemplate:
     logLevel: DEBUG
     configFilesDirectory: examples/06-git/.brigade

--- a/examples/07-npm/project.yaml
+++ b/examples/07-npm/project.yaml
@@ -5,6 +5,10 @@ metadata:
   id: npm
 description: A project with third-party dependencies managed using npm
 spec:
+  eventSubscriptions:
+  - source: brigade.sh/cli
+    types:
+    - exec
   workerTemplate:
     logLevel: DEBUG
     configFilesDirectory: examples/07-npm/.brigade

--- a/examples/08-yarn/project.yaml
+++ b/examples/08-yarn/project.yaml
@@ -5,6 +5,10 @@ metadata:
   id: yarn
 description: A project with third-party dependencies managed using yarn
 spec:
+  eventSubscriptions:
+  - source: brigade.sh/cli
+    types:
+    - exec
   workerTemplate:
     logLevel: DEBUG
     configFilesDirectory: examples/08-yarn/.brigade

--- a/examples/09-typescript/project.yaml
+++ b/examples/09-typescript/project.yaml
@@ -5,6 +5,10 @@ metadata:
   id: hello-typescript
 description: You can use TypeScript!
 spec:
+  eventSubscriptions:
+  - source: brigade.sh/cli
+    types:
+    - exec
   workerTemplate:
     logLevel: DEBUG
     defaultConfigFiles:

--- a/examples/12-first-payload/project.yaml
+++ b/examples/12-first-payload/project.yaml
@@ -5,6 +5,10 @@ metadata:
   id: first-payload
 description: Demonstrates using the event payload
 spec:
+  eventSubscriptions:
+  - source: brigade.sh/cli
+    types:
+    - exec
   workerTemplate:
     logLevel: DEBUG
     defaultConfigFiles:


### PR DESCRIPTION
Follow up to #1445 

Since #1445, several examples couldn't be triggered by the CLI because they weren't subscribed to any events from the CLI.

This PR fixes that.