### PR TITLE
Fix link to the github gateway

### DIFF
--- a/docs/content/intro/install.md
+++ b/docs/content/intro/install.md
@@ -109,11 +109,11 @@ such as `brigade.sh/cli:exec` (the event source and type generated from the `bri
 
 Currently, the list of official Brigade v2 gateways that process external events is as follows:
 
-* [Github Gateway](/topics/operators/gateways.md#github-gateway)
+* [Github Gateway](https://github.com/brigadecore/brigade-github-gateway)
 * [BitBucket Gateway](https://github.com/brigadecore/brigade-bitbucket-gateway/tree/v2)
 * [CloudEvents Gateway](https://github.com/brigadecore/brigade-cloudevents-gateway)
 
-[Gateway]: ../topics/operators/gateways.md
+[Gateway]: /topics/operators/gateways/
 
 ## Troubleshooting
 

--- a/docs/content/topics/operators/gateways.md
+++ b/docs/content/topics/operators/gateways.md
@@ -9,11 +9,6 @@ aliases:
   - /topics/operators/gateways.md
 ---
 
-TODO: update per v2
-
-# Github Gateway
-TODO: Add [GitHub Gateway](https://github.com/brigadecore/brigade-github-gateway) mention/link.
-
 # Brigade Gateways
 
 This guide explains how gateways work, and provides guidance for creating your own


### PR DESCRIPTION
**What this PR does / why we need it**:
The link to the GitHub Gateway is broken.

**Special notes for your reviewer**:
The gateway page itself needs work in a separate PR. A lot of the links are broken because the pages are missing.

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
