### PR TITLE
update logger Dockerfiles

### DIFF
--- a/v2/logger-linux/Dockerfile
+++ b/v2/logger-linux/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile builds a custom Fluentd image that layers in the Fluentd
 # plugins we rely upon on top of a standard Fluentd image.
 
-FROM fluentd:v1.14.0-debian-1.0
+FROM fluent/fluentd:v1.14.2-debian-1.0
 
 USER root
 

--- a/v2/logger-windows/Dockerfile
+++ b/v2/logger-windows/Dockerfile
@@ -1,41 +1,12 @@
-# This Dockerfile builds a custom Fluentd image for Windows. It is significantly
-# derived from a Dockerfile maintained by the Fluentd project:
-#
-# https://github.com/fluent/fluentd-docker-image/blob/master/v1.11/windows/Dockerfile
-#
-# That upstream Dockerfile, however, builds an image derived from the
-# mcr.microsoft.com/windows/servercore:1903 base image. The resulting image is
-# incompatible with the kernel on AKS Windows nodes. Ours builds on top of
-# mcr.microsoft.com/windows/servercore:ltsc2019 instead to ensure AKS
-# compatibility.
-#
-# Additionally, this Dockerfile layers in all the Fluentd plugins upon which we
-# depend.
+# This Dockerfile builds a custom Fluentd image that layers in the Fluentd
+# plugins we rely upon on top of a standard Fluentd image.
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM fluent/fluentd:v1.14.2-windows-ltsc2019-1.0
 
-RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
-
-RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'"
-RUN choco install -y msys2 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
-
-RUN ridk install 3 \
-  && echo gem: --no-document >> C:\ProgramData\gemrc \
-  && gem install cool.io -v 1.5.4 --platform ruby \
-  && gem install oj -v 3.3.10 \
-  && gem install json -v 2.2.0 \
-  && gem install fluentd -v 1.7.4 \
-  && gem install win32-service -v 1.0.1 \
-  && gem install win32-ipc -v 0.7.0 \
-  && gem install win32-event -v 0.6.3 \
-  && gem install windows-pr -v 1.2.6 \
-  && gem install bson -v 4.5.0 \
-  && gem install fluent-plugin-rewrite-tag-filter -v 2.3.0 \
-  && gem install fluent-plugin-mongo -v 1.4.1 \
-  && gem install fluent-plugin-kubernetes_metadata_filter -v 2.5.2 \
+RUN gem install bson -v 4.12.0 \
+  && gem install fluent-plugin-rewrite-tag-filter -v 2.4.0 \
+  && gem install fluent-plugin-mongo -v 1.5.0 \
+  && gem install fluent-plugin-kubernetes_metadata_filter -v 2.9.1 \
   && gem install fluent-plugin-multi-format-parser -v 1.0.0 \
-  && gem sources --clear-all
-
-RUN powershell -Command "mkdir -p C:\fluentd\etc ; mkdir C:\fluentd\log ; rm -fo C:\ruby26\lib\ruby\gems\2.6.0\cache\*.gem; Remove-Item -Recurse -Force 'C:\ProgramData\chocolatey'"
-
-ENTRYPOINT ["cmd", "/k", "fluentd", "-c", "C:\\fluentd\\etc\\fluent.conf"]
+  && gem sources --clear-all \
+  && powershell -Command "rm -fo C:\ruby26\lib\ruby\gems\2.6.0\cache\*.gem"


### PR DESCRIPTION
The main point of this PR is to reduce build time for the Windows-based logger image by starting from an image that already has most of what we need. We didn't do this initially because the base image this PR uses didn't exist until relatively recently.

At the same time, I've updated various gems/fluentd plugins on the Windows-based logger image to match the versions used on the Linux-based logger image. The latter were updated fairly recently and it was an oversight that the Windows-based image didn't receive the same changes.

Last, both the Windows-based and Linux-based images now use `fluent/fluentd` images as their base instead of `fluentd`. `fluentd` trails `fluent/fluentd` by a couple major versions and also does not offer Windows-based images.