### PR TITLE
fix broken worker build

### DIFF
--- a/v2/brigadier-polyfill/package.json
+++ b/v2/brigadier-polyfill/package.json
@@ -23,13 +23,13 @@
     "chai": "^4.2.0",
     "eslint": "^7.15.0",
     "mocha": "^8.2.1",
-    "ts-node": "^9.1.1",
-    "typescript": "^4.1.2"
+    "ts-node": "^9.1.1"
   },
   "dependencies": {
     "@brigadecore/brigade-sdk": "^v2.0.0-beta.2",
     "@brigadecore/brigadier": "../brigadier",
     "@types/node": "^14.14.11",
+    "typescript": "4.1.6",
     "winston": "^3.3.3"
   }
 }

--- a/v2/brigadier-polyfill/yarn.lock
+++ b/v2/brigadier-polyfill/yarn.lock
@@ -38,6 +38,7 @@
   version "0.0.1-placeholder"
   dependencies:
     "@types/node" "^14.14.11"
+    typescript "4.1.6"
 
 "@dabh/diagnostics@^2.0.2":
   version "2.0.2"
@@ -1592,10 +1593,10 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
-typescript@^4.1.2:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
+  integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
 
 uri-js@^4.2.2:
   version "4.4.1"

--- a/v2/brigadier/package.json
+++ b/v2/brigadier/package.json
@@ -31,10 +31,10 @@
     "chai": "^4.2.0",
     "eslint": "^7.15.0",
     "mocha": "^8.2.1",
-    "ts-node": "^9.1.1",
-    "typescript": "^4.1.2"
+    "ts-node": "^9.1.1"
   },
   "dependencies": {
-    "@types/node": "^14.14.11"
+    "@types/node": "^14.14.11",
+    "typescript": "4.1.6"
   }
 }

--- a/v2/brigadier/yarn.lock
+++ b/v2/brigadier/yarn.lock
@@ -1341,10 +1341,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^4.1.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+typescript@4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
+  integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
 
 uri-js@^4.2.2:
   version "4.4.1"

--- a/v2/worker/Dockerfile
+++ b/v2/worker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14.16.0-alpine3.11
 ARG VERSION
 ENV WORKER_VERSION=${VERSION}
 
-RUN apk add bash && npm install -g typescript
+RUN apk add bash
 
 WORKDIR /var/brigade-worker/brigadier
 COPY v2/brigadier/ .

--- a/v2/worker/package.json
+++ b/v2/worker/package.json
@@ -23,11 +23,11 @@
     "chai": "^4.2.0",
     "eslint": "^7.15.0",
     "mocha": "^8.2.1",
-    "ts-node": "^9.1.1",
-    "typescript": "^4.1.2"
+    "ts-node": "^9.1.1"
   },
   "dependencies": {
     "@types/node": "^14.14.11",
-    "@brigadecore/brigadier-polyfill": "../brigadier-polyfill"
+    "@brigadecore/brigadier-polyfill": "../brigadier-polyfill",
+    "typescript": "4.1.6"
   }
 }

--- a/v2/worker/yarn.lock
+++ b/v2/worker/yarn.lock
@@ -40,12 +40,14 @@
     "@brigadecore/brigade-sdk" "^v2.0.0-beta.2"
     "@brigadecore/brigadier" "../brigadier"
     "@types/node" "^14.14.11"
+    typescript "4.1.6"
     winston "^3.3.3"
 
 "@brigadecore/brigadier@../brigadier":
   version "0.0.1-placeholder"
   dependencies:
     "@types/node" "^14.14.11"
+    typescript "4.1.6"
 
 "@dabh/diagnostics@^2.0.2":
   version "2.0.2"
@@ -1600,10 +1602,10 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
-typescript@^4.1.2:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
+  integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Four days ago, the latest version of TypeScript available from npm took a leap from 4.1.6 to 4.4.2.

Semantic versioning would lead one to expect there were no breaking changes between 4.1.6 and 4.4.2, but alas, that isn't the case.

Our use of `yarn install --prod` for each of brigadier, brigadier-polyfill, and the worker itself in the worker's Dockerfile meant we had to source TypeScript from elsewhere to be able to compile, so an `npm install -g typescript` appeared in the Dockerfile. As stated, this took a large leap in the last few days and started breaking things.

My solution here, for each of the three components in question, is to pin us to `typescript@4.1.6` _specifically_ (not `^4.1.6`, which would allow automatically using the latest minor release in 4.x.) _and_ to lift that out of the development dependencies section and into the normal dependencies section.

I also removed the `npm -g typescript` from the Dockerfile since `npm --install prod` now gets TypeScript for us at the correct version.