### PR TITLE
fix release process for windows images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
-name: Brigade v2 Merge
+name: Brigade v2 Release
 
 on:
   push:
-    branches:
-      - v2
+    tags:
+      - v2.*.*
 
 jobs:
   build:
@@ -22,6 +22,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push Windows logger agent
-        run: make push-logger-windows
+        run: VERSION=${GITHUB_REF:10} make push-logger-windows
       - name: Push Windows git initializer
-        run: make push-git-initializer-windows
+        run: VERSION=${GITHUB_REF:10} make push-git-initializer-windows


### PR DESCRIPTION
Noticed recently that we successfully publish images tagged "edge" and with short git SHA on ever merge to v2... but we're _not_ publishing images tagged "latest" and with the semantic version number on each release.

This is because `VERSION=xxx` is missing from the publishing commands.

This PR is a quick and dirty fix. There's probably a more elegant way to do this, but GitHub Actions isn't where I want to be spending my time.