### PR TITLE
add user delete functionality

### DIFF
--- a/sdk/v2/authn/users.go
+++ b/sdk/v2/authn/users.go
@@ -91,6 +91,9 @@ type UsersClient interface {
 	// Unlock restores system access for a single User (after presumably having
 	// been revoked) specified by their identifier.
 	Unlock(context.Context, string) error
+
+	// Delete deletes a single User specified by their identifier.
+	Delete(context.Context, string) error
 }
 
 type usersClient struct {
@@ -156,6 +159,17 @@ func (u *usersClient) Unlock(ctx context.Context, id string) error {
 		rm.OutboundRequest{
 			Method:      http.MethodDelete,
 			Path:        fmt.Sprintf("v2/users/%s/lock", id),
+			SuccessCode: http.StatusOK,
+		},
+	)
+}
+
+func (u *usersClient) Delete(ctx context.Context, id string) error {
+	return u.ExecuteRequest(
+		ctx,
+		rm.OutboundRequest{
+			Method:      http.MethodDelete,
+			Path:        fmt.Sprintf("v2/users/%s", id),
 			SuccessCode: http.StatusOK,
 		},
 	)

--- a/sdk/v2/authn/users_test.go
+++ b/sdk/v2/authn/users_test.go
@@ -136,3 +136,24 @@ func TestUsersClientUnlock(t *testing.T) {
 	err := client.Unlock(context.Background(), testUserID)
 	require.NoError(t, err)
 }
+
+func TestUsersClientDelete(t *testing.T) {
+	const testUserID = "tony@starkindustries.com"
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodDelete, r.Method)
+				require.Equal(
+					t,
+					fmt.Sprintf("/v2/users/%s", testUserID),
+					r.URL.Path,
+				)
+				w.WriteHeader(http.StatusOK)
+			},
+		),
+	)
+	defer server.Close()
+	client := NewUsersClient(server.URL, rmTesting.TestAPIToken, nil)
+	err := client.Delete(context.Background(), testUserID)
+	require.NoError(t, err)
+}

