### PR TITLE
fix(integration tests): update empty-testbed branch

### DIFF
--- a/v2/tests/testcases.go
+++ b/v2/tests/testcases.go
@@ -66,7 +66,7 @@ var TestCases = []testcase{
 				WorkerTemplate: core.WorkerSpec{
 					Git: &core.GitConfig{
 						CloneURL: "https://github.com/brigadecore/empty-testbed.git",
-						Ref:      "refs/heads/master",
+						Ref:      "refs/heads/main",
 					},
 				},
 			},
@@ -96,7 +96,7 @@ var TestCases = []testcase{
 				WorkerTemplate: core.WorkerSpec{
 					Git: &core.GitConfig{
 						CloneURL: "https://github.com/brigadecore/empty-testbed.git",
-						Ref:      "master",
+						Ref:      "main",
 					},
 				},
 			},


### PR DESCRIPTION
Oops, I renamed the default branch on the `empty-testbed` repo from `master` to `main` earlier today.  This updates the integration tests that use this value.