### PR TITLE
Support more than one brigade instance per cluster

### DIFF
--- a/charts/brigade/templates/apiserver/cluster-role-binding.yaml
+++ b/charts/brigade/templates/apiserver/cluster-role-binding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -14,4 +13,3 @@ subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
   name: {{ include "brigade.apiserver.fullname" . }}
-{{- end }}

--- a/charts/brigade/templates/apiserver/cluster-role.yaml
+++ b/charts/brigade/templates/apiserver/cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled }}
+{{- if .Values.rbac.installGlobalResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/brigade/templates/apiserver/deployment.yaml
+++ b/charts/brigade/templates/apiserver/deployment.yaml
@@ -30,6 +30,8 @@ spec:
         args:
         - --logtostderr=true
         env:
+        - name: BRIGADE_ID
+          value: {{ .Release.Namespace }}.{{ .Release.Name }}
         - name: API_ADDRESS
           {{- if .Values.apiserver.tls.enabled }}
           value: https://{{ include "brigade.apiserver.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/brigade/templates/logger/cluster-role-binding.yaml
+++ b/charts/brigade/templates/logger/cluster-role-binding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -14,4 +13,3 @@ subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
   name: {{ include "brigade.logger.fullname" . }}
-{{- end }}

--- a/charts/brigade/templates/logger/cluster-role.yaml
+++ b/charts/brigade/templates/logger/cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled }}
+{{- if .Values.rbac.installGlobalResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/brigade/templates/logger/secret.yaml
+++ b/charts/brigade/templates/logger/secret.yaml
@@ -36,6 +36,15 @@ stringData:
     <match kube.var.log.containers.**.log>
       @type rewrite_tag_filter
       <rule>
+        key     $.kubernetes.labels.brigade_sh/id
+        pattern /^{{ .Release.Namespace }}\.{{ .Release.Name }}$/
+        tag     workerload
+      </rule>
+    </match>
+
+    <match workerload>
+      @type rewrite_tag_filter
+      <rule>
         key     $.kubernetes.labels.brigade_sh/component
         pattern /^worker$/
         tag     worker

--- a/charts/brigade/templates/observer/cluster-role-binding.yaml
+++ b/charts/brigade/templates/observer/cluster-role-binding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -14,4 +13,3 @@ subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
   name: {{ include "brigade.observer.fullname" . }}
-{{- end }}

--- a/charts/brigade/templates/observer/cluster-role.yaml
+++ b/charts/brigade/templates/observer/cluster-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled }}
+{{- if .Values.rbac.installGlobalResources }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/brigade/templates/observer/deployment.yaml
+++ b/charts/brigade/templates/observer/deployment.yaml
@@ -27,6 +27,8 @@ spec:
         args:
         - --logtostderr=true
         env:
+        - name: BRIGADE_ID
+          value: {{ .Release.Namespace }}.{{ .Release.Name }}
         - name: API_ADDRESS
           {{- if .Values.apiserver.tls.enabled }}
           value: https://{{ include "brigade.apiserver.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -3,7 +3,11 @@
 ## Declare variables to be passed into your templates.
 
 rbac:
-  enabled: true
+  ## Indicates whether relevant cluster-scoped roles should be installed/updated
+  ## by this chart. Set to false if this is NOT the first install of brigade in
+  ## a given cluster, otherwise this chart will attempt to create resources that
+  ## already exist.
+  installGlobalResources: true
 
 ## All settings for the API server
 apiserver:

--- a/v2/apiserver/config.go
+++ b/v2/apiserver/config.go
@@ -99,6 +99,10 @@ func writerFactoryConfig() (amqp.WriterFactoryConfig, error) {
 func substrateConfig() (kubernetes.SubstrateConfig, error) {
 	config := kubernetes.SubstrateConfig{}
 	var err error
+	config.BrigadeID, err = os.GetRequiredEnvVar("BRIGADE_ID")
+	if err != nil {
+		return config, err
+	}
 	config.APIAddress, err = os.GetRequiredEnvVar("API_ADDRESS")
 	if err != nil {
 		return config, err

--- a/v2/apiserver/config_test.go
+++ b/v2/apiserver/config_test.go
@@ -158,6 +158,7 @@ func TestWriterFactoryConfig(t *testing.T) {
 }
 
 func TestSubstrateConfig(t *testing.T) {
+	const testBrigadeID = "4077th"
 	const testAPIAddress = "http://localhost"
 	const testGitInitializerImage = "brigadecore/brigade2-git-initializer:2.0.0"
 	const testGitInitializerImagePullPolicy = api.ImagePullPolicy("IfNotPresent")
@@ -170,8 +171,19 @@ func TestSubstrateConfig(t *testing.T) {
 		assertions func(kubernetes.SubstrateConfig, error)
 	}{
 		{
-			name:  "API_ADDRESS not set",
+			name:  "BRIGADE_ID not set",
 			setup: func() {},
+			assertions: func(_ kubernetes.SubstrateConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "BRIGADE_ID")
+			},
+		},
+		{
+			name: "API_ADDRESS not set",
+			setup: func() {
+				t.Setenv("BRIGADE_ID", testBrigadeID)
+			},
 			assertions: func(_ kubernetes.SubstrateConfig, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "value not found for")
@@ -246,6 +258,7 @@ func TestSubstrateConfig(t *testing.T) {
 			},
 			assertions: func(config kubernetes.SubstrateConfig, err error) {
 				require.NoError(t, err)
+				require.Equal(t, testBrigadeID, config.BrigadeID)
 				require.Equal(t, testAPIAddress, config.APIAddress)
 				require.Equal(t, testGitInitializerImage, config.GitInitializerImage)
 				require.Equal(

--- a/v2/apiserver/internal/api/kubernetes/substrate.go
+++ b/v2/apiserver/internal/api/kubernetes/substrate.go
@@ -41,6 +41,11 @@ var unknownPhasePodsSelector = fields.Set(
 // SubstrateConfig encapsulates several configuration options for the
 // Kubernetes-based Substrate.
 type SubstrateConfig struct {
+	// BrigadeID is a unique-within-the-cluster identifier for an instance of
+	// Brigade. This helps the substrate constrain any operation it performs on
+	// the cluster to only k8s resources that are created and managed by THIS
+	// instance of Brigade.
+	BrigadeID string
 	// APIAddress is the address of the Brigade API server. The substrate will use
 	// this information whenever it needs to tell another component where to find
 	// the API server.

--- a/v2/apiserver/internal/api/kubernetes/substrate.go
+++ b/v2/apiserver/internal/api/kubernetes/substrate.go
@@ -121,7 +121,10 @@ func (s *substrate) CountRunningWorkers(
 ) (api.SubstrateWorkerCount, error) {
 	count := api.SubstrateWorkerCount{}
 	var err error
-	count.Count, err = s.countRunningPods(ctx, myk8s.WorkerPodsSelector())
+	count.Count, err = s.countRunningPods(
+		ctx,
+		myk8s.WorkerPodsSelector(s.config.BrigadeID),
+	)
 	return count, err
 }
 
@@ -130,7 +133,10 @@ func (s *substrate) CountRunningJobs(
 ) (api.SubstrateJobCount, error) {
 	count := api.SubstrateJobCount{}
 	var err error
-	count.Count, err = s.countRunningPods(ctx, myk8s.JobPodsSelector())
+	count.Count, err = s.countRunningPods(
+		ctx,
+		myk8s.JobPodsSelector(s.config.BrigadeID),
+	)
 	return count, err
 }
 
@@ -151,7 +157,8 @@ func (s *substrate) CreateProject(
 			ObjectMeta: metav1.ObjectMeta{
 				Name: project.Kubernetes.Namespace,
 				Labels: map[string]string{
-					myk8s.LabelProject: project.ID,
+					myk8s.LabelBrigadeID: s.config.BrigadeID,
+					myk8s.LabelProject:   project.ID,
 				},
 			},
 		},
@@ -312,6 +319,7 @@ func (s *substrate) CreateProject(
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "project-secrets",
 				Labels: map[string]string{
+					myk8s.LabelBrigadeID: s.config.BrigadeID,
 					myk8s.LabelComponent: myk8s.LabelKeyProjectSecrets,
 					myk8s.LabelProject:   project.ID,
 				},
@@ -444,6 +452,7 @@ func (s *substrate) ScheduleWorker(
 			ObjectMeta: metav1.ObjectMeta{
 				Name: myk8s.EventSecretName(event.ID),
 				Labels: map[string]string{
+					myk8s.LabelBrigadeID: s.config.BrigadeID,
 					myk8s.LabelComponent: myk8s.LabelKeyEvent,
 					myk8s.LabelProject:   event.ProjectID,
 					myk8s.LabelEvent:     event.ID,
@@ -607,8 +616,9 @@ func (s *substrate) DeleteJob(
 ) error {
 	labelSelector := labels.Set(
 		map[string]string{
-			myk8s.LabelEvent: event.ID,
-			myk8s.LabelJob:   jobName,
+			myk8s.LabelBrigadeID: s.config.BrigadeID,
+			myk8s.LabelEvent:     event.ID,
+			myk8s.LabelJob:       jobName,
 		},
 	).AsSelector().String()
 
@@ -660,7 +670,8 @@ func (s *substrate) DeleteWorkerAndJobs(
 ) error {
 	labelSelector := labels.Set(
 		map[string]string{
-			myk8s.LabelEvent: event.ID,
+			myk8s.LabelBrigadeID: s.config.BrigadeID,
+			myk8s.LabelEvent:     event.ID,
 		},
 	).AsSelector().String()
 
@@ -792,6 +803,7 @@ func (s *substrate) createWorkspacePVC(
 			Name:      myk8s.WorkspacePVCName(event.ID),
 			Namespace: project.Kubernetes.Namespace,
 			Labels: map[string]string{
+				myk8s.LabelBrigadeID: s.config.BrigadeID,
 				myk8s.LabelComponent: "workspace",
 				myk8s.LabelProject:   event.ProjectID,
 				myk8s.LabelEvent:     event.ID,
@@ -948,6 +960,7 @@ func (s *substrate) createWorkerPod(
 				myk8s.AnnotationTimeoutDuration: event.Worker.Spec.TimeoutDuration,
 			},
 			Labels: map[string]string{
+				myk8s.LabelBrigadeID: s.config.BrigadeID,
 				myk8s.LabelComponent: myk8s.LabelKeyWorker,
 				myk8s.LabelProject:   event.ProjectID,
 				myk8s.LabelEvent:     event.ID,
@@ -1002,6 +1015,7 @@ func (s *substrate) createJobSecret(
 			Name:      myk8s.JobSecretName(eventID, jobName),
 			Namespace: project.Kubernetes.Namespace,
 			Labels: map[string]string{
+				myk8s.LabelBrigadeID: s.config.BrigadeID,
 				myk8s.LabelComponent: myk8s.LabelKeyJob,
 				myk8s.LabelProject:   project.ID,
 				myk8s.LabelEvent:     eventID,
@@ -1184,6 +1198,7 @@ func (s *substrate) createJobPod(
 				myk8s.AnnotationTimeoutDuration: fmt.Sprint(jobSpec.TimeoutDuration),
 			},
 			Labels: map[string]string{
+				myk8s.LabelBrigadeID: s.config.BrigadeID,
 				myk8s.LabelComponent: myk8s.LabelKeyJob,
 				myk8s.LabelProject:   event.ProjectID,
 				myk8s.LabelEvent:     event.ID,

--- a/v2/apiserver/internal/api/kubernetes/substrate_test.go
+++ b/v2/apiserver/internal/api/kubernetes/substrate_test.go
@@ -32,6 +32,7 @@ func TestNewSubstrate(t *testing.T) {
 }
 
 func TestSubstrateCountRunningWorkers(t *testing.T) {
+	const testBrigadeID = "4077th"
 	const testNamespace = "foo"
 	kubeClient := fake.NewSimpleClientset()
 	podsClient := kubeClient.CoreV1().Pods(testNamespace)
@@ -42,6 +43,7 @@ func TestSubstrateCountRunningWorkers(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name: "bar",
 				Labels: map[string]string{
+					myk8s.LabelBrigadeID: testBrigadeID,
 					myk8s.LabelComponent: myk8s.LabelKeyJob,
 				},
 			},
@@ -59,6 +61,7 @@ func TestSubstrateCountRunningWorkers(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name: "bat",
 				Labels: map[string]string{
+					myk8s.LabelBrigadeID: testBrigadeID,
 					myk8s.LabelComponent: myk8s.LabelKeyWorker,
 				},
 			},
@@ -70,6 +73,9 @@ func TestSubstrateCountRunningWorkers(t *testing.T) {
 	)
 	require.NoError(t, err)
 	s := &substrate{
+		config: SubstrateConfig{
+			BrigadeID: testBrigadeID,
+		},
 		kubeClient: kubeClient,
 	}
 	count, err := s.CountRunningWorkers(context.Background())
@@ -78,6 +84,7 @@ func TestSubstrateCountRunningWorkers(t *testing.T) {
 }
 
 func TestSubstrateCountRunningJobs(t *testing.T) {
+	const testBrigadeID = "4077th"
 	const testNamespace = "foo"
 	kubeClient := fake.NewSimpleClientset()
 	podsClient := kubeClient.CoreV1().Pods(testNamespace)
@@ -88,6 +95,7 @@ func TestSubstrateCountRunningJobs(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name: "bar",
 				Labels: map[string]string{
+					myk8s.LabelBrigadeID: testBrigadeID,
 					myk8s.LabelComponent: myk8s.LabelKeyWorker,
 				},
 			},
@@ -105,6 +113,7 @@ func TestSubstrateCountRunningJobs(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name: "bat",
 				Labels: map[string]string{
+					myk8s.LabelBrigadeID: testBrigadeID,
 					myk8s.LabelComponent: myk8s.LabelKeyJob,
 				},
 			},
@@ -116,6 +125,9 @@ func TestSubstrateCountRunningJobs(t *testing.T) {
 	)
 	require.NoError(t, err)
 	s := &substrate{
+		config: SubstrateConfig{
+			BrigadeID: testBrigadeID,
+		},
 		kubeClient: kubeClient,
 	}
 	count, err := s.CountRunningJobs(context.Background())

--- a/v2/internal/kubernetes/common.go
+++ b/v2/internal/kubernetes/common.go
@@ -9,6 +9,7 @@ import (
 const (
 	AnnotationTimeoutDuration = "brigade.sh/timeoutDuration"
 
+	LabelBrigadeID = "brigade.sh/id"
 	LabelComponent = "brigade.sh/component"
 	LabelEvent     = "brigade.sh/event"
 	LabelJob       = "brigade.sh/job"
@@ -37,9 +38,10 @@ func WorkerPodName(eventID string) string {
 	return eventID
 }
 
-func WorkerPodsSelector() string {
+func WorkerPodsSelector(brigadeID string) string {
 	return labels.Set(
 		map[string]string{
+			LabelBrigadeID: brigadeID,
 			LabelComponent: LabelKeyWorker,
 		},
 	).AsSelector().String()
@@ -53,9 +55,10 @@ func JobPodName(eventID, jobName string) string {
 	return fmt.Sprintf("%s-%s", eventID, jobName)
 }
 
-func JobPodsSelector() string {
+func JobPodsSelector(brigadeID string) string {
 	return labels.Set(
 		map[string]string{
+			LabelBrigadeID: brigadeID,
 			LabelComponent: LabelKeyJob,
 		},
 	).AsSelector().String()

--- a/v2/observer/jobs.go
+++ b/v2/observer/jobs.go
@@ -17,14 +17,15 @@ import (
 )
 
 func (o *observer) syncJobPods(ctx context.Context) {
+	jobsSelector := myk8s.JobPodsSelector(o.config.brigadeID)
 	jobPodsInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				options.LabelSelector = myk8s.JobPodsSelector()
+				options.LabelSelector = jobsSelector
 				return o.kubeClient.CoreV1().Pods("").List(ctx, options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				options.LabelSelector = myk8s.JobPodsSelector()
+				options.LabelSelector = jobsSelector
 				return o.kubeClient.CoreV1().Pods("").Watch(ctx, options)
 			},
 		},

--- a/v2/observer/observer.go
+++ b/v2/observer/observer.go
@@ -19,11 +19,15 @@ type observerConfig struct {
 	healthcheckInterval time.Duration
 	maxWorkerLifetime   time.Duration
 	maxJobLifetime      time.Duration
+	brigadeID           string
 }
 
 func getObserverConfig() (observerConfig, error) {
 	config := observerConfig{}
 	var err error
+	if config.brigadeID, err = os.GetRequiredEnvVar("BRIGADE_ID"); err != nil {
+		return config, err
+	}
 	config.healthcheckInterval = 30 * time.Second
 	if config.delayBeforeCleanup, err =
 		os.GetDurationFromEnvVar("DELAY_BEFORE_CLEANUP", time.Minute); err != nil {

--- a/v2/observer/workers.go
+++ b/v2/observer/workers.go
@@ -17,14 +17,15 @@ import (
 )
 
 func (o *observer) syncWorkerPods(ctx context.Context) {
+	workersSelector := myk8s.WorkerPodsSelector(o.config.brigadeID)
 	workerPodsInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				options.LabelSelector = myk8s.WorkerPodsSelector()
+				options.LabelSelector = workersSelector
 				return o.kubeClient.CoreV1().Pods("").List(ctx, options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				options.LabelSelector = myk8s.WorkerPodsSelector()
+				options.LabelSelector = workersSelector
 				return o.kubeClient.CoreV1().Pods("").Watch(ctx, options)
 			},
 		},


### PR DESCRIPTION
Fixes #1630

This PR injects a unique-to-the-cluster "Brigade ID" into the apiserver and observer. Both of those incorporate this new metadata into all labels and label selectors.

Fluentd configs also get updated so that only logs from a given Brigade instance are sent to that Brigade instance's database.