### PR TITLE
fix readnext link; adjust ordering of install and quickstart docs

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -24,13 +24,13 @@ relativeURLs = "true"
     weight = 21
     parent = "intro"
     [[menu.index]]
-    name = "QuickStart"
-    url = "/intro/quickstart/"
+    name = "Installing Brigade"
+    url = "/intro/install/"
     weight = 22
     parent = "intro"
     [[menu.index]]
-    name = "Installing Brigade"
-    url = "/intro/install/"
+    name = "QuickStart"
+    url = "/intro/quickstart/"
     weight = 23
     parent = "intro"
     [[menu.index]]

--- a/docs/content/intro/_index.md
+++ b/docs/content/intro/_index.md
@@ -28,6 +28,6 @@ if you work your way through these guides you should come out knowing pretty muc
 ## Table of Contents
 
 - [Brigade at a glance](overview)
-- [QuickStart](quickstart)
 - [Installation Guide](install)
+- [QuickStart](quickstart)
 - [What to read next](readnext)

--- a/docs/content/intro/install.md
+++ b/docs/content/intro/install.md
@@ -2,7 +2,7 @@
 title: Installing Brigade
 description: 'Quick install guide for Brigade'
 section: intro
-weight: 3
+weight: 2
 aliases:
   - /install.md
   - /intro/install.md

--- a/docs/content/intro/quickstart.md
+++ b/docs/content/intro/quickstart.md
@@ -2,7 +2,7 @@
 title: A Brigade Quickstart
 description: A Brigade Quickstart.
 section: intro
-weight: 2
+weight: 3
 aliases:
   - /quickstart.md
   - /intro/quickstart.md
@@ -274,10 +274,9 @@ Otherwise, you can remove ALL resources created in this QuickStart by either:
 ## Next Steps
 
 You now know how to install Brigade on a local development cluster, define a project, and trigger an event for the project.
-Next learn how to [install and configure Brigade](/intro/install/) on a production cluster, or continue on to the [Read Next]
-document where we review the more advanced topics to delve into.
+Continue on to the [Read Next] document where we review more advanced topics to delve into.
 
-[Read Next]: /readnext
+[Read Next]: /intro/readnext
 
 ## Troubleshooting
 


### PR DESCRIPTION
* Fixes the 'Read Next' link in the QuickStart doc
* Swaps order of Install and QuickStart docs, so that the next page after QuickStart goes to the Read Next doc


Fixes https://github.com/brigadecore/brigade/issues/1543