### PR TITLE
chart: improve pvc provisioning

### DIFF
--- a/charts/brigade/templates/artemis/primary-stateful-set.yaml
+++ b/charts/brigade/templates/artemis/primary-stateful-set.yaml
@@ -120,7 +120,9 @@ spec:
   - metadata:
       name: data
     spec:
+      {{- if .Values.artemis.persistence.storageClass }}
       storageClassName: {{ .Values.artemis.persistence.storageClass }}
+      {{- end }}
       accessModes: [ {{ .Values.artemis.persistence.accessMode }} ]
       resources:
         requests:

--- a/charts/brigade/templates/artemis/secondary-stateful-set.yaml
+++ b/charts/brigade/templates/artemis/secondary-stateful-set.yaml
@@ -120,7 +120,9 @@ spec:
   - metadata:
       name: data
     spec:
+      {{- if .Values.artemis.persistence.storageClass }}
       storageClassName: {{ .Values.artemis.persistence.storageClass }}
+      {{- end }}
       accessModes: [ {{ .Values.artemis.persistence.accessMode }} ]
       resources:
         requests:

--- a/charts/brigade/templates/artemis/stateful-set.yaml
+++ b/charts/brigade/templates/artemis/stateful-set.yaml
@@ -101,7 +101,9 @@ spec:
   - metadata:
       name: data
     spec:
+      {{- if .Values.artemis.persistence.storageClass }}
       storageClassName: {{ .Values.artemis.persistence.storageClass }}
+      {{- end }}
       accessModes: [ {{ .Values.artemis.persistence.accessMode }} ]
       resources:
         requests:

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -1373,9 +1373,7 @@ artemis:
   ## Persist data to a volume
   persistence:
     enabled: true
-    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
-    ## Default: volume.alpha.kubernetes.io/storage-class: default
-    ##
+    ## If undefined, the cluster's default storage class is used
     # storageClass:
     accessMode: ReadWriteOnce
     size: 8Gi


### PR DESCRIPTION
While this does not seem to have been a problem for this chart, thanks to the use of `volumeClaimTemplates` for the Artemis `StatefulSets`, I've observed in other charts of ours that use `PersistentVolumeClaims` instead, that when a storage class isn't explicitly specified, there can be problems with `helm upgrade`.

If one wants to use the cluster's default storage class, it's better to not mention storage class at all than to mention it with an empty value.

As noted, this hasn't been an issue in this chart, but what this PR does is improve the consistency with how we're addressing this issue in _other_ affected charts.