### PR TITLE
explicitly direct user to NOTES.txt after brig init

### DIFF
--- a/v2/cli/init_command.go
+++ b/v2/cli/init_command.go
@@ -241,6 +241,8 @@ func initialize(c *cli.Context) error {
 	fmt.Printf("Adding %s to .gitignore...\n", secretsPath)
 	fmt.Printf("Adding .brigade/node_modules/ to .gitignore...\n")
 
+	fmt.Printf("\nPlease refer to %s for next steps.\n", notesPath)
+
 	return nil
 }
 


### PR DESCRIPTION
Noticed during @willie-yao's demo yesterday that we could be more explicit about directing `brig init` users to `.brigade/NOTES.txt` for next steps.