### PR TITLE
improved windows support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,9 +433,9 @@ hack-deploy:
 		--set worker.image.repository=$(DOCKER_IMAGE_PREFIX)worker \
 		--set worker.image.tag=$(IMMUTABLE_DOCKER_TAG) \
 		--set worker.image.pullPolicy=$(IMAGE_PULL_POLICY) \
-		--set gitInitializer.image.repository=$(DOCKER_IMAGE_PREFIX)git-initializer \
-		--set gitInitializer.image.tag=$(IMMUTABLE_DOCKER_TAG) \
-		--set gitInitializer.image.pullPolicy=$(IMAGE_PULL_POLICY) \
+		--set gitInitializer.linux.image.repository=$(DOCKER_IMAGE_PREFIX)git-initializer \
+		--set gitInitializer.linux.image.tag=$(IMMUTABLE_DOCKER_TAG) \
+		--set gitInitializer.linux.image.pullPolicy=$(IMAGE_PULL_POLICY) \
 		--set logger.linux.image.repository=$(DOCKER_IMAGE_PREFIX)logger\
 		--set logger.linux.image.tag=$(IMMUTABLE_DOCKER_TAG) \
 		--set logger.linux.image.pullPolicy=$(IMAGE_PULL_POLICY)

--- a/charts/brigade/templates/apiserver/deployment.yaml
+++ b/charts/brigade/templates/apiserver/deployment.yaml
@@ -150,9 +150,13 @@ spec:
               name: {{ include "brigade.artemis.fullname" . }}
               key: password
         - name: GIT_INITIALIZER_IMAGE
-          value: {{ .Values.gitInitializer.image.repository }}:{{ default .Chart.AppVersion .Values.gitInitializer.image.tag }}
+          value: {{ .Values.gitInitializer.linux.image.repository }}:{{ default .Chart.AppVersion .Values.gitInitializer.linux.image.tag }}
         - name: GIT_INITIALIZER_IMAGE_PULL_POLICY
-          value: {{ .Values.gitInitializer.image.pullPolicy }}
+          value: {{ .Values.gitInitializer.linux.image.pullPolicy }}
+        - name: GIT_INITIALIZER_WINDOWS_IMAGE
+          value: {{ .Values.gitInitializer.windows.image.repository }}:{{ default .Chart.AppVersion .Values.gitInitializer.windows.image.tag }}
+        - name: GIT_INITIALIZER_WINDOWS_IMAGE_PULL_POLICY
+          value: {{ .Values.gitInitializer.windows.image.pullPolicy }}
         - name: DEFAULT_WORKER_IMAGE
           value: {{ .Values.worker.image.repository }}:{{ default .Chart.AppVersion .Values.worker.image.tag }}
         - name: DEFAULT_WORKER_IMAGE_PULL_POLICY

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -253,12 +253,21 @@ observer:
 
 gitInitializer:
 
-  image:
-    repository: brigadecore/brigade2-git-initializer
-    ## tag should only be specified if you want to override Chart.appVersion
-    ## The default tag is the value of .Chart.AppVersion
-    # tag:
-    pullPolicy: IfNotPresent
+  linux:
+    image:
+      repository: brigadecore/brigade2-git-initializer
+      ## tag should only be specified if you want to override Chart.appVersion
+      ## The default tag is the value of .Chart.AppVersion
+      # tag:
+      pullPolicy: IfNotPresent
+
+  windows:
+    image:
+      repository: brigadecore/brigade2-git-initializer-windows
+      ## tag should only be specified if you want to override Chart.appVersion
+      ## The default tag is the value of .Chart.AppVersion
+      # tag:
+      pullPolicy: IfNotPresent
 
 worker:
 

