### PR TITLE
add event summary field

### DIFF
--- a/sdk/v2/testing/core/mock_events_client.go
+++ b/sdk/v2/testing/core/mock_events_client.go
@@ -17,6 +17,7 @@ type MockEventsClient struct {
 	GetFn               func(context.Context, string) (core.Event, error)
 	CloneFn             func(context.Context, string) (core.Event, error)
 	UpdateSourceStateFn func(context.Context, string, core.SourceState) error
+	UpdateSummaryFn     func(context.Context, string, core.EventSummary) error
 	CancelFn            func(context.Context, string) error
 	CancelManyFn        func(
 		context.Context,
@@ -67,6 +68,14 @@ func (m *MockEventsClient) UpdateSourceState(
 	state core.SourceState,
 ) error {
 	return m.UpdateSourceStateFn(ctx, id, state)
+}
+
+func (m *MockEventsClient) UpdateSummary(
+	ctx context.Context,
+	id string,
+	summary core.EventSummary,
+) error {
+	return m.UpdateSummaryFn(ctx, id, summary)
 }
 
 func (m *MockEventsClient) Cancel(ctx context.Context, id string) error {

--- a/v2/apiserver/internal/api/mongodb/events_store_test.go
+++ b/v2/apiserver/internal/api/mongodb/events_store_test.go
@@ -470,6 +470,87 @@ func TestEventsStoreUpdateSourceState(t *testing.T) {
 	}
 }
 
+func TestEventsStoreUpdateSummary(t *testing.T) {
+	const testEvent = "123456789"
+	testCases := []struct {
+		name       string
+		collection mongodb.Collection
+		assertions func(err error)
+	}{
+		{
+			name: "unanticipated error",
+			collection: &mongoTesting.MockCollection{
+				UpdateOneFn: func(
+					context.Context,
+					interface{},
+					interface{},
+					...*options.UpdateOptions,
+				) (*mongo.UpdateResult, error) {
+					return nil, errors.New("something went wrong")
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "something went wrong")
+				require.Contains(t, err.Error(), "error updating summary of event")
+			},
+		},
+
+		{
+			name: "event not found",
+			collection: &mongoTesting.MockCollection{
+				UpdateOneFn: func(
+					context.Context,
+					interface{},
+					interface{},
+					...*options.UpdateOptions,
+				) (*mongo.UpdateResult, error) {
+					return &mongo.UpdateResult{
+						MatchedCount: 0,
+					}, nil
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrNotFound{}, err)
+			},
+		},
+
+		{
+			name: "success",
+			collection: &mongoTesting.MockCollection{
+				UpdateOneFn: func(
+					context.Context,
+					interface{},
+					interface{},
+					...*options.UpdateOptions,
+				) (*mongo.UpdateResult, error) {
+					return &mongo.UpdateResult{
+						MatchedCount: 1,
+					}, nil
+				},
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := &eventsStore{
+				collection: testCase.collection,
+			}
+			err :=
+				store.UpdateSummary(
+					context.Background(),
+					testEvent,
+					api.EventSummary{},
+				)
+			testCase.assertions(err)
+		})
+	}
+}
+
 func TestEventsStoreCancel(t *testing.T) {
 	const testEventID = "abcedfg"
 	testCases := []struct {

--- a/v2/apiserver/main.go
+++ b/v2/apiserver/main.go
@@ -260,6 +260,9 @@ func main() {
 					SourceStateSchemaLoader: gojsonschema.NewReferenceLoader(
 						"file:///brigade/schemas/source-state.json",
 					),
+					EventSummarySchemaLoader: gojsonschema.NewReferenceLoader(
+						"file:///brigade/schemas/event-summary.json",
+					),
 					Service: eventsService,
 				},
 				&rest.JobsEndpoints{

--- a/v2/apiserver/schemas/event-summary.json
+++ b/v2/apiserver/schemas/event-summary.json
@@ -1,0 +1,32 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "event-summary.json",
+
+	"definitions": {
+
+		"kind": {
+			"type": "string",
+			"description": "The type of object represented by the document",
+			"enum": ["EventSummary"]
+		}
+
+	},
+
+	"title": "EventSummary",
+	"type": "object",
+	"required": ["apiVersion", "kind"],
+	"additionalProperties": false,
+	"properties": {
+		"apiVersion": {
+			"$ref": "common.json#/definitions/apiVersion"
+		},
+		"kind": {
+			"$ref": "#/definitions/kind"
+		},
+		"text": {
+			"type": "string",
+			"description": "A summary of work performed by the worker and its jobs",
+			"maxLength": 4096
+		}
+	}
+}


### PR DESCRIPTION
This is a the first of a few PRs that will, in aggregate, address #1590.

This particular PR adds the summary in the API server and the Go SDK.

Once the API server supports this, I'll open a PR against the sdk-for-js.

Once that is merged, the final part will be another PR to this project, to make the worker use the latest sdk-for-js to update the event summary on success.