### PR TITLE
fix artemis image build

### DIFF
--- a/v2/artemis/Dockerfile
+++ b/v2/artemis/Dockerfile
@@ -1,10 +1,15 @@
 FROM openjdk:8-jre-bullseye
 
-ENV ARTEMIS_VERSION=2.18.0
+ENV ARTEMIS_VERSION=2.19.0
 ENV ARTEMIS_USERNAME=artemis
 ENV ARTEMIS_PASSWORD=artemis
 
 WORKDIR /opt/artemis
+## Special note about the URL for downloading Artemis: Annoyingly, the URL for
+## the latest release and the the URLs for previous releases do not vary only
+## by version number. If this build starts breaking, the very likely cause is a
+## 404 on the download. It can be fixed by upgrading to the latest Artemis or
+## by changing the download URL.
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
This fixes recent issues with the Artemis Docker image build.

It seems the root cause is that, annoyingly, the format of the download URL for the latest release and previous releases varies in ways beyond version number.

I've left a note to this effect in the Dockerfile so that it is easier to diagnose and repair this issue if it recurs.