--- a/examples/15-windows/project.yaml
+++ b/examples/15-windows/project.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
+apiVersion: brigade.sh/v2-beta
+kind: Project
+metadata:
+  id: windows
+description: Demonstrates a Windows-based job
+spec:
+  eventSubscriptions:
+  - source: brigade.sh/cli
+    types:
+    - exec
+  workerTemplate:
+    # logLevel: DEBUG
+    defaultConfigFiles:
+      brigade.js: |
+        const { events, Job } = require("@brigadecore/brigadier");
+
+        events.on("brigade.sh/cli", "exec", async event => {
+          let job = new Job("hello", "mcr.microsoft.com/windows/nanoserver", event);
+          job.primaryContainer.command = ["echo"];
+          job.primaryContainer.arguments = ["Hello from Windows!"];
+          job.host = {
+            nodeSelector: {
+              os: "windows"
+            }
+          };
+          await job.run();
+        });
+
+        events.process();

--- a/sdk/v2/core/jobs.go
+++ b/sdk/v2/core/jobs.go
@@ -16,6 +16,16 @@ import (
 // JobKind represents the canonical Job kind string
 const JobKind = "Job"
 
+// OSFamily represents a type of operating system.
+type OSFamily string
+
+const (
+	// OSFamilyLinux represents a Linux-based OS.
+	OSFamilyLinux OSFamily = "linux"
+	// OSFamilyWindows represents a Windows-based OS.
+	OSFamilyWindows OSFamily = "windows"
+)
+
 // JobPhase represents where a Job is within its lifecycle.
 type JobPhase string
 
@@ -182,7 +192,7 @@ type JobHost struct {
 	// OS specifies which "family" of operating system is required on a substrate
 	// node to host a Job. Valid values are "linux" and "windows". When empty,
 	// Brigade assumes "linux".
-	OS string `json:"os,omitempty"`
+	OS OSFamily `json:"os,omitempty"`
 	// NodeSelector specifies labels that must be present on the substrate node to
 	// host a Job. This provides an opaque mechanism for communicating Job needs
 	// such as specific hardware like an SSD or GPU.

--- a/v2/apiserver/config.go
+++ b/v2/apiserver/config.go
@@ -119,6 +119,18 @@ func substrateConfig() (kubernetes.SubstrateConfig, error) {
 	}
 	config.GitInitializerImagePullPolicy =
 		api.ImagePullPolicy(gitInitializerImagePullPolicyStr)
+	config.GitInitializerWindowsImage, err =
+		os.GetRequiredEnvVar("GIT_INITIALIZER_WINDOWS_IMAGE")
+	if err != nil {
+		return config, err
+	}
+	gitInitializerWindowsImagePullPolicyStr, err :=
+		os.GetRequiredEnvVar("GIT_INITIALIZER_WINDOWS_IMAGE_PULL_POLICY")
+	if err != nil {
+		return config, err
+	}
+	config.GitInitializerWindowsImagePullPolicy =
+		api.ImagePullPolicy(gitInitializerWindowsImagePullPolicyStr)
 	config.DefaultWorkerImage, err = os.GetRequiredEnvVar("DEFAULT_WORKER_IMAGE")
 	if err != nil {
 		return config, err

--- a/v2/apiserver/config_test.go
+++ b/v2/apiserver/config_test.go
@@ -158,13 +158,18 @@ func TestWriterFactoryConfig(t *testing.T) {
 }
 
 func TestSubstrateConfig(t *testing.T) {
-	const testBrigadeID = "4077th"
-	const testAPIAddress = "http://localhost"
-	const testGitInitializerImage = "brigadecore/brigade2-git-initializer:2.0.0"
-	const testGitInitializerImagePullPolicy = api.ImagePullPolicy("IfNotPresent")
-	const testDefaultWorkerImage = "brigadecore/brigade2-worker:2.0.0"
-	const testDefaultWorkerImagePullPolicy = api.ImagePullPolicy("IfNotPresent")
-	const testWorkspaceStorageClass = "nfs"
+	// nolint: lll
+	const (
+		testBrigadeID                            = "4077th"
+		testAPIAddress                           = "http://localhost"
+		testGitInitializerImage                  = "brigadecore/brigade2-git-initializer:2.0.0"
+		testGitInitializerImagePullPolicy        = api.ImagePullPolicy("IfNotPresent")
+		testGitInitializerWindowsImage           = "brigadecore/brigade2-git-initializer-windows:2.0.0"
+		testGitInitializerWindowsImagePullPolicy = api.ImagePullPolicy("IfNotPresent")
+		testDefaultWorkerImage                   = "brigadecore/brigade2-worker:2.0.0"
+		testDefaultWorkerImagePullPolicy         = api.ImagePullPolicy("IfNotPresent")
+		testWorkspaceStorageClass                = "nfs"
+	)
 	testCases := []struct {
 		name       string
 		setup      func()
@@ -213,11 +218,43 @@ func TestSubstrateConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "DEFAULT_WORKER_IMAGE not set",
+			name: "GIT_INITIALIZER_WINDOWS_IMAGE not set",
 			setup: func() {
 				t.Setenv(
 					"GIT_INITIALIZER_IMAGE_PULL_POLICY",
 					string(testGitInitializerImagePullPolicy),
+				)
+			},
+			assertions: func(_ kubernetes.SubstrateConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "GIT_INITIALIZER_WINDOWS_IMAGE")
+			},
+		},
+		{
+			name: "GIT_INITIALIZER_WINDOWS_IMAGE_PULL_POLICY not set",
+			setup: func() {
+				t.Setenv(
+					"GIT_INITIALIZER_WINDOWS_IMAGE",
+					testGitInitializerWindowsImage,
+				)
+			},
+			assertions: func(_ kubernetes.SubstrateConfig, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(
+					t,
+					err.Error(),
+					"GIT_INITIALIZER_WINDOWS_IMAGE_PULL_POLICY",
+				)
+			},
+		},
+		{
+			name: "DEFAULT_WORKER_IMAGE not set",
+			setup: func() {
+				t.Setenv(
+					"GIT_INITIALIZER_WINDOWS_IMAGE_PULL_POLICY",
+					string(testGitInitializerWindowsImagePullPolicy),
 				)
 			},
 			assertions: func(_ kubernetes.SubstrateConfig, err error) {
@@ -265,6 +302,16 @@ func TestSubstrateConfig(t *testing.T) {
 					t,
 					testGitInitializerImagePullPolicy,
 					config.GitInitializerImagePullPolicy,
+				)
+				require.Equal(
+					t,
+					testGitInitializerWindowsImage,
+					config.GitInitializerWindowsImage,
+				)
+				require.Equal(
+					t,
+					testGitInitializerWindowsImagePullPolicy,
+					config.GitInitializerWindowsImagePullPolicy,
 				)
 				require.Equal(t, testDefaultWorkerImage, config.DefaultWorkerImage)
 				require.Equal(

--- a/v2/apiserver/internal/api/jobs.go
+++ b/v2/apiserver/internal/api/jobs.go
@@ -14,6 +14,16 @@ import (
 // JobKind represents the canonical Job kind string
 const JobKind = "Job"
 
+// OSFamily represents a type of operating system.
+type OSFamily string
+
+const (
+	// OSFamilyLinux represents a Linux-based OS.
+	OSFamilyLinux OSFamily = "linux"
+	// OSFamilyWindows represents a Windows-based OS.
+	OSFamilyWindows OSFamily = "windows"
+)
+
 // JobPhase represents where a Job is within its lifecycle.
 type JobPhase string
 
@@ -216,7 +226,7 @@ type JobHost struct {
 	// OS specifies which "family" of operating system is required on a substrate
 	// node to host a Job. Valid values are "linux" and "windows". When empty,
 	// Brigade assumes "linux".
-	OS string `json:"os,omitempty" bson:"os,omitempty"`
+	OS OSFamily `json:"os,omitempty" bson:"os,omitempty"`
 	// NodeSelector specifies labels that must be present on the substrate node to
 	// host a Job. This provides an opaque mechanism for communicating Job needs
 	// such as specific hardware like an SSD or GPU.


### PR DESCRIPTION
This corrects several overlooked aspects of our support for Windows-based jobs:

1. When applicable, uses node selector to request scheduling on a Windows node.
2. When applicable, uses a toleration to _tolerate_ being scheduled on a Windows node.
3. When applicable, uses Windows-based variant of git initializer component.
4. Adds a Windows example