### PR TITLE
remove errant mentions of brigade.json

### DIFF
--- a/sdk/v2/core/workers.go
+++ b/sdk/v2/core/workers.go
@@ -177,13 +177,13 @@ type WorkerSpec struct {
 	// LogLevel specifies the desired granularity of Worker log output.
 	LogLevel LogLevel `json:"logLevel,omitempty"`
 	// ConfigFilesDirectory specifies a directory within the Worker's workspace
-	// where any relevant configuration files (e.g. brigade.json, brigade.js,
+	// where any relevant configuration files (e.g. brigade.js, package.json,
 	// etc.) can be located.
 	ConfigFilesDirectory string `json:"configFilesDirectory,omitempty"`
 	// DefaultConfigFiles is a map of configuration file names to configuration
 	// file content. This is useful for Workers that do not integrate with any
 	// source control system and would like to embed configuration (e.g.
-	// brigade.json) or scripts (e.g. brigade.js) directly within the WorkerSpec.
+	// package.json) or scripts (e.g. brigade.js) directly within the WorkerSpec.
 	DefaultConfigFiles map[string]string `json:"defaultConfigFiles,omitempty"`
 	// TimeoutDuration specifies the time duration that must elapse before a
 	// running Job should be considered to have timed out. This duration string

--- a/v2/apiserver/internal/api/workers.go
+++ b/v2/apiserver/internal/api/workers.go
@@ -147,13 +147,13 @@ type WorkerSpec struct {
 	// LogLevel specifies the desired granularity of Worker log output.
 	LogLevel LogLevel `json:"logLevel,omitempty" bson:"logLevel,omitempty"`
 	// ConfigFilesDirectory specifies a directory within the Worker's workspace
-	// where any relevant configuration files (e.g. brigade.json, brigade.js,
+	// where any relevant configuration files (e.g. brigade.js, package.json,
 	// etc.) can be located.
 	ConfigFilesDirectory string `json:"configFilesDirectory,omitempty" bson:"configFilesDirectory,omitempty"` // nolint: lll
 	// DefaultConfigFiles is a map of configuration file names to configuration
 	// file content. This is useful for Workers that do not integrate with any
 	// source control system and would like to embed configuration (e.g.
-	// brigade.json) or scripts (e.g. brigade.js) directly within the WorkerSpec.
+	// package.json) or scripts (e.g. brigade.js) directly within the WorkerSpec.
 	DefaultConfigFiles map[string]string `json:"defaultConfigFiles,omitempty" bson:"defaultConfigFiles,omitempty"` // nolint: lll
 	// TimeoutDuration specifies the time duration that must elapse before a
 	// running Job should be considered to have timed out. This duration string

--- a/v2/brigadier/src/workers.ts
+++ b/v2/brigadier/src/workers.ts
@@ -12,7 +12,7 @@ export interface Worker {
   apiToken: string
   /**
    * The directory where the worker stores configuration files,
-   * including event handler code files such as brigade.js and brigade.json.
+   * including event handler code files such as brigade.js and package.json.
    */
   configFilesDirectory: string
   /**


### PR DESCRIPTION
We removed support for brigade.json quite some time ago (in favor of more standard/familiar package.json), but there were still some errant mentions of this file. This PR corrects that.