### PR TITLE
brigadier: export ImagePullPolicy

### DIFF
--- a/v2/brigadier/src/index.ts
+++ b/v2/brigadier/src/index.ts
@@ -1,4 +1,4 @@
 export { Event, EventRegistry, events } from "./events"
 export { ConcurrentGroup, SerialGroup } from "./groups"
-export { Container, Job, JobHost } from "./jobs"
+export { Container, ImagePullPolicy, Job, JobHost } from "./jobs"
 export { logger } from "./logger"


### PR DESCRIPTION
This fixes a bug I stumbled upon this morning. `ImagePullPolicy` was mistakenly not exported from Brigadier, which (if one is using TS) made it impossible to set a container's `imagePullPolicy` field to `ImagePullPolicy.IfNotPresent` or `ImagePullPolicy.Always`.