### PR TITLE
upgrade to helm 3.7.0 ga + pre-release version bumps

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -5,7 +5,7 @@ const releaseTagRegex = /^refs\/tags\/(v[0-9]+(?:\.[0-9]+)*(?:\-.+)?)$/
 const goImg = "brigadecore/go-tools:v0.3.0"
 const jsImg = "node:16.8.0-bullseye"
 const kanikoImg = "brigadecore/kaniko:v0.2.0"
-const helmImg = "brigadecore/helm-tools:v0.1.0"
+const helmImg = "brigadecore/helm-tools:v0.4.0"
 const localPath = "/workspaces/brigade"
 
 // MakeTargetJob is just a job wrapper around a make target.

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ifneq ($(SKIP_DOCKER),true)
 		-w /workspaces/brigade \
 		$(KANIKO_IMAGE)
 
-	HELM_IMAGE := brigadecore/helm-tools:v0.1.0
+	HELM_IMAGE := brigadecore/helm-tools:v0.4.0
 
 	HELM_DOCKER_CMD := docker run \
 	  -it \

--- a/docs/content/intro/install.md
+++ b/docs/content/intro/install.md
@@ -22,7 +22,7 @@ Before you can install Brigade, ensure that you have the [prerequisites](#prereq
   Your cluster should be accessible to the source of your event triggers.
   For example, if you want to trigger events from GitHub, the cluster should have a public ip address, and a domain name that resolves to the cluster.
   If you are using Brigade in a local development environment, the [QuickStart] demonstrates how to access a local KinD or Minikube cluster.
-* [Helm] CLI v3+ installed.
+* [Helm] v3.7.0+ installed.
 * [kubectl] CLI installed.
 * Free disk space on the cluster nodes.  
   The installation requires sufficient free disk space and will fail if a cluster node disk is nearly full.
@@ -38,20 +38,20 @@ Install the Brigade CLI, brig, by copying the appropriate binary from our releas
 
 **linux**
 ```bash
-curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.0.0-beta.2/brig-linux-amd64
+curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.0.0-beta.3/brig-linux-amd64
 chmod +x /usr/local/bin/brig
 ```
 
 **macos**
 ```bash
-curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.0.0-beta.2/brig-darwin-amd64
+curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.0.0-beta.3/brig-darwin-amd64
 chmod +x /usr/local/bin/brig
 ```
 
 **windows**
 ```powershell
 mkdir -force $env:USERPROFILE\bin
-(New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.0.0-beta.2/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
+(New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.0.0-beta.3/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
 $env:PATH+=";$env:USERPROFILE\bin"
 ```
 
@@ -76,25 +76,15 @@ $env:PATH+=";$env:USERPROFILE\bin"
     $env:HELM_EXPERIMENTAL_OCI=1
     ```
 
-1. Create a directory to store the Brigade Helm charts.
-
-    **posix**
-    ```bash
-    mkdir -p ~/charts
-    ```
-
-    **powershell**
-    ```powershell
-    mkdir -force $env:USERPROFILE/charts
-    ```
-
 1. Run the following commands to install Brigade and wait for it to finish installing.
 
     ```
-    helm chart pull ghcr.io/brigadecore/brigade:v2.0.0-beta.2
-    helm chart export ghcr.io/brigadecore/brigade:v2.0.0-beta.2 -d ~/charts
-    helm install brigade2 ~/charts/brigade --namespace brigade2 --create-namespace
-    kubectl rollout status deployment brigade2-apiserver -n brigade2 --timeout 5m
+    helm install brigade \
+      oci://ghcr.io/brigadecore/brigade \
+      --version v2.0.0-beta.3 \
+      --create-namespace \
+      --namespace brigade
+    kubectl rollout status deployment brigade-apiserver -n brigade --timeout 5m
     ```
    
     If the deployment fails, proceed to the [troubleshooting](#troubleshooting) section.
@@ -132,13 +122,13 @@ If the logs include "No space left on device" or "Disk Full!", then you need to 
 Running `docker system prune` is one way to recover disk space for Docker.
 
 ```console
-$ kubectl logs brigade2-mongodb-0
+$ kubectl logs brigade-mongodb-0
 ...
 mkdir: cannot create directory '/bitnami/mongodb/data': No space left on device
 ```
 
 ```console
-$ kubectl logs brigade2-artemis-0
+$ kubectl logs brigade-artemis-0
 ...
 2021-05-26 17:20:17,865 WARN  [org.apache.activemq.artemis.core.server] AMQ222212: Disk Full! Blocking message production on address 'healthz'. Clients will report blocked.
 ```
@@ -146,6 +136,9 @@ $ kubectl logs brigade2-artemis-0
 After you have freed up disk space, remove the bad installation, and then retry the installation using the following commands:
 
 ```
-helm uninstall brigade2 -n brigade2
-helm install brigade2 ~/charts/brigade --namespace brigade2
+helm uninstall brigade -n brigade
+helm install brigade \
+  oci://ghcr.io/brigadecore/brigade \
+  --version v2.0.0-beta.3 \
+  --namespace brigade
 ```

--- a/docs/content/intro/quickstart.md
+++ b/docs/content/intro/quickstart.md
@@ -20,7 +20,7 @@ In this QuickStart, you will install Brigade, create a project and execute it.
 
 * [A development Kubernetes cluster](#create-a-cluster).
 * [Brigade CLI](#install-the-brigade-cli) installed.
-* [Helm] CLI v3+ installed.
+* [Helm] v3.7.0+ installed.
 * [kubectl] CLI installed.
 * Free disk space. The installation requires sufficient free disk space and will fail if your disk is nearly full.
 
@@ -85,20 +85,20 @@ Install the Brigade CLI, brig, by copying the appropriate binary from our releas
 
 **linux**
 ```bash
-curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.0.0-beta.2/brig-linux-amd64
+curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.0.0-beta.3/brig-linux-amd64
 chmod +x /usr/local/bin/brig
 ```
 
 **macos**
 ```bash
-curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.0.0-beta.2/brig-darwin-amd64
+curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.0.0-beta.3/brig-darwin-amd64
 chmod +x /usr/local/bin/brig
 ```
 
 **windows**
 ```powershell
 mkdir -force $env:USERPROFILE\bin
-(New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.0.0-beta.2/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
+(New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.0.0-beta.3/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
 $env:PATH+=";$env:USERPROFILE\bin"
 ```
 
@@ -125,25 +125,15 @@ Install Brigade on your local development cluster. See our [Installation] instru
     $env:HELM_EXPERIMENTAL_OCI=1
     ```
 
-1. Create a directory to store the Brigade Helm charts.
-
-    **posix**
-    ```bash
-    mkdir -p ~/charts
-    ```
-
-    **powershell**
-    ```powershell
-    mkdir -force $env:USERPROFILE/charts
-    ```
-
 1. Run the following commands to install Brigade.
 
     ```
-    helm chart pull ghcr.io/brigadecore/brigade:v2.0.0-beta.2
-    helm chart export ghcr.io/brigadecore/brigade:v2.0.0-beta.2 -d ~/charts
-    helm install brigade2 ~/charts/brigade --namespace brigade2 --create-namespace
-    kubectl rollout status deployment brigade2-apiserver -n brigade2 --timeout 5m
+    helm install brigade \
+      oci://ghcr.io/brigadecore/brigade \
+      --version v2.0.0-beta.3 \
+      --create-namespace \
+      --namespace brigade
+    kubectl rollout status deployment brigade-apiserver -n brigade --timeout 5m
     ```
     
     Wait for the Brigade deployment to be ready.
@@ -158,21 +148,21 @@ If you are running a cluster locally, use port forwarding to make the Brigade AP
 **posix**
 
 ```
-kubectl --namespace brigade2 port-forward service/brigade2-apiserver 8443:443 &>/dev/null &
+kubectl --namespace brigade port-forward service/brigade-apiserver 8443:443 &>/dev/null &
 ```
 
 **powershell**
 
 ```
-& kubectl --namespace brigade2 port-forward service/brigade2-apiserver 8443:443 *> $null  
+& kubectl --namespace brigade port-forward service/brigade-apiserver 8443:443 *> $null  
 ```
 
 ### Get External IP of a Remote Cluster
 
-If you are running a cluster remotely, such as on a cloud provider, the Brigade API is available at the External IP of the brigade2-apiserver service:
+If you are running a cluster remotely, such as on a cloud provider, the Brigade API is available at the External IP of the brigade-apiserver service:
 
 ```
-kubectl get service --namespace brigade2 brigade2-apiserver -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+kubectl get service --namespace brigade brigade-apiserver -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'
 ```
 
 [Installation]: /intro/install/
@@ -187,7 +177,7 @@ Authenticate to Brigade as the root user using demo password `F00Bar!!!`. The \-
 brig login --insecure --server https://localhost:8443 --root
 ```
 
-If the address https://localhost:8443 does not resolve, double-check that the brigade2-apiserver service was successfully forwarded from the previous section.
+If the address https://localhost:8443 does not resolve, double-check that the brigade-apiserver service was successfully forwarded from the previous section.
 
 **remote clusters**
 
@@ -268,7 +258,7 @@ Below is example output of a successful event handler:
 Created event "2cb85062-f964-454d-ac5c-526cdbdd2679".
 
 Waiting for event's worker to be RUNNING...
-2021-08-10T16:52:01.699Z INFO: brigade-worker version: v2.0.0-beta.2
+2021-08-10T16:52:01.699Z INFO: brigade-worker version: v2.0.0-beta.3
 2021-08-10T16:52:01.701Z DEBUG: writing default brigade.ts to /var/vcs/.brigade/brigade.ts
 2021-08-10T16:52:01.702Z DEBUG: using npm as the package manager
 2021-08-10T16:52:01.702Z DEBUG: path /var/vcs/.brigade/node_modules/@brigadecore does not exist; creating it
@@ -290,7 +280,7 @@ brig project delete --id first-project
 Otherwise, you can remove ALL resources created in this QuickStart by either:
 
 * Deleting the KinD cluster that you created at the beginning with `kind delete cluster --name kind-kind` OR
-* Preserving the cluster and uninstalling Brigade with `helm delete brigade2 -n brigade2`
+* Preserving the cluster and uninstalling Brigade with `helm delete brigade -n brigade`
 
 ## Next Steps
 

--- a/v2/cli/init_templates.go
+++ b/v2/cli/init_templates.go
@@ -136,7 +136,7 @@ var secretsTemplate = []byte(`## This file was created by brig init.
 var packageTemplate = []byte(`{
   "name": "{{ .ProjectID }}",
   "dependencies": {
-    "@brigadecore/brigadier": "^2.0.0-beta.2"
+    "@brigadecore/brigadier": "^2.0.0-beta.3"
   }
 }
 `)


### PR DESCRIPTION
Fixes #1594 

This also includes pre-release version bumps because beta.2 was published using Helm 3.6 and is _not_ compatible with these Helm 3.7+ instructions.

i.e. We need to release beta.3 after we merge this.

While already touching quickstart and install instructions, I also switched from using "brigade2" as the release and namespace name and started using just plain "brigade."

The instructions were originally written with users who are already running brigade 1.x in mind, but as v2 marches closer to GA, we can start treating v2 as our assumption when "brigade" is discussed.