--- a/sdk/v2/testing/authn/mock_users_client.go
+++ b/sdk/v2/testing/authn/mock_users_client.go
@@ -16,6 +16,7 @@ type MockUsersClient struct {
 	GetFn    func(context.Context, string) (authn.User, error)
 	LockFn   func(context.Context, string) error
 	UnlockFn func(context.Context, string) error
+	DeleteFn func(context.Context, string) error
 }
 
 func (m *MockUsersClient) List(
@@ -39,4 +40,8 @@ func (m *MockUsersClient) Lock(ctx context.Context, id string) error {
 
 func (m *MockUsersClient) Unlock(ctx context.Context, id string) error {
 	return m.UnlockFn(ctx, id)
+}
+
+func (m *MockUsersClient) Delete(ctx context.Context, id string) error {
+	return m.DeleteFn(ctx, id)
 }

--- a/v2/apiserver/internal/api/mongodb/project_role_assignments_store.go
+++ b/v2/apiserver/internal/api/mongodb/project_role_assignments_store.go
@@ -227,6 +227,24 @@ func (p *projectRoleAssignmentsStore) RevokeByProjectID(
 	return nil
 }
 
+func (p *projectRoleAssignmentsStore) RevokeByPrincipal(
+	ctx context.Context,
+	principalReference api.PrincipalReference,
+) error {
+	if _, err := p.collection.DeleteMany(
+		ctx,
+		bson.M{"principal": principalReference},
+	); err != nil {
+		return errors.Wrapf(
+			err,
+			"error deleting project role assignments for %s %q",
+			principalReference.Type,
+			principalReference.ID,
+		)
+	}
+	return nil
+}
+
 func (p *projectRoleAssignmentsStore) Exists(
 	ctx context.Context,
 	projectRoleAssignment api.ProjectRoleAssignment,

--- a/v2/apiserver/internal/api/mongodb/role_assignments_store.go
+++ b/v2/apiserver/internal/api/mongodb/role_assignments_store.go
@@ -192,6 +192,24 @@ func (r *roleAssignmentsStore) Revoke(
 	return nil
 }
 
+func (r *roleAssignmentsStore) RevokeByPrincipal(
+	ctx context.Context,
+	principalReference api.PrincipalReference,
+) error {
+	if _, err := r.collection.DeleteMany(
+		ctx,
+		bson.M{"principal": principalReference},
+	); err != nil {
+		return errors.Wrapf(
+			err,
+			"error deleting role assignments for %s %q",
+			principalReference.Type,
+			principalReference.ID,
+		)
+	}
+	return nil
+}
+
 func (r *roleAssignmentsStore) Exists(
 	ctx context.Context,
 	roleAssignment api.RoleAssignment,

--- a/v2/apiserver/internal/api/mongodb/role_assignments_store_test.go
+++ b/v2/apiserver/internal/api/mongodb/role_assignments_store_test.go
@@ -236,6 +236,69 @@ func TestRoleAssignmentsStoreRevoke(t *testing.T) {
 	}
 }
 
+func TestRoleAssignmentStoreRevokeByPrincipal(t *testing.T) {
+	testPrincipalReference := api.PrincipalReference{
+		Type: api.PrincipalTypeUser,
+		ID:   "tony@starkindustries.com",
+	}
+	testCases := []struct {
+		name       string
+		collection mongodb.Collection
+		assertions func(error)
+	}{
+		{
+			name: "error",
+			collection: &mongoTesting.MockCollection{
+				DeleteManyFn: func(
+					context.Context,
+					interface{},
+					...*options.DeleteOptions,
+				) (*mongo.DeleteResult, error) {
+					return nil, errors.New("something went wrong")
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(
+					t,
+					err.Error(),
+					"error deleting role assignments",
+				)
+			},
+		},
+		{
+			name: "success",
+			collection: &mongoTesting.MockCollection{
+				DeleteManyFn: func(
+					context.Context,
+					interface{},
+					...*options.DeleteOptions,
+				) (*mongo.DeleteResult, error) {
+					return &mongo.DeleteResult{
+						DeletedCount: 1,
+					}, nil
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := &roleAssignmentsStore{
+				collection: testCase.collection,
+			}
+			err := store.RevokeByPrincipal(
+				context.Background(),
+				testPrincipalReference,
+			)
+			testCase.assertions(err)
+		})
+	}
+}
+
 func TestExists(t *testing.T) {
 	testRoleAssignment := api.RoleAssignment{}
 	testCases := []struct {

--- a/v2/apiserver/internal/api/mongodb/users_store.go
+++ b/v2/apiserver/internal/api/mongodb/users_store.go
@@ -185,3 +185,17 @@ func (u *usersStore) Unlock(ctx context.Context, id string) error {
 	}
 	return nil
 }
+
+func (u *usersStore) Delete(ctx context.Context, id string) error {
+	res, err := u.collection.DeleteOne(ctx, bson.M{"id": id})
+	if err != nil {
+		return errors.Wrapf(err, "error deleting user %q", id)
+	}
+	if res.DeletedCount == 0 {
+		return &meta.ErrNotFound{
+			Type: api.UserKind,
+			ID:   id,
+		}
+	}
+	return nil
+}

--- a/v2/apiserver/internal/api/project_role_assignments.go
+++ b/v2/apiserver/internal/api/project_role_assignments.go
@@ -330,6 +330,9 @@ type ProjectRoleAssignmentsStore interface {
 	// RevokeByProjectID revokes all ProjectRoleAssignments for the specified
 	// Project.
 	RevokeByProjectID(ctx context.Context, projectID string) error
+	// RevokeByPrincipal revokes all project roles for the principal specified by
+	// the PrincipalReference.
+	RevokeByPrincipal(context.Context, PrincipalReference) error
 	// Exists returns a bool indicating whether the specified
 	// ProjectRoleAssignment exists within the store. Implementations MUST also
 	// return true if a ProjectRoleAssignment exists in the store that logically

--- a/v2/apiserver/internal/api/project_role_assignments_test.go
+++ b/v2/apiserver/internal/api/project_role_assignments_test.go
@@ -529,9 +529,13 @@ type mockProjectRoleAssignmentsStore struct {
 		ProjectRoleAssignmentsSelector,
 		meta.ListOptions,
 	) (ProjectRoleAssignmentList, error)
-	RevokeFn     func(context.Context, ProjectRoleAssignment) error
-	RevokeManyFn func(ctx context.Context, projectID string) error
-	ExistsFn     func(context.Context, ProjectRoleAssignment) (bool, error)
+	RevokeFn            func(context.Context, ProjectRoleAssignment) error
+	RevokeByProjectIDFn func(ctx context.Context, projectID string) error
+	RevokeByPrincipalFn func(context.Context, PrincipalReference) error
+	ExistsFn            func(
+		context.Context,
+		ProjectRoleAssignment,
+	) (bool, error)
 }
 
 func (m *mockProjectRoleAssignmentsStore) Grant(
@@ -560,7 +564,14 @@ func (m *mockProjectRoleAssignmentsStore) RevokeByProjectID(
 	ctx context.Context,
 	projectID string,
 ) error {
-	return m.RevokeManyFn(ctx, projectID)
+	return m.RevokeByProjectIDFn(ctx, projectID)
+}
+
+func (m *mockProjectRoleAssignmentsStore) RevokeByPrincipal(
+	ctx context.Context,
+	principalReference PrincipalReference,
+) error {
+	return m.RevokeByPrincipalFn(ctx, principalReference)
 }
 
 func (m *mockProjectRoleAssignmentsStore) Exists(

--- a/v2/apiserver/internal/api/projects_test.go
+++ b/v2/apiserver/internal/api/projects_test.go
@@ -445,7 +445,7 @@ func TestProjectServiceDelete(t *testing.T) {
 					},
 				},
 				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, string) error {
+					RevokeByProjectIDFn: func(context.Context, string) error {
 						return nil
 					},
 				},
@@ -486,7 +486,7 @@ func TestProjectServiceDelete(t *testing.T) {
 					},
 				},
 				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, string) error {
+					RevokeByProjectIDFn: func(context.Context, string) error {
 						return errors.New("something went wrong")
 					},
 				},
@@ -527,7 +527,7 @@ func TestProjectServiceDelete(t *testing.T) {
 					},
 				},
 				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, string) error {
+					RevokeByProjectIDFn: func(context.Context, string) error {
 						return nil
 					},
 				},
@@ -564,7 +564,7 @@ func TestProjectServiceDelete(t *testing.T) {
 					},
 				},
 				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, string) error {
+					RevokeByProjectIDFn: func(context.Context, string) error {
 						return nil
 					},
 				},
@@ -606,7 +606,7 @@ func TestProjectServiceDelete(t *testing.T) {
 					},
 				},
 				projectRoleAssignmentsStore: &mockProjectRoleAssignmentsStore{
-					RevokeManyFn: func(context.Context, string) error {
+					RevokeByProjectIDFn: func(context.Context, string) error {
 						return nil
 					},
 				},

--- a/v2/apiserver/internal/api/rest/users_endpoints.go
+++ b/v2/apiserver/internal/api/rest/users_endpoints.go
@@ -40,6 +40,12 @@ func (u *UsersEndpoints) Register(router *mux.Router) {
 		"/v2/users/{id}/lock",
 		u.AuthFilter.Decorate(u.unlock),
 	).Methods(http.MethodDelete)
+
+	// Delete user
+	router.HandleFunc(
+		"/v2/users/{id}",
+		u.AuthFilter.Decorate(u.delete),
+	).Methods(http.MethodDelete)
 }
 
 func (u *UsersEndpoints) list(w http.ResponseWriter, r *http.Request) {
@@ -111,6 +117,19 @@ func (u *UsersEndpoints) unlock(w http.ResponseWriter, r *http.Request) {
 			R: r,
 			EndpointLogic: func() (interface{}, error) {
 				return nil, u.Service.Unlock(r.Context(), mux.Vars(r)["id"])
+			},
+			SuccessCode: http.StatusOK,
+		},
+	)
+}
+
+func (u *UsersEndpoints) delete(w http.ResponseWriter, r *http.Request) {
+	restmachinery.ServeRequest(
+		restmachinery.InboundRequest{
+			W: w,
+			R: r,
+			EndpointLogic: func() (interface{}, error) {
+				return nil, u.Service.Delete(r.Context(), mux.Vars(r)["id"])
 			},
 			SuccessCode: http.StatusOK,
 		},

--- a/v2/apiserver/internal/api/role_assignments.go
+++ b/v2/apiserver/internal/api/role_assignments.go
@@ -282,6 +282,9 @@ type RoleAssignmentsStore interface {
 	// Revoke the role specified by the RoleAssignment for the principal specified
 	// by the RoleAssignment.
 	Revoke(context.Context, RoleAssignment) error
+	// RevokeByPrincipal revokes all roles for the principal specified by the
+	// PrincipalReference.
+	RevokeByPrincipal(context.Context, PrincipalReference) error
 	// Exists returns a bool indicating whether the specified RoleAssignment
 	// exists within the store. Implementations MUST also return true if a
 	// RoleAssignment exists in the store that logically "overlaps" the specified

--- a/v2/apiserver/internal/api/role_assignments_test.go
+++ b/v2/apiserver/internal/api/role_assignments_test.go
@@ -428,8 +428,9 @@ type mockRoleAssignmentsStore struct {
 		RoleAssignmentsSelector,
 		meta.ListOptions,
 	) (RoleAssignmentList, error)
-	RevokeFn func(context.Context, RoleAssignment) error
-	ExistsFn func(context.Context, RoleAssignment) (bool, error)
+	RevokeFn            func(context.Context, RoleAssignment) error
+	RevokeByPrincipalFn func(context.Context, PrincipalReference) error
+	ExistsFn            func(context.Context, RoleAssignment) (bool, error)
 }
 
 func (m *mockRoleAssignmentsStore) Grant(
@@ -452,6 +453,13 @@ func (m *mockRoleAssignmentsStore) Revoke(
 	roleAssignment RoleAssignment,
 ) error {
 	return m.RevokeFn(ctx, roleAssignment)
+}
+
+func (m *mockRoleAssignmentsStore) RevokeByPrincipal(
+	ctx context.Context,
+	principalReference PrincipalReference,
+) error {
+	return m.RevokeByPrincipalFn(ctx, principalReference)
 }
 
 func (m *mockRoleAssignmentsStore) Exists(

--- a/v2/apiserver/main.go
+++ b/v2/apiserver/main.go
@@ -215,6 +215,8 @@ func main() {
 		authorizer.Authorize,
 		usersStore,
 		sessionsStore,
+		roleAssignmentsStore,
+		projectRoleAssignmentsStore,
 		usersServiceConfig(),
 	)
 

--- a/v2/cli/user_commands.go
+++ b/v2/cli/user_commands.go
@@ -18,6 +18,25 @@ var userCommand = &cli.Command{
 	Aliases: []string{"users"},
 	Subcommands: []*cli.Command{
 		{
+			Name:  "delete",
+			Usage: "Delete a single user",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     flagID,
+					Aliases:  []string{"i"},
+					Usage:    "Delete the specified user (required)",
+					Required: true,
+				},
+				nonInteractiveFlag,
+				&cli.BoolFlag{
+					Name:    flagYes,
+					Aliases: []string{"y"},
+					Usage:   "Non-interactively confirm deletion",
+				},
+			},
+			Action: userDelete,
+		},
+		{
 			Name:  "get",
 			Usage: "Retrieve a user",
 			Flags: []cli.Flag{
@@ -240,6 +259,31 @@ func userUnlock(c *cli.Context) error {
 	}
 
 	fmt.Printf("User %q unlocked.\n", id)
+
+	return nil
+}
+
+func userDelete(c *cli.Context) error {
+	id := c.String(flagID)
+
+	confirmed, err := confirmed(c)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		return nil
+	}
+
+	client, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	if err := client.Authn().Users().Delete(c.Context, id); err != nil {
+		return err
+	}
+
+	fmt.Printf("User %q deleted.\n", id)
 
 	return nil
 }


### PR DESCRIPTION
Initially, there was no delete user functionality. The rationale behind that was that when third party authn is enabled, a deleted user could _still_ return and seamlessly federate. Locking users instead of deleting them seemed reasonable, but that meant users you wish you could have deleted hang around forever.

#1457 changed that. Because authn can be limited to users in particular orgs, it's easy not to ensure a deleted user _can't_ just come back and federate anew.

On top of that, #1528 cleared some technical hurdles that would have made deleting users very difficult.

So... here it is... we can delete users now.