### PR TITLE
chore: upgrade node

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -3,7 +3,7 @@ import { events, Event, Job, ConcurrentGroup, SerialGroup } from "@brigadecore/b
 const releaseTagRegex = /^refs\/tags\/(v[0-9]+(?:\.[0-9]+)*(?:\-.+)?)$/
 
 const goImg = "brigadecore/go-tools:v0.2.0"
-const jsImg = "node:12.3.1-stretch"
+const jsImg = "node:16.8.0-bullseye"
 const kanikoImg = "brigadecore/kaniko:v0.2.0"
 const helmImg = "brigadecore/helm-tools:v0.1.0"
 const localPath = "/workspaces/brigade"

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifneq ($(SKIP_DOCKER),true)
 		-w /workspaces/brigade \
 		$(GO_DEV_IMAGE)
 
-	JS_DEV_IMAGE := node:14.16.0-stretch
+	JS_DEV_IMAGE := node:16.8.0-bullseye
 
 	JS_DOCKER_CMD := docker run \
 		-it \

--- a/v2/worker/Dockerfile
+++ b/v2/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.16.0-alpine3.11
+FROM node:16.8.0-alpine3.14
 ARG VERSION
 ENV WORKER_VERSION=${VERSION}
 


### PR DESCRIPTION
The version of Node we were using was pretty old. This upgrades to the latest LTS release. It also corrects the oversight that we weren't using the same Node version across the board.