### PR TITLE
Add support for `ingressClassName` to v2 Helm charts

### DIFF
--- a/charts/brigade/templates/_helpers.tpl
+++ b/charts/brigade/templates/_helpers.tpl
@@ -121,3 +121,22 @@ app.kubernetes.io/os: windows
 {{- $template := index . 2 }}
 {{- include $template (dict "Chart" (dict "Name" $subchart) "Values" (index $dot.Values $subchart) "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
 {{- end }}
+
+{{/*
+Return the appropriate apiVersion for a networking object.
+*/}}
+{{- define "networking.apiVersion" -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "networking.apiVersion.isStable" -}}
+  {{- eq (include "networking.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{- define "networking.apiVersion.supportIngressClassName" -}}
+  {{- semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- end -}}

--- a/charts/brigade/templates/apiserver/ingress.yaml
+++ b/charts/brigade/templates/apiserver/ingress.yaml
@@ -1,9 +1,7 @@
 {{- if .Values.apiserver.ingress.enabled }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
-apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
+{{- $networkingApiIsStable := eq (include "networking.apiVersion.isStable" .) "true" -}}
+{{- $networkingApiSupportsIngressClassName := eq (include "networking.apiVersion.supportIngressClassName" .) "true" -}}
+apiVersion: {{ template "networking.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "brigade.apiserver.fullname" . }}
@@ -15,11 +13,14 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and (.Values.apiserver.ingress.ingressClassName) ($networkingApiSupportsIngressClassName) }}
+  ingressClassName: {{ .Values.api.ingress.ingressClassName }}
+  {{- end }}
   rules:
   - host: {{ .Values.apiserver.host }}
     http:
       paths:
-      {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+      {{- if $networkingApiIsStable }}
       - pathType: ImplementationSpecific
         path: /
         backend:

--- a/charts/brigade/templates/apiserver/ingress.yaml
+++ b/charts/brigade/templates/apiserver/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 spec:
   {{- if and (.Values.apiserver.ingress.ingressClassName) ($networkingApiSupportsIngressClassName) }}
-  ingressClassName: {{ .Values.api.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.apiserver.ingress.ingressClassName }}
   {{- end }}
   rules:
   - host: {{ .Values.apiserver.host }}

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -122,6 +122,9 @@ apiserver:
     ## documentation to customize the behavior of the ingress resource.
     annotations:
       # kubernetes.io/ingress.class: nginx
+    ## From Kubernetes 1.18+ this field is supported in case your ingress controller supports it.
+    ## When set, you do not need to add the ingress class as annotation.
+    ingressClassName:
     tls:
       ## Whether to enable TLS. If true then you MUST do ONE of three things to
       ## ensure the existence of a TLS certificate:


### PR DESCRIPTION
Also rewrite API version handling according to https://github.com/brigadecore/charts/pull/92.

closes #1626

Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>