### PR TITLE
add @brigadecore/docs-maintainers as CODEOWNERS for /docs/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,7 @@
 # This file is described here:  https://help.github.com/en/articles/about-code-owners
 
-# Global Owners: These members are Core Maintainers of Brigade
+# Global Owners: These are brigadecore org maintainers
 * @brigadecore/maintainers
+
+# Doc Owners:
+/docs/ @brigadecore/docs-maintainers


### PR DESCRIPTION
This PR adds the @brigadecore/docs-maintainers group as owners of the `/docs/` dir in this repo, with intentions of soon nominating additional maintainers specifically for docs.