### PR TITLE
chart: upgrade mongodb

### DIFF
--- a/charts/brigade/Chart.lock
+++ b/charts/brigade/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.3.7
-digest: sha256:0370ef4db426321d173bf80ae4e8a5e6b7152bdf38cc3bfbe6d31a3c78fdb3b6
-generated: "2021-02-10T10:05:38.297831-05:00"
+  version: 10.29.2
+digest: sha256:8767dceb9c2c808c8a089b700f3287727c8fb48c1be288c5486e08d228030839
+generated: "2021-11-12T09:50:47.56396-05:00"

--- a/charts/brigade/Chart.yaml
+++ b/charts/brigade/Chart.yaml
@@ -13,6 +13,6 @@ maintainers:
   email: cncf-brigade-maintainers@lists.cncf.io
 dependencies:
 - name: mongodb
-  version: 10.3.7
+  version: 10.29.2
   repository: https://charts.bitnami.com/bitnami
   condition: mongodb.enabled

--- a/charts/brigade/templates/NOTES.txt
+++ b/charts/brigade/templates/NOTES.txt
@@ -28,7 +28,7 @@ To retrieve the password for the {{ quote .Values.mongodb.auth.database }} datab
 
   $ kubectl --namespace {{ .Release.Namespace }} get secret \
       {{ include "call-nested" (list . "mongodb" "mongodb.fullname") }} \
-      -o jsonpath={.data.mongodb-password} | base64 --decode
+      -o jsonpath={.data.mongodb-passwords} | base64 --decode
 
 To retrieve the auto-generated password for Artemis, run:
 

--- a/charts/brigade/templates/apiserver/deployment.yaml
+++ b/charts/brigade/templates/apiserver/deployment.yaml
@@ -123,14 +123,14 @@ spec:
           value: {{ include "call-nested" (list . "mongodb" "mongodb.fullname") }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.mongodb.service.port }}
         {{- end }}
         - name: DATABASE_NAME
-          value: {{ .Values.mongodb.auth.database }}
+          value: {{ index .Values.mongodb.auth.databases 0 }}
         - name: DATABASE_USERNAME
-          value: {{ .Values.mongodb.auth.username }}
+          value: {{ index .Values.mongodb.auth.usernames 0 }}
         - name: DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "call-nested" (list . "mongodb" "mongodb.fullname") }}
-              key: mongodb-password
+              key: mongodb-passwords
         {{- else }}
         - name: DATABASE_CONNECTION_STRING
           valueFrom:

--- a/charts/brigade/templates/logger/secret.yaml
+++ b/charts/brigade/templates/logger/secret.yaml
@@ -102,9 +102,9 @@ stringData:
       host {{ include "call-nested" (list . "mongodb" "mongodb.fullname") }}.{{ .Release.Namespace }}.svc.cluster.local
       {{- end }}
       port 27017
-      database {{ .Values.mongodb.auth.database }}
-      user {{ .Values.mongodb.auth.username }}
-      password {{ .Values.mongodb.auth.password }}
+      database {{ index .Values.mongodb.auth.databases 0 }}
+      user {{ index .Values.mongodb.auth.usernames 0 }}
+      password {{ index .Values.mongodb.auth.passwords 0 }}
       {{- else }}
       connection_string {{ .Values.externalMongodb.connectionString }}
       {{- end }}

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -397,29 +397,108 @@ mongodb:
 
   enabled: true
 
+  ## @section Global parameters
   ## Global Docker image parameters
   ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-  ## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+  ## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
   ##
-  # global:
-  #   imageRegistry: myRegistryName
-  #   imagePullSecrets:
-  #     - myRegistryKeySecretName
-  #   storageClass: myStorageClass
-  ## Override the namespace for resource deployed by the chart, but can itself be overridden by the local namespaceOverride
-  #   namespaceOverride: my-global-namespace
 
+  ## @param global.imageRegistry Global Docker image registry
+  ## @param global.imagePullSecrets Global Docker registry secret names as an array
+  ## @param global.storageClass Global StorageClass for Persistent Volume(s)
+  ## @param global.namespaceOverride Override the namespace for resource deployed by the chart, but can itself be overridden by the local namespaceOverride
+  ##
+  global:
+    imageRegistry: ""
+    ## E.g.
+    ## imagePullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    imagePullSecrets: []
+    storageClass: ""
+    namespaceOverride: ""
+
+  ## @section Common parameters
+  ##
+
+  ## @param nameOverride String to partially override mongodb.fullname template (will maintain the release name)
+  ##
+  nameOverride: ""
+  ## @param fullnameOverride String to fully override mongodb.fullname template
+  ##
+  fullnameOverride: ""
+  ## @param clusterDomain Default Kubernetes cluster domain
+  ##
+  clusterDomain: cluster.local
+  ## @param extraDeploy Array of extra objects to deploy with the release
+  ## extraDeploy:
+  ## This needs to be uncommented and added to 'extraDeploy' in order to use the replicaset 'mongo-labeler' sidecar
+  ## for dynamically discovering the mongodb primary pod
+  ## suggestion is to use a hard-coded and predictable TCP port for the primary mongodb pod (here is 30001, choose your own)
+  ## - apiVersion: v1
+  ##   kind: Service
+  ##   metadata:
+  ##     name: mongodb-primary
+  ##     namespace: the-mongodb-namespace
+  ##     labels:
+  ##       app.kubernetes.io/component: mongodb
+  ##       app.kubernetes.io/instance: mongodb
+  ##       app.kubernetes.io/managed-by: Helm
+  ##       app.kubernetes.io/name: mongodb
+  ##   spec:
+  ##     type: NodePort
+  ##     externalTrafficPolicy: Cluster
+  ##     ports:
+  ##       - name: mongodb
+  ##         port: 30001
+  ##         nodePort: 30001
+  ##         protocol: TCP
+  ##         targetPort: mongodb
+  ##     selector:
+  ##       app.kubernetes.io/component: mongodb
+  ##       app.kubernetes.io/instance: mongodb
+  ##       app.kubernetes.io/name: mongodb
+  ##       primary: "true"
+  ##
+  extraDeploy: []
+  ## @param commonLabels Add labels to all the deployed resources (sub-charts are not considered). Evaluated as a template
+  ##
+  commonLabels: {}
+  ## @param commonAnnotations Common annotations to add to all Mongo resources (sub-charts are not considered). Evaluated as a template
+  ##
+  commonAnnotations: {}
+
+  ## Enable diagnostic mode in the deployment
+  ##
+  diagnosticMode:
+    ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
+    ##
+    enabled: false
+    ## @param diagnosticMode.command Command to override all containers in the deployment
+    ##
+    command:
+      - sleep
+    ## @param diagnosticMode.args Args to override all containers in the deployment
+    ##
+    args:
+      - infinity
+
+  ## @section MongoDB&reg; parameters
+  ##
+
+  ## Bitnami MongoDB&reg; image
+  ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
+  ## @param image.registry MongoDB&reg; image registry
+  ## @param image.repository MongoDB&reg; image registry
+  ## @param image.tag MongoDB&reg; image tag (immutable tags are recommended)
+  ## @param image.pullPolicy MongoDB&reg; image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
+  ## @param image.debug Set to true if you would like to see extra information on logs
+  ##
   image:
-    ## Bitnami MongoDB registry
-    ##
     registry: docker.io
-    ## Bitnami MongoDB image name
-    ##
     repository: bitnami/mongodb
-    ## Bitnami MongoDB image tag
-    ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
-    ##
-    tag: 4.4.3-debian-10-r0
+    tag: 4.4.10-debian-10-r20
     ## Specify a imagePullPolicy
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
@@ -427,117 +506,137 @@ mongodb:
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
     ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
-
+    pullSecrets: []
     ## Set to true if you would like to see extra information on logs
-    ## It turns on Bitnami debugging in minideb-extras-base
-    ## ref:  https://github.com/bitnami/minideb-extras-base
+    ##
     debug: false
 
-  ## String to partially override mongodb.fullname template (will maintain the release name)
-  ##
-  # nameOverride:
-
-  ## String to fully override mongodb.fullname template
-  ##
-  # fullnameOverride:
-
-  ## Kubernetes Cluster Domain
-  ##
-  clusterDomain: cluster.local
-
-  ## Use an alternate scheduler, e.g. "stork".
+  ## @param schedulerName Name of the scheduler (other than default) to dispatch pods
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##
-  # schedulerName:
-
-  ## MongoDB architecture. Allowed values: standalone or replicaset
+  schedulerName: ""
+  ## @param architecture MongoDB&reg; architecture (`standalone` or `replicaset`)
   ##
-  architecture: replicaset
-
-  ## Use StatefulSet instead of Deployment when deploying standalone
+  architecture: standalone
+  ## @param useStatefulSet Set to true to use a StatefulSet instead of a Deployment (only when `architecture=standalone`)
   ##
   useStatefulSet: false
-
-  ## MongoDB Authentication parameters
+  ## MongoDB&reg; Authentication parameters
   ##
   auth:
-    ## Enable authentication
+    ## @param auth.enabled Enable authentication
     ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
     ##
     enabled: true
-    ## MongoDB root password
+    ## @param auth.rootUser MongoDB&reg; root user
+    ##
+    rootUser: root
+    ## @param auth.rootPassword MongoDB&reg; root password
     ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
     ##
-    rootPassword: "FOOBAR"
-    ## MongoDB custom user and database
-    ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#creating-a-user-and-database-on-first-run
+    rootPassword: ""
+    ## MongoDB&reg; custom users and databases
+    ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#creating-users-and-databases-on-first-run
+    ## @param auth.usernames List of custom users to be created during the initialization
+    ## @param auth.passwords List of passwords for the custom users set at `auth.usernames`
+    ## @param auth.databases List of custom databases to be created during the initialization
     ##
-    username: brigade
-    password: foobar
-    database: brigade
-    ## Key used for replica set authentication
-    ## Ignored when mongodb.architecture=standalone
+    usernames:
+    - brigade
+    passwords:
+    - foobar
+    databases:
+    - brigade
+    ## @param auth.username DEPRECATED: use `auth.usernames` instead
+    ## @param auth.password DEPRECATED: use `auth.passwords` instead
+    ## @param auth.database DEPRECATED: use `auth.databases` instead
+    username: ""
+    password: ""
+    database: ""
+    ## @param auth.replicaSetKey Key used for authentication in the replicaset (only when `architecture=replicaset`)
     ##
-    replicaSetKey: "abcdefg"
-
-    ## Existing secret with MongoDB credentials
+    replicaSetKey: ""
+    ## @param auth.existingSecret Existing secret with MongoDB&reg; credentials (keys: `mongodb-password`, `mongodb-root-password`, ` mongodb-replica-set-key`)
     ## NOTE: When it's set the previous parameters are ignored.
     ##
-    # existingSecret: name-of-existing-secret
-
+    existingSecret: ""
   tls:
-    ## Enable or disable MongoDB TLS Support
+    ## @param tls.enabled Enable MongoDB&reg; TLS support between nodes in the cluster as well as between mongo clients and nodes
+    ##
     enabled: false
-
-    ## Existing secret with MongoDB TLS certificates
+    ## @param tls.autoGenerated Generate a custom CA and self-signed certificates
+    ##
+    autoGenerated: true
+    ## @param tls.existingSecret Existing secret with TLS certificates (keys: `mongodb-ca-cert`, `mongodb-ca-key`, `client-pem`)
     ## NOTE: When it's set it will disable certificate creation
     ##
-    # existingSecret: name-of-existing-secret
-
+    existingSecret: ""
     ## Add Custom CA certificate
-    # caCert: base64 encoded ca certificate
-    # caKey: base64 encoded private key
+    ## @param tls.caCert Custom CA certificated (base64 encoded)
+    ## @param tls.caKey CA certificate private key (base64 encoded)
     ##
+    caCert: ""
+    caKey: ""
     ## Bitnami Nginx image
+    ## @param tls.image.registry Init container TLS certs setup image registry
+    ## @param tls.image.repository Init container TLS certs setup image repository
+    ## @param tls.image.tag Init container TLS certs setup image tag (immutable tags are recommended)
+    ## @param tls.image.pullPolicy Init container TLS certs setup image pull policy
+    ## @param tls.extraDnsNames Add extra dns names to the CA, can solve x509 auth issue for pod clients
     ##
     image:
       registry: docker.io
       repository: bitnami/nginx
-      tag: 1.19.6-debian-10-r6
+      tag: 1.21.3-debian-10-r54
       pullPolicy: IfNotPresent
-
-  ## Name of the replica set
+    ## e.g:
+    ## extraDnsNames
+    ##   - "DNS.6": "$my_host"
+    ##   - "DNS.7": "$test"
+    ##
+    extraDnsNames: []
+  ## @param hostAliases Add deployment host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param replicaSetName Name of the replica set (only when `architecture=replicaset`)
   ## Ignored when mongodb.architecture=standalone
   ##
   replicaSetName: rs0
-
-  ## Enable DNS hostnames in the replica set config
+  ## @param replicaSetHostnames Enable DNS hostnames in the replicaset config (only when `architecture=replicaset`)
   ## Ignored when mongodb.architecture=standalone
   ## Ignored when externalAccess.enabled=true
   ##
   replicaSetHostnames: true
-
-  ## Whether enable/disable IPv6 on MongoDB
+  ## @param enableIPv6 Switch to enable/disable IPv6 on MongoDB&reg;
   ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-ipv6
   ##
   enableIPv6: false
-
-  ## Whether enable/disable DirectoryPerDB on MongoDB
+  ## @param directoryPerDB Switch to enable/disable DirectoryPerDB on MongoDB&reg;
   ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-directoryperdb
   ##
   directoryPerDB: false
-
-  ## MongoDB System Log configuration
+  ## MongoDB&reg; System Log configuration
   ## ref: https://github.com/bitnami/bitnami-docker-mongodb#configuring-system-log-verbosity-level
+  ## @param systemLogVerbosity MongoDB&reg; system log verbosity level
+  ## @param disableSystemLog Switch to enable/disable MongoDB&reg; system log
   ##
   systemLogVerbosity: 0
   disableSystemLog: false
-
-  ## MongoDB configuration file for Primary and Secondary nodes. For documentation of all options, see:
-  ##   http://docs.mongodb.org/manual/reference/configuration-options/
+  ## @param disableJavascript Switch to enable/disable MongoDB&reg; server-side JavaScript execution
+  ## ref: https://docs.mongodb.com/manual/core/server-side-javascript/
+  ##
+  disableJavascript: false
+  ## @param enableJournal Switch to enable/disable MongoDB&reg; Journaling
+  ## ref: https://docs.mongodb.com/manual/reference/configuration-options/#mongodb-setting-storage.journal.enabled
+  ##
+  enableJournal: true
+  ## @param configuration MongoDB&reg; configuration file to be used for Primary and Secondary nodes
+  ## For documentation of all options, see: http://docs.mongodb.org/manual/reference/configuration-options/
   ## Example:
   ## configuration: |-
   ##   # where and how to store data.
@@ -579,141 +678,130 @@ mongodb:
   ##     #keyFile: /opt/bitnami/mongodb/conf/keyfile
   ##
   configuration: ""
-
-  ## ConfigMap with MongoDB configuration for Primary and Secondary nodes
+  ## @param existingConfigmap Name of existing ConfigMap with MongoDB&reg; configuration for Primary and Secondary nodes
   ## NOTE: When it's set the arbiter.configuration parameter is ignored
   ##
-  # existingConfigmap:
-
-  ## initdb scripts
+  existingConfigmap: ""
+  ## @param initdbScripts Dictionary of initdb scripts
   ## Specify dictionary of scripts to be run at first boot
   ## Example:
   ## initdbScripts:
   ##   my_init_script.sh: |
   ##      #!/bin/bash
   ##      echo "Do something."
+  ##
   initdbScripts: {}
-
-  ## Existing ConfigMap with custom init scripts
+  ## @param initdbScriptsConfigMap Existing ConfigMap with custom initdb scripts
   ##
-  # initdbScriptsConfigMap:
-
+  initdbScriptsConfigMap: ""
   ## Command and args for running the container (set to default if not set). Use array form
+  ## @param command Override default container command (useful when using custom images)
+  ## @param args Override default container args (useful when using custom images)
   ##
-  # command:
-  # args:
-
-  ## Additional command line flags
+  command: []
+  args: []
+  ## @param extraFlags MongoDB&reg; additional command line flags
   ## Example:
   ## extraFlags:
   ##  - "--wiredTigerCacheSizeGB=2"
   ##
   extraFlags: []
-
-  ## Additional environment variables to set
+  ## @param extraEnvVars Extra environment variables to add to MongoDB&reg; pods
   ## E.g:
   ## extraEnvVars:
   ##   - name: FOO
   ##     value: BAR
   ##
   extraEnvVars: []
-
-  ## ConfigMap with extra environment variables
+  ## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars
   ##
-  # extraEnvVarsCM:
-
-  ## Secret with extra environment variables
+  extraEnvVarsCM: ""
+  ## @param extraEnvVarsSecret Name of existing Secret containing extra env vars (in case of sensitive data)
   ##
-  # extraEnvVarsSecret:
+  extraEnvVarsSecret: ""
 
-  ## Annotations to be added to the MongoDB statefulset. Evaluated as a template.
+  ## @section MongoDB&reg; statefulset parameters
+  ##
+
+  ## @param annotations Additional labels to be added to the MongoDB&reg; statefulset. Evaluated as a template
   ##
   annotations: {}
-
-  ## Additional labels to be added to the MongoDB statefulset. Evaluated as a template.
+  ## @param labels Annotations to be added to the MongoDB&reg; statefulset. Evaluated as a template
   ##
   labels: {}
-
-  ## Number of MongoDB replicas to deploy.
+  ## @param replicaCount Number of MongoDB&reg; nodes (only when `architecture=replicaset`)
   ## Ignored when mongodb.architecture=standalone
   ##
-  replicaCount: 1
-
-  ## StrategyType for MongoDB statefulset
+  replicaCount: 2
+  ## @param strategyType StrategyType for MongoDB&reg; statefulset
   ## It can be set to RollingUpdate or Recreate by default.
   ##
   strategyType: RollingUpdate
-
-  ## MongoDB should be initialized one by one when building the replicaset for the first time.
+  ## @param podManagementPolicy Pod management policy for MongoDB&reg;
+  ## Should be initialized one by one when building the replicaset for the first time
   ##
   podManagementPolicy: OrderedReady
-
-  ## Pod affinity preset
+  ## @param podAffinityPreset MongoDB&reg; Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-  ## Allowed values: soft, hard
   ##
   podAffinityPreset: ""
-
-  ## Pod anti-affinity preset
+  ## @param podAntiAffinityPreset MongoDB&reg; Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-  ## Allowed values: soft, hard
   ##
   podAntiAffinityPreset: soft
-
   ## Node affinity preset
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-  ## Allowed values: soft, hard
   ##
   nodeAffinityPreset:
-    ## Node affinity type
-    ## Allowed values: soft, hard
+    ## @param nodeAffinityPreset.type MongoDB&reg; Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ##
     type: ""
-    ## Node label key to match
+    ## @param nodeAffinityPreset.key MongoDB&reg; Node label key to match Ignored if `affinity` is set.
     ## E.g.
     ## key: "kubernetes.io/e2e-az-name"
     ##
     key: ""
-    ## Node label values to match
+    ## @param nodeAffinityPreset.values MongoDB&reg; Node label values to match. Ignored if `affinity` is set.
     ## E.g.
     ## values:
     ##   - e2e-az1
     ##   - e2e-az2
     ##
     values: []
-
-  ## Affinity for pod assignment. Evaluated as a template.
+  ## @param affinity MongoDB&reg; Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
   ##
   affinity: {}
-
-  ## Node labels for pod assignment. Evaluated as a template.
+  ## @param nodeSelector MongoDB&reg; Node labels for pod assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
-
-  ## Tolerations for pod assignment. Evaluated as a template.
+  ## @param tolerations MongoDB&reg; Tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-
-  ## Labels for MongoDB pods. Evaluated as a template.
+  ## @param podLabels MongoDB&reg; pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   ##
   podLabels: {}
-
-  ## Annotations for MongoDB pods. Evaluated as a template.
+  ## @param podAnnotations MongoDB&reg; Pod annotations
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations: {}
-
-  ## MongoDB pods' priority.
+  ## @param priorityClassName Name of the existing priority class to be used by MongoDB&reg; pod(s)
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##
-  # priorityClassName: ""
-
-  ## MongoDB pods' Security Context.
+  priorityClassName: ""
+  ## @param runtimeClassName Name of the runtime class to be used by MongoDB&reg; pod(s)
+  ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  ##
+  runtimeClassName: ""
+  ## MongoDB&reg; pods' Security Context.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param podSecurityContext.enabled Enable MongoDB&reg; pod(s)' Security Context
+  ## @param podSecurityContext.fsGroup Group ID for the volumes of the MongoDB&reg; pod(s)
+  ## @param podSecurityContext.sysctls sysctl settings of the MongoDB&reg; pod(s)'
   ##
   podSecurityContext:
     enabled: true
@@ -725,32 +813,46 @@ mongodb:
     ##   value: "10000"
     ##
     sysctls: []
-
-  ## MongoDB containers' Security Context (main and metrics container).
+  ## MongoDB&reg; containers' Security Context (main and metrics container).
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param containerSecurityContext.enabled Enable MongoDB&reg; container(s)' Security Context
+  ## @param containerSecurityContext.runAsUser User ID for the MongoDB&reg; container
+  ## @param containerSecurityContext.runAsNonRoot Set MongoDB&reg; container's Security Context runAsNonRoot
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
     runAsNonRoot: true
-
-  ## MongoDB containers' resource requests and limits.
+  ## MongoDB&reg; containers' resource requests and limits.
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param resources.limits The resources limits for MongoDB&reg; containers
+  ## @param resources.requests The requested resources for MongoDB&reg; containers
   ##
   resources:
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## Example:
+    ## limits:
+    ##    cpu: 100m
+    ##    memory: 128Mi
+    ##
     limits: {}
-    #   cpu: 100m
-    #   memory: 128Mi
+    ## Examples:
+    ## requests:
+    ##    cpu: 100m
+    ##    memory: 128Mi
+    ##
     requests: {}
-    #   cpu: 100m
-    #   memory: 128Mi
-
-  ## MongoDB pods' liveness and readiness probes. Evaluated as a template.
+  ## MongoDB&reg; pods' liveness probe. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ## @param livenessProbe.enabled Enable livenessProbe
+  ## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param livenessProbe.successThreshold Success threshold for livenessProbe
   ##
   livenessProbe:
     enabled: true
@@ -759,6 +861,15 @@ mongodb:
     timeoutSeconds: 5
     failureThreshold: 6
     successThreshold: 1
+  ## MongoDB&reg; pods' readiness probe. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ## @param readinessProbe.enabled Enable readinessProbe
+  ## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
   readinessProbe:
     enabled: true
     initialDelaySeconds: 5
@@ -766,18 +877,36 @@ mongodb:
     timeoutSeconds: 5
     failureThreshold: 6
     successThreshold: 1
-
-  ## Custom Liveness probes for MongoDB pods
+  ## Slow starting containers can be protected through startup probes
+  ## Startup probes are available in Kubernetes version 1.16 and above
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes
+  ## @param startupProbe.enabled Enable startupProbe
+  ## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 30
+  ## @param customLivenessProbe Override default liveness probe for MongoDB&reg; containers
   ## Ignored when livenessProbe.enabled=true
   ##
   customLivenessProbe: {}
-
-  ## Custom Readiness probes MongoDB pods
+  ## @param customReadinessProbe Override default readiness probe for MongoDB&reg; containers
   ## Ignored when readinessProbe.enabled=true
   ##
   customReadinessProbe: {}
-
-  ## Add init containers to the MongoDB pods.
+  ## @param customStartupProbe Override default startup probe for MongoDB&reg; containers
+  ## Ignored when startupProbe.enabled=true
+  ##
+  customStartupProbe: {}
+  ## @param initContainers Add additional init containers for the hidden node pod(s)
   ## Example:
   ## initContainers:
   ##   - name: your-image-name
@@ -787,9 +916,8 @@ mongodb:
   ##       - name: portname
   ##         containerPort: 1234
   ##
-  initContainers: {}
-
-  ## Add sidecars to the MongoDB pods.
+  initContainers: []
+  ## @param sidecars Add additional sidecar containers for the MongoDB&reg; pod(s)
   ## Example:
   ## sidecars:
   ##   - name: your-image-name
@@ -798,114 +926,98 @@ mongodb:
   ##     ports:
   ##       - name: portname
   ##         containerPort: 1234
+  ## This is an optional 'mongo-labeler' sidecar container that tracks replica-set for the primary mongodb pod
+  ## and labels it dynamically with ' primary: "true" ' in order for an extra-deployed service to always expose
+  ## and attach to the primary pod, this needs to be uncommented along with the suggested 'extraDeploy' example
+  ## and the suggested rbac example for the pod to be allowed adding labels to mongo replica pods
+  ## search 'mongo-labeler' through this file to find the sections that needs to be uncommented to make it work
   ##
-  sidecars: {}
-
-  ## extraVolumes and extraVolumeMounts allows you to mount other volumes on MongoDB pods
+  ## - name: mongo-labeler
+  ##   image: korenlev/k8s-mongo-labeler-sidecar
+  ##   imagePullPolicy: Always
+  ##   env:
+  ##     - name: LABEL_SELECTOR
+  ##       value: "app.kubernetes.io/component=mongodb,app.kubernetes.io/instance=mongodb,app.kubernetes.io/name=mongodb"
+  ##     - name: NAMESPACE
+  ##       value: "the-mongodb-namespace"
+  ##     - name: DEBUG
+  ##       value: "true"
+  ##
+  sidecars: []
+  ## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for the MongoDB&reg; container(s)
   ## Examples:
   ## extraVolumeMounts:
   ##   - name: extras
   ##     mountPath: /usr/share/extras
   ##     readOnly: true
+  ##
+  extraVolumeMounts: []
+  ## @param extraVolumes Optionally specify extra list of additional volumes to the MongoDB&reg; statefulset
   ## extraVolumes:
   ##   - name: extras
   ##     emptyDir: {}
-  extraVolumeMounts: []
+  ##
   extraVolumes: []
-
-  ## MongoDB Pod Disruption Budget configuration
+  ## MongoDB&reg; Pod Disruption Budget configuration
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   pdb:
+    ## @param pdb.create Enable/disable a Pod Disruption Budget creation for MongoDB&reg; pod(s)
+    ##
     create: false
-    ## Min number of pods that must still be available after the eviction
+    ## @param pdb.minAvailable Minimum number/percentage of MongoDB&reg; pods that must still be available after the eviction
     ##
     minAvailable: 1
-    ## Max number of pods that can be unavailable after the eviction
+    ## @param pdb.maxUnavailable Maximum number/percentage of MongoDB&reg; pods that may be made unavailable after the eviction
     ##
-    # maxUnavailable: 1
+    maxUnavailable: ""
 
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ## @section Traffic exposure parameters
   ##
-  persistence:
-    enabled: true
-    ## A manually managed Persistent Volume and Claim
-    ## Requires persistence.enabled: true
-    ## If defined, PVC must be created manually before volume will be bound
-    ## Ignored when mongodb.architecture=replicaset
-    ##
-    # existingClaim:
-    ## PV Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ## set, choosing the default provisioner.
-    ##
-    # storageClass: "-"
-    ## PV Access Mode
-    ##
-    accessModes:
-      - ReadWriteOnce
-    ## PVC size
-    ##
-    size: 8Gi
-    ## PVC annotations
-    ##
-    annotations: {}
-    ## The path the volume will be mounted at, useful when using different
-    ## MongoDB images.
-    ##
-    mountPath: /bitnami/mongodb
-    ## The subdirectory of the volume to mount to, useful in dev environments
-    ## and one PV for multiple services.
-    ##
-    subPath: ""
-    ## Fine tuning for volumeClaimTemplates
-    volumeClaimTemplates:
-      ## A label query over volumes to consider for binding (e.g. when using local volumes)
-      ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta for more details
-      selector:
 
   ## Service parameters
   ##
   service:
-    ## Service type
+    ## @param service.nameOverride MongoDB&reg; service name
+    ##
+    nameOverride: ""
+    ## @param service.type Kubernetes Service type
     ##
     type: ClusterIP
-    ## MongoDB service port
+    ## @param service.port MongoDB&reg; service port
     ##
     port: 27017
-    ## MongoDB service port name
+    ## @param service.portName MongoDB&reg; service port name
     ##
     portName: mongodb
-    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## @param service.nodePort Port to bind to for NodePort and LoadBalancer service types
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
     ##
     nodePort: ""
-    ## MongoDB service clusterIP IP
+    ## @param service.clusterIP MongoDB&reg; service cluster IP
+    ## e.g:
+    ## clusterIP: None
     ##
-    # clusterIP: None
-    ## Specify the externalIP value ClusterIP service type.
+    clusterIP: ""
+    ## @param service.externalIPs Specify the externalIP value ClusterIP service type.
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
     ##
     externalIPs: []
-    ## Specify the loadBalancerIP value for LoadBalancer service types.
+    ## @param service.loadBalancerIP loadBalancerIP for MongoDB&reg; Service
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
     ##
-    # loadBalancerIP:
-    ## Specify the loadBalancerSourceRanges value for LoadBalancer service types.
+    loadBalancerIP: ""
+    ## @param service.loadBalancerSourceRanges Address(es) that are allowed when service is LoadBalancer
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ##
     loadBalancerSourceRanges: []
-    ## Provide any additional annotations which may be required. Evaluated as a template
+    ## @param service.annotations Provide any additional annotations that may be required
     ##
     annotations: {}
-
-  ## External Access to MongoDB nodes configuration
+  ## External Access to MongoDB&reg; nodes configuration
   ##
   externalAccess:
-    ## Enable Kubernetes external cluster access to MongoDB nodes
+    ## @param externalAccess.enabled Enable Kubernetes external cluster access to MongoDB&reg; nodes (only for replicaset architecture)
     ##
     enabled: false
     ## External IPs auto-discovery configuration
@@ -913,16 +1025,21 @@ mongodb:
     ## Note: RBAC might be required
     ##
     autoDiscovery:
-      ## Enable external IP/ports auto-discovery
+      ## @param externalAccess.autoDiscovery.enabled Enable using an init container to auto-detect external IPs by querying the K8s API
       ##
       enabled: false
       ## Bitnami Kubectl image
       ## ref: https://hub.docker.com/r/bitnami/kubectl/tags/
+      ## @param externalAccess.autoDiscovery.image.registry Init container auto-discovery image registry
+      ## @param externalAccess.autoDiscovery.image.repository Init container auto-discovery image repository
+      ## @param externalAccess.autoDiscovery.image.tag Init container auto-discovery image tag (immutable tags are recommended)
+      ## @param externalAccess.autoDiscovery.image.pullPolicy Init container auto-discovery image pull policy
+      ## @param externalAccess.autoDiscovery.image.pullSecrets Init container auto-discovery image pull secrets
       ##
       image:
         registry: docker.io
         repository: bitnami/kubectl
-        tag: 1.18.13-debian-10-r12
+        tag: 1.19.16-debian-10-r4
         ## Specify a imagePullPolicy
         ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
         ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -937,177 +1054,446 @@ mongodb:
         pullSecrets: []
       ## Init Container resource requests and limits
       ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+      ## We usually recommend not to specify default resources and to leave this as a conscious
+      ## choice for the user. This also increases chances charts run on environments with little
+      ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+      ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      ## @param externalAccess.autoDiscovery.resources.limits Init container auto-discovery resource limits
+      ## @param externalAccess.autoDiscovery.resources.requests Init container auto-discovery resource requests
       ##
       resources:
-        # We usually recommend not to specify default resources and to leave this as a conscious
-        # choice for the user. This also increases chances charts run on environments with little
-        # resources, such as Minikube. If you do want to specify resources, uncomment the following
-        # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+        ## Example:
+        ## limits:
+        ##    cpu: 100m
+        ##    memory: 128Mi
+        ##
         limits: {}
-        #   cpu: 100m
-        #   memory: 128Mi
+        ## Examples:
+        ## requests:
+        ##    cpu: 100m
+        ##    memory: 128Mi
+        ##
         requests: {}
-        #   cpu: 100m
-        #   memory: 128Mi
-    ## Parameters to configure K8s service(s) used to externally access MongoDB
+    ## Parameters to configure K8s service(s) used to externally access MongoDB&reg;
     ## A new service per broker will be created
     ##
     service:
-      ## Service type. Allowed values: LoadBalancer or NodePort
+      ## @param externalAccess.service.type Kubernetes Service type for external access. Allowed values: NodePort, LoadBalancer or ClusterIP
       ##
       type: LoadBalancer
-      ## Port used when service type is LoadBalancer
+      ## @param externalAccess.service.port MongoDB&reg; port used for external access when service type is LoadBalancer
       ##
       port: 27017
-      ## Array of load balancer IPs for each MongoDB node. Length must be the same as replicaCount
+      ## @param externalAccess.service.loadBalancerIPs Array of load balancer IPs for MongoDB&reg; nodes
       ## Example:
       ## loadBalancerIPs:
       ##   - X.X.X.X
       ##   - Y.Y.Y.Y
       ##
       loadBalancerIPs: []
-      ## Load Balancer sources
+      ## @param externalAccess.service.loadBalancerSourceRanges Address(es) that are allowed when service is LoadBalancer
       ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
       ## Example:
       ## loadBalancerSourceRanges:
       ## - 10.10.10.0/24
       ##
       loadBalancerSourceRanges: []
-      ## Array of node ports used for each MongoDB nodes. Length must be the same as replicaCount
+      ## @param externalAccess.service.nodePorts Array of node ports used to configure MongoDB&reg; advertised hostname when service type is NodePort
       ## Example:
       ## nodePorts:
       ##   - 30001
       ##   - 30002
       ##
       nodePorts: []
-      ## When service type is NodePort, you can specify the domain used for MongoDB advertised hostnames.
+      ## @param externalAccess.service.domain Domain or external IP used to configure MongoDB&reg; advertised hostname when service type is NodePort
       ## If not specified, the container will try to get the kubernetes node external IP
+      ## e.g:
+      ## domain: mydomain.com
       ##
-      # domain: mydomain.com
-      ## Provide any additional annotations which may be required. Evaluated as a template
+      domain: ""
+      ## @param externalAccess.service.annotations Service annotations for external access
       ##
       annotations: {}
+    ## External Access to MongoDB&reg; Hidden nodes configuration
+    ##
+    hidden:
+      ## @param externalAccess.hidden.enabled Enable Kubernetes external cluster access to MongoDB&reg; hidden nodes
+      ##
+      enabled: false
+      ## Parameters to configure K8s service(s) used to externally access MongoDB&reg;
+      ## A new service per broker will be created
+      ##
+      service:
+        ## @param externalAccess.hidden.service.type Kubernetes Service type for external access. Allowed values: NodePort or LoadBalancer
+        ##
+        type: LoadBalancer
+        ## @param externalAccess.hidden.service.port MongoDB&reg; port used for external access when service type is LoadBalancer
+        ##
+        port: 27017
+        ## @param externalAccess.hidden.service.loadBalancerIPs Array of load balancer IPs for MongoDB&reg; nodes
+        ## Example:
+        ## loadBalancerIPs:
+        ##   - X.X.X.X
+        ##   - Y.Y.Y.Y
+        ##
+        loadBalancerIPs: []
+        ## @param externalAccess.hidden.service.loadBalancerSourceRanges Address(es) that are allowed when service is LoadBalancer
+        ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+        ## Example:
+        ## loadBalancerSourceRanges:
+        ## - 10.10.10.0/24
+        ##
+        loadBalancerSourceRanges: []
+        ## @param externalAccess.hidden.service.nodePorts Array of node ports used to configure MongoDB&reg; advertised hostname when service type is NodePort. Length must be the same as replicaCount
+        ## Example:
+        ## nodePorts:
+        ##   - 30001
+        ##   - 30002
+        ##
+        nodePorts: []
+        ## @param externalAccess.hidden.service.domain Domain or external IP used to configure MongoDB&reg; advertised hostname when service type is NodePort
+        ## If not specified, the container will try to get the kubernetes node external IP
+        ## e.g:
+        ## domain: mydomain.com
+        ##
+        domain: ""
+        ## @param externalAccess.hidden.service.annotations Service annotations for external access
+        ##
+        annotations: {}
 
+  ## @section Persistence parameters
   ##
-  ## MongoDB Arbiter parameters.
+
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
   ##
-  arbiter:
-    ## Enable deploying the MongoDB Arbiter
-    ##   https://docs.mongodb.com/manual/tutorial/add-replica-set-arbiter/
+  persistence:
+    ## @param persistence.enabled Enable MongoDB&reg; data persistence using PVC
+    ##
+    enabled: true
+    ## @param persistence.existingClaim Provide an existing `PersistentVolumeClaim` (only when `architecture=standalone`)
+    ## Requires persistence.enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    ## Ignored when mongodb.architecture=replicaset
+    ##
+    existingClaim: ""
+    ## @param persistence.storageClass PVC Storage Class for MongoDB&reg; data volume
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ## set, choosing the default provisioner.
+    ##
+    storageClass: ""
+    ## @param persistence.accessModes PV Access Mode
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## @param persistence.size PVC Storage Request for MongoDB&reg; data volume
+    ##
+    size: 8Gi
+    ## @param persistence.annotations PVC annotations
+    ##
+    annotations: {}
+    ## @param persistence.mountPath Path to mount the volume at
+    ## MongoDB&reg; images.
+    ##
+    mountPath: /bitnami/mongodb
+    ## @param persistence.subPath Subdirectory of the volume to mount at
+    ## and one PV for multiple services.
+    ##
+    subPath: ""
+    ## Fine tuning for volumeClaimTemplates
+    ##
+    volumeClaimTemplates:
+      ## @param persistence.volumeClaimTemplates.selector A label query over volumes to consider for binding (e.g. when using local volumes)
+      ## A label query over volumes to consider for binding (e.g. when using local volumes)
+      ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta for more details
+      ##
+      selector: {}
+      ## @param persistence.volumeClaimTemplates.requests Custom PVC requests attributes
+      ## Sometime cloud providers use additional requests attributes to provision custom storage instance
+      ## See https://cloud.ibm.com/docs/containers?topic=containers-file_storage#file_dynamic_statefulset
+      ##
+      requests: {}
+      ## @param persistence.volumeClaimTemplates.dataSource Add dataSource to the VolumeClaimTemplate
+      ##
+      dataSource: {}
+
+  ## @section RBAC parameters
+  ##
+
+  ## ServiceAccount
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccount:
+    ## @param serviceAccount.create Enable creation of ServiceAccount for MongoDB&reg; pods
+    ##
+    create: true
+    ## @param serviceAccount.name Name of the created serviceAccount
+    ## If not set and create is true, a name is generated using the mongodb.fullname template
+    ##
+    name: ""
+    ## @param serviceAccount.annotations Additional Service Account annotations
+    ##
+    annotations: {}
+  ## Role Based Access
+  ## ref: https://kubernetes.io/docs/admin/authorization/rbac/
+  ##
+  rbac:
+    ## @param rbac.create Whether to create & use RBAC resources or not
+    ## binding MongoDB&reg; ServiceAccount to a role
+    ## that allows MongoDB&reg; pods querying the K8s API
+    ## this needs to be set to 'true' to enable the mongo-labeler sidecar primary mongodb discovery
+    ##
+    create: false
+    role:
+      ## @param rbac.role.rules Custom rules to create following the role specification
+      ## The example below needs to be uncommented to use the 'mongo-labeler' sidecar for dynamic discovery of the primary mongodb pod:
+      ## rules:
+      ##   - apiGroups:
+      ##       - ""
+      ##     resources:
+      ##       - pods
+      ##     verbs:
+      ##       - get
+      ##       - list
+      ##       - watch
+      ##       - update
+      ##
+      rules: []
+  ## PodSecurityPolicy configuration
+  ## Be sure to also set rbac.create to true, otherwise Role and RoleBinding won't be created.
+  ## ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+  ##
+  podSecurityPolicy:
+    ## @param podSecurityPolicy.create Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later
+    ##
+    create: false
+    ## @param podSecurityPolicy.allowPrivilegeEscalation Enable privilege escalation
+    ## Either use predefined policy with some adjustments or use `podSecurityPolicy.spec`
+    ##
+    allowPrivilegeEscalation: false
+    ## @param podSecurityPolicy.privileged Allow privileged
+    ##
+    privileged: false
+    ## @param podSecurityPolicy.spec Specify the full spec to use for Pod Security Policy
+    ## ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+    ## Defining a spec ignores the above values.
+    ##
+    spec: {}
+    ## Example:
+    ##    allowPrivilegeEscalation: false
+    ##    fsGroup:
+    ##      rule: 'MustRunAs'
+    ##      ranges:
+    ##        - min: 1001
+    ##          max: 1001
+    ##    hostIPC: false
+    ##    hostNetwork: false
+    ##    hostPID: false
+    ##    privileged: false
+    ##    readOnlyRootFilesystem: false
+    ##    requiredDropCapabilities:
+    ##      - ALL
+    ##    runAsUser:
+    ##      rule: 'MustRunAs'
+    ##      ranges:
+    ##        - min: 1001
+    ##          max: 1001
+    ##    seLinux:
+    ##      rule: 'RunAsAny'
+    ##    supplementalGroups:
+    ##      rule: 'MustRunAs'
+    ##      ranges:
+    ##        - min: 1001
+    ##          max: 1001
+    ##    volumes:
+    ##      - 'configMap'
+    ##      - 'secret'
+    ##      - 'emptyDir'
+    ##      - 'persistentVolumeClaim'
+    ##
+
+  ## @section Volume Permissions parameters
+  ##
+
+  ## Init Container parameters
+  ## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component
+  ## values from the securityContext section of the component
+  ##
+  volumePermissions:
+    ## @param volumePermissions.enabled Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`
+    ##
     enabled: false
+    ## @param volumePermissions.image.registry Init container volume-permissions image registry
+    ## @param volumePermissions.image.repository Init container volume-permissions image repository
+    ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+    ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
+    ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
+    ##
+    image:
+      registry: docker.io
+      repository: bitnami/bitnami-shell
+      tag: 10-debian-10-r239
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## Example:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+    ## Init Container resource requests and limits
+    ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ## We usually recommend not to specify default resources and to leave this as a conscious
+    ## choice for the user. This also increases chances charts run on environments with little
+    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## @param volumePermissions.resources.limits Init container volume-permissions resource limits
+    ## @param volumePermissions.resources.requests Init container volume-permissions resource requests
+    ##
+    resources:
+      ## Example:
+      ## limits:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      ##
+      limits: {}
+      ## Examples:
+      ## requests:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      ##
+      requests: {}
+    ## Init container Security Context
+    ## Note: the chown of the data folder is done to containerSecurityContext.runAsUser
+    ## and not the below volumePermissions.securityContext.runAsUser
+    ## When runAsUser is set to special value "auto", init container will try to chwon the
+    ## data folder to autodetermined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
+    ## "auto" is especially useful for OpenShift which has scc with dynamic userids (and 0 is not allowed).
+    ## You may want to use this volumePermissions.securityContext.runAsUser="auto" in combination with
+    ## podSecurityContext.enabled=false,containerSecurityContext.enabled=false and shmVolume.chmod.enabled=false
+    ## @param volumePermissions.securityContext.runAsUser User ID for the volumePermissions container
+    ##
+    securityContext:
+      runAsUser: 0
 
-    ## MongoDB configuration file for the Arbiter. For documentation of all options, see:
+  ## @section Arbiter parameters
+  ##
+
+  arbiter:
+    ## @param arbiter.enabled Enable deploying the arbiter
+    ##   https://docs.mongodb.com/manual/tutorial/add-replica-set-arbiter/
+    ##
+    enabled: true
+    ## @param arbiter.configuration Arbiter configuration file to be used
     ##   http://docs.mongodb.org/manual/reference/configuration-options/
     ##
     configuration: ""
-
-    ## ConfigMap with MongoDB configuration for the Arbiter
+    ## @param arbiter.hostAliases Add deployment host aliases
+    ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+    ##
+    hostAliases: []
+    ## @param arbiter.existingConfigmap Name of existing ConfigMap with Arbiter configuration
     ## NOTE: When it's set the arbiter.configuration parameter is ignored
     ##
-    # existingConfigmap:
-
+    existingConfigmap: ""
     ## Command and args for running the container (set to default if not set). Use array form
+    ## @param arbiter.command Override default container command (useful when using custom images)
+    ## @param arbiter.args Override default container args (useful when using custom images)
     ##
-    # command:
-    # args:
-
-    ## Additional command line flags
+    command: []
+    args: []
+    ## @param arbiter.extraFlags Arbiter additional command line flags
     ## Example:
     ## extraFlags:
     ##  - "--wiredTigerCacheSizeGB=2"
     ##
     extraFlags: []
-
-    ## Additional environment variables to set
+    ## @param arbiter.extraEnvVars Extra environment variables to add to Arbiter pods
     ## E.g:
     ## extraEnvVars:
     ##   - name: FOO
     ##     value: BAR
     ##
     extraEnvVars: []
-
-    ## ConfigMap with extra environment variables
+    ## @param arbiter.extraEnvVarsCM Name of existing ConfigMap containing extra env vars
     ##
-    # extraEnvVarsCM:
-
-    ## Secret with extra environment variables
+    extraEnvVarsCM: ""
+    ## @param arbiter.extraEnvVarsSecret Name of existing Secret containing extra env vars (in case of sensitive data)
     ##
-    # extraEnvVarsSecret:
-
-    ## Annotations to be added to the Arbiter statefulset. Evaluated as a template.
+    extraEnvVarsSecret: ""
+    ## @param arbiter.annotations Additional labels to be added to the Arbiter statefulset
     ##
     annotations: {}
-
-    ## Additional to be added to the Arbiter statefulset. Evaluated as a template.
+    ## @param arbiter.labels Annotations to be added to the Arbiter statefulset
     ##
     labels: {}
-
-    ## Pod affinity preset
+    ## @param arbiter.podAffinityPreset Arbiter Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
     ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-    ## Allowed values: soft, hard
     ##
     podAffinityPreset: ""
-
-    ## Pod anti-affinity preset
+    ## @param arbiter.podAntiAffinityPreset Arbiter Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
     ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-    ## Allowed values: soft, hard
     ##
     podAntiAffinityPreset: soft
-
     ## Node affinity preset
     ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-    ## Allowed values: soft, hard
     ##
     nodeAffinityPreset:
-      ## Node affinity type
-      ## Allowed values: soft, hard
+      ## @param arbiter.nodeAffinityPreset.type Arbiter Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+      ##
       type: ""
-      ## Node label key to match
+      ## @param arbiter.nodeAffinityPreset.key Arbiter Node label key to match Ignored if `affinity` is set.
       ## E.g.
       ## key: "kubernetes.io/e2e-az-name"
       ##
       key: ""
-      ## Node label values to match
+      ## @param arbiter.nodeAffinityPreset.values Arbiter Node label values to match. Ignored if `affinity` is set.
       ## E.g.
       ## values:
       ##   - e2e-az1
       ##   - e2e-az2
       ##
       values: []
-
-    ## Affinity for pod assignment
+    ## @param arbiter.affinity Arbiter Affinity for pod assignment
     ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
     ## Note: arbiter.podAffinityPreset, arbiter.podAntiAffinityPreset, and arbiter.nodeAffinityPreset will be ignored when it's set
     ##
     affinity: {}
-
-    ## Node labels for pod assignment
+    ## @param arbiter.nodeSelector Arbiter Node labels for pod assignment
     ## ref: https://kubernetes.io/docs/user-guide/node-selection/
     ##
     nodeSelector: {}
-
-    ## Tolerations for pod assignment
+    ## @param arbiter.tolerations Arbiter Tolerations for pod assignment
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
     ##
     tolerations: []
-
-    ## Labels for MongoDB Arbiter pods. Evaluated as a template.
+    ## @param arbiter.podLabels Arbiter pod labels
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
     ##
     podLabels: {}
-
-    ## Annotations for MongoDB Arbiter pods. Evaluated as a template.
+    ## @param arbiter.podAnnotations Arbiter Pod annotations
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     ##
     podAnnotations: {}
-
-    ## MongoDB Arbiter pods' priority.
+    ## @param arbiter.priorityClassName Name of the existing priority class to be used by Arbiter pod(s)
     ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
     ##
-    # priorityClassName: ""
-
-    ## MongoDB Arbiter pods' Security Context.
+    priorityClassName: ""
+    ## @param arbiter.runtimeClassName Name of the runtime class to be used by Arbiter pod(s)
+    ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
+    ##
+    runtimeClassName: ""
+    ## MongoDB&reg; Arbiter pods' Security Context.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+    ## @param arbiter.podSecurityContext.enabled Enable Arbiter pod(s)' Security Context
+    ## @param arbiter.podSecurityContext.fsGroup Group ID for the volumes of the Arbiter pod(s)
+    ## @param arbiter.podSecurityContext.sysctls sysctl settings of the Arbiter pod(s)'
     ##
     podSecurityContext:
       enabled: true
@@ -1119,31 +1505,44 @@ mongodb:
       ##   value: "10000"
       ##
       sysctls: []
-
-    ## MongoDB Arbiter containers' Security Context (only main container).
+    ## MongoDB&reg; Arbiter containers' Security Context (only main container).
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+    ## @param arbiter.containerSecurityContext.enabled Enable Arbiter container(s)' Security Context
+    ## @param arbiter.containerSecurityContext.runAsUser User ID for the Arbiter container
     ##
     containerSecurityContext:
       enabled: true
       runAsUser: 1001
-
-    ## MongoDB Arbiter containers' resource requests and limits.
+    ## MongoDB&reg; Arbiter containers' resource requests and limits.
     ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ## We usually recommend not to specify default resources and to leave this as a conscious
+    ## choice for the user. This also increases chances charts run on environments with little
+    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## @param arbiter.resources.limits The resources limits for Arbiter containers
+    ## @param arbiter.resources.requests The requested resources for Arbiter containers
     ##
     resources:
-      # We usually recommend not to specify default resources and to leave this as a conscious
-      # choice for the user. This also increases chances charts run on environments with little
-      # resources, such as Minikube. If you do want to specify resources, uncomment the following
-      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      ## Example:
+      ## limits:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      ##
       limits: {}
-      #   cpu: 100m
-      #   memory: 128Mi
+      ## Examples:
+      ## requests:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      ##
       requests: {}
-      #   cpu: 100m
-      #   memory: 128Mi
-
-    ## MongoDB Arbiter pods' liveness and readiness probes. Evaluated as a template.
+    ## MongoDB&reg; Arbiter pods' liveness probe. Evaluated as a template.
     ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+    ## @param arbiter.livenessProbe.enabled Enable livenessProbe
+    ## @param arbiter.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+    ## @param arbiter.livenessProbe.periodSeconds Period seconds for livenessProbe
+    ## @param arbiter.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+    ## @param arbiter.livenessProbe.failureThreshold Failure threshold for livenessProbe
+    ## @param arbiter.livenessProbe.successThreshold Success threshold for livenessProbe
     ##
     livenessProbe:
       enabled: true
@@ -1152,6 +1551,15 @@ mongodb:
       timeoutSeconds: 5
       failureThreshold: 6
       successThreshold: 1
+    ## MongoDB&reg; Arbiter pods' readiness probe. Evaluated as a template.
+    ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+    ## @param arbiter.readinessProbe.enabled Enable readinessProbe
+    ## @param arbiter.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+    ## @param arbiter.readinessProbe.periodSeconds Period seconds for readinessProbe
+    ## @param arbiter.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+    ## @param arbiter.readinessProbe.failureThreshold Failure threshold for readinessProbe
+    ## @param arbiter.readinessProbe.successThreshold Success threshold for readinessProbe
+    ##
     readinessProbe:
       enabled: true
       initialDelaySeconds: 5
@@ -1159,18 +1567,15 @@ mongodb:
       timeoutSeconds: 5
       failureThreshold: 6
       successThreshold: 1
-
-    ## Custom Liveness probes for MongoDB Arbiter pods
+    ## @param arbiter.customLivenessProbe Override default liveness probe for Arbiter containers
     ## Ignored when arbiter.livenessProbe.enabled=true
     ##
     customLivenessProbe: {}
-
-    ## Custom Readiness probes MongoDB Arbiter pods
+    ## @param arbiter.customReadinessProbe Override default readiness probe for Arbiter containers
     ## Ignored when arbiter.readinessProbe.enabled=true
     ##
     customReadinessProbe: {}
-
-    ## Add init containers to the MongoDB Arbiter pods.
+    ## @param arbiter.initContainers Add additional init containers for the Arbiter pod(s)
     ## Example:
     ## initContainers:
     ##   - name: your-image-name
@@ -1180,9 +1585,8 @@ mongodb:
     ##       - name: portname
     ##         containerPort: 1234
     ##
-    initContainers: {}
-
-    ## Add sidecars to the MongoDB Arbiter pods.
+    initContainers: []
+    ## @param arbiter.sidecars Add additional sidecar containers for the Arbiter pod(s)
     ## Example:
     ## sidecars:
     ##   - name: your-image-name
@@ -1192,164 +1596,401 @@ mongodb:
     ##       - name: portname
     ##         containerPort: 1234
     ##
-    sidecars: {}
-
-    ## extraVolumes and extraVolumeMounts allows you to mount other volumes on MongoDB Arbiter pods
+    sidecars: []
+    ## @param arbiter.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Arbiter container(s)
     ## Examples:
     ## extraVolumeMounts:
     ##   - name: extras
     ##     mountPath: /usr/share/extras
     ##     readOnly: true
+    ##
+    extraVolumeMounts: []
+    ## @param arbiter.extraVolumes Optionally specify extra list of additional volumes to the Arbiter statefulset
     ## extraVolumes:
     ##   - name: extras
     ##     emptyDir: {}
-    extraVolumeMounts: []
+    ##
     extraVolumes: []
-
-    ## MongoDB Arbiter Pod Disruption Budget configuration
+    ## MongoDB&reg; Arbiter Pod Disruption Budget configuration
     ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
     ##
     pdb:
+      ## @param arbiter.pdb.create Enable/disable a Pod Disruption Budget creation for Arbiter pod(s)
+      ##
       create: false
-      ## Min number of pods that must still be available after the eviction
+      ## @param arbiter.pdb.minAvailable Minimum number/percentage of Arbiter pods that should remain scheduled
       ##
       minAvailable: 1
-      ## Max number of pods that can be unavailable after the eviction
+      ## @param arbiter.pdb.maxUnavailable Maximum number/percentage of Arbiter pods that may be made unavailable
       ##
-      # maxUnavailable: 1
-
-  ## ServiceAccount
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-  ##
-  serviceAccount:
-    ## Specifies whether a ServiceAccount should be created
+      maxUnavailable: ""
+    ## MongoDB&reg; Arbiter service parameters
     ##
-    create: true
-    ## The name of the ServiceAccount to use.
-    ## If not set and create is true, a name is generated using the rabbitmq.fullname template
-    ##
-    # name:
+    service:
+      ## @param arbiter.service.nameOverride The arbiter service name
+      ##
+      nameOverride: ""
 
-  ## Role Based Access
-  ## ref: https://kubernetes.io/docs/admin/authorization/rbac/
+  ## @section Hidden Node parameters
   ##
-  rbac:
-    ## Specifies whether RBAC rules should be created
-    ## binding MongoDB ServiceAccount to a role
-    ## that allows MongoDB pods querying the K8s API
-    ##
-    create: false
 
-  ## Init Container parameters
-  ## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component
-  ## values from the securityContext section of the component
-  ##
-  volumePermissions:
+  hidden:
+    ## @param hidden.enabled Enable deploying the hidden nodes
+    ##   https://docs.mongodb.com/manual/tutorial/configure-a-hidden-replica-set-member/
+    ##
     enabled: false
-    ## Bitnami Minideb image
-    ## ref: https://hub.docker.com/r/bitnami/minideb/tags/
+    ## @param hidden.configuration Hidden node configuration file to be used
+    ##   http://docs.mongodb.org/manual/reference/configuration-options/
     ##
-    image:
-      registry: docker.io
-      repository: bitnami/minideb
-      tag: buster
-      ## Specify a imagePullPolicy
-      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    configuration: ""
+    ## @param hidden.existingConfigmap Name of existing ConfigMap with Hidden node configuration
+    ## NOTE: When it's set the hidden.configuration parameter is ignored
+    ##
+    existingConfigmap: ""
+    ## Command and args for running the container (set to default if not set). Use array form
+    ## @param hidden.command Override default container command (useful when using custom images)
+    ## @param hidden.args Override default container args (useful when using custom images)
+    ##
+    command: []
+    args: []
+    ## @param hidden.extraFlags Hidden node additional command line flags
+    ## Example:
+    ## extraFlags:
+    ##  - "--wiredTigerCacheSizeGB=2"
+    ##
+    extraFlags: []
+    ## @param hidden.extraEnvVars Extra environment variables to add to Hidden node pods
+    ## E.g:
+    ## extraEnvVars:
+    ##   - name: FOO
+    ##     value: BAR
+    ##
+    extraEnvVars: []
+    ## @param hidden.extraEnvVarsCM Name of existing ConfigMap containing extra env vars
+    ##
+    extraEnvVarsCM: ""
+    ## @param hidden.extraEnvVarsSecret Name of existing Secret containing extra env vars (in case of sensitive data)
+    ##
+    extraEnvVarsSecret: ""
+    ## @param hidden.annotations Additional labels to be added to thehidden node statefulset
+    ##
+    annotations: {}
+    ## @param hidden.labels Annotations to be added to the hidden node statefulset
+    ##
+    labels: {}
+    ## @param hidden.replicaCount Number of hidden nodes (only when `architecture=replicaset`)
+    ## Ignored when mongodb.architecture=standalone
+    ##
+    replicaCount: 1
+    ## @param hidden.strategyType StrategyType for hidden node statefulset
+    ## It can be set to RollingUpdate or Recreate by default.
+    ##
+    strategyType: RollingUpdate
+    ## @param hidden.podManagementPolicy Pod management policy for hidden node
+    ##
+    podManagementPolicy: OrderedReady
+    ## @param hidden.podAffinityPreset Hidden node Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+    ##
+    podAffinityPreset: ""
+    ## @param hidden.podAntiAffinityPreset Hidden node Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+    ##
+    podAntiAffinityPreset: soft
+    ## Node affinity preset
+    ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    ## Allowed values: soft, hard
+    ##
+    nodeAffinityPreset:
+      ## @param hidden.nodeAffinityPreset.type Hidden Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
       ##
-      pullPolicy: Always
-      ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
-      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-      ## Example:
-      ## pullSecrets:
-      ##   - myRegistryKeySecretName
+      type: ""
+      ## @param hidden.nodeAffinityPreset.key Hidden Node label key to match Ignored if `affinity` is set.
+      ## E.g.
+      ## key: "kubernetes.io/e2e-az-name"
       ##
-      pullSecrets: []
-    ## Init Container resource requests and limits
+      key: ""
+      ## @param hidden.nodeAffinityPreset.values Hidden Node label values to match. Ignored if `affinity` is set.
+      ## E.g.
+      ## values:
+      ##   - e2e-az1
+      ##   - e2e-az2
+      ##
+      values: []
+    ## @param hidden.affinity Hidden node Affinity for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+    ##
+    affinity: {}
+    ## @param hidden.nodeSelector Hidden node Node labels for pod assignment
+    ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+    ##
+    nodeSelector: {}
+    ## @param hidden.tolerations Hidden node Tolerations for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    ##
+    tolerations: []
+    ## @param hidden.podLabels Hidden node pod labels
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    ##
+    podLabels: {}
+    ## @param hidden.podAnnotations Hidden node Pod annotations
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    ##
+    podAnnotations: {}
+    ## @param hidden.priorityClassName Name of the existing priority class to be used by hidden node pod(s)
+    ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+    ##
+    priorityClassName: ""
+    ## @param hidden.runtimeClassName Name of the runtime class to be used by hidden node pod(s)
+    ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
+    ##
+    runtimeClassName: ""
+    ## MongoDB&reg; Hidden containers' resource requests and limits.
     ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ## We usually recommend not to specify default resources and to leave this as a conscious
+    ## choice for the user. This also increases chances charts run on environments with little
+    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## @param hidden.resources.limits The resources limits for hidden node containers
+    ## @param hidden.resources.requests The requested resources for hidden node containers
     ##
     resources:
-      # We usually recommend not to specify default resources and to leave this as a conscious
-      # choice for the user. This also increases chances charts run on environments with little
-      # resources, such as Minikube. If you do want to specify resources, uncomment the following
-      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      ## Example:
+      ## limits:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      ##
       limits: {}
-      #   cpu: 100m
-      #   memory: 128Mi
+      ## Examples:
+      ## requests:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      ##
       requests: {}
-      #   cpu: 100m
-      #   memory: 128Mi
-    ## Init container Security Context
-    ## Note: the chown of the data folder is done to containerSecurityContext.runAsUser
-    ## and not the below volumePermissions.securityContext.runAsUser
-    ## When runAsUser is set to special value "auto", init container will try to chwon the
-    ## data folder to autodetermined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
-    ## "auto" is especially useful for OpenShift which has scc with dynamic userids (and 0 is not allowed).
-    ## You may want to use this volumePermissions.securityContext.runAsUser="auto" in combination with
-    ## podSecurityContext.enabled=false,containerSecurityContext.enabled=false and shmVolume.chmod.enabled=false
+    ## MongoDB&reg; Hidden pods' liveness probe. Evaluated as a template.
+    ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+    ## @param hidden.livenessProbe.enabled Enable livenessProbe
+    ## @param hidden.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+    ## @param hidden.livenessProbe.periodSeconds Period seconds for livenessProbe
+    ## @param hidden.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+    ## @param hidden.livenessProbe.failureThreshold Failure threshold for livenessProbe
+    ## @param hidden.livenessProbe.successThreshold Success threshold for livenessProbe
     ##
-    securityContext:
-      runAsUser: 0
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+    ## MongoDB&reg; Hidden pods' readiness probe. Evaluated as a template.
+    ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+    ## @param hidden.readinessProbe.enabled Enable readinessProbe
+    ## @param hidden.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+    ## @param hidden.readinessProbe.periodSeconds Period seconds for readinessProbe
+    ## @param hidden.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+    ## @param hidden.readinessProbe.failureThreshold Failure threshold for readinessProbe
+    ## @param hidden.readinessProbe.successThreshold Success threshold for readinessProbe
+    ##
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+    ## @param hidden.customLivenessProbe Override default liveness probe for hidden node containers
+    ## Ignored when livenessProbe.enabled=true
+    ##
+    customLivenessProbe: {}
+    ## @param hidden.customReadinessProbe Override default readiness probe for hidden node containers
+    ## Ignored when readinessProbe.enabled=true
+    ##
+    customReadinessProbe: {}
+    ## @param hidden.initContainers Add init containers to the MongoDB&reg; Hidden pods.
+    ## Example:
+    ## initContainers:
+    ##   - name: your-image-name
+    ##     image: your-image
+    ##     imagePullPolicy: Always
+    ##     ports:
+    ##       - name: portname
+    ##         containerPort: 1234
+    ##
+    initContainers: []
+    ## @param hidden.sidecars Add additional sidecar containers for the hidden node pod(s)
+    ## Example:
+    ## sidecars:
+    ##   - name: your-image-name
+    ##     image: your-image
+    ##     imagePullPolicy: Always
+    ##     ports:
+    ##       - name: portname
+    ##         containerPort: 1234
+    ##
+    sidecars: []
+    ## @param hidden.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the hidden node container(s)
+    ## Examples:
+    ## extraVolumeMounts:
+    ##   - name: extras
+    ##     mountPath: /usr/share/extras
+    ##     readOnly: true
+    ##
+    extraVolumeMounts: []
+    ## @param hidden.extraVolumes Optionally specify extra list of additional volumes to the hidden node statefulset
+    ## extraVolumes:
+    ##   - name: extras
+    ##     emptyDir: {}
+    ##
+    extraVolumes: []
+    ## MongoDB&reg; Hidden Pod Disruption Budget configuration
+    ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+    ##
+    pdb:
+      ## @param hidden.pdb.create Enable/disable a Pod Disruption Budget creation for hidden node pod(s)
+      ##
+      create: false
+      ## @param hidden.pdb.minAvailable Minimum number/percentage of hidden node pods that should remain scheduled
+      ##
+      minAvailable: 1
+      ## @param hidden.pdb.maxUnavailable Maximum number/percentage of hidden node pods that may be made unavailable
+      ##
+      maxUnavailable: ""
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    persistence:
+      ## @param hidden.persistence.enabled Enable hidden node data persistence using PVC
+      ##
+      enabled: true
+      ## @param hidden.persistence.storageClass PVC Storage Class for hidden node data volume
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is
+      ## set, choosing the default provisioner.
+      ##
+      storageClass: ""
+      ## @param hidden.persistence.accessModes PV Access Mode
+      ##
+      accessModes:
+        - ReadWriteOnce
+      ## @param hidden.persistence.size PVC Storage Request for hidden node data volume
+      ##
+      size: 8Gi
+      ## @param hidden.persistence.annotations PVC annotations
+      ##
+      annotations: {}
+      ## @param hidden.persistence.mountPath The path the volume will be mounted at, useful when using different MongoDB&reg; images.
+      ##
+      mountPath: /bitnami/mongodb
+      ## @param hidden.persistence.subPath The subdirectory of the volume to mount to, useful in dev environments
+      ## and one PV for multiple services.
+      ##
+      subPath: ""
+      ## Fine tuning for volumeClaimTemplates
+      ##
+      volumeClaimTemplates:
+        ## @param hidden.persistence.volumeClaimTemplates.selector A label query over volumes to consider for binding (e.g. when using local volumes)
+        ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta for more details
+        ##
+        selector: {}
+        ## @param hidden.persistence.volumeClaimTemplates.dataSource Set volumeClaimTemplate dataSource
+        ##
+        dataSource: {}
 
-  ## Prometheus Exporter / Metrics
+  ## @section Metrics parameters
   ##
+
   metrics:
+    ## @param metrics.enabled Enable using a sidecar Prometheus exporter
+    ##
     enabled: false
-    ## Bitnami MongoDB Promtheus Exporter image
+    ## Bitnami MongoDB&reg; Promtheus Exporter image
     ## ref: https://hub.docker.com/r/bitnami/mongodb-exporter/tags/
+    ## @param metrics.image.registry MongoDB&reg; Prometheus exporter image registry
+    ## @param metrics.image.repository MongoDB&reg; Prometheus exporter image repository
+    ## @param metrics.image.tag MongoDB&reg; Prometheus exporter image tag (immutable tags are recommended)
+    ## @param metrics.image.pullPolicy MongoDB&reg; Prometheus exporter image pull policy
+    ## @param metrics.image.pullSecrets Specify docker-registry secret names as an array
     ##
     image:
       registry: docker.io
       repository: bitnami/mongodb-exporter
-      tag: 0.20.1-debian-10-r18
+      tag: 0.11.2-debian-10-r327
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## e.g:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
       ##
-      # pullSecrets:
-      #   - myRegistryKeySecretName
+      pullSecrets: []
 
-    ## String with extra flags to the metrics exporter
+    ## @param metrics.username String with username for the metrics exporter
+    ## If undefined the root user will be used for the metrics exporter
+    username: ""
+    ## @param metrics.password String with password for the metrics exporter
+    ## If undefined but metrics.username is defined, a random password will be generated
+    password: ""
+    ## @param metrics.extraFlags String with extra flags to the metrics exporter
     ## ref: https://github.com/percona/mongodb_exporter/blob/master/mongodb_exporter.go
     ##
     extraFlags: ""
-
-    ## String with additional URI options to the metrics exporter
+    ## @param metrics.extraUri Additional URI options of the metrics service
     ## ref: https://docs.mongodb.com/manual/reference/connection-string
     ##
     extraUri: ""
-
     ## Metrics exporter container resource requests and limits
     ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ## We usually recommend not to specify default resources and to leave this as a conscious
+    ## choice for the user. This also increases chances charts run on environments with little
+    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## @param metrics.resources.limits The resources limits for Prometheus exporter containers
+    ## @param metrics.resources.requests The requested resources for Prometheus exporter containers
     ##
     resources:
-      # We usually recommend not to specify default resources and to leave this as a conscious
-      # choice for the user. This also increases chances charts run on environments with little
-      # resources, such as Minikube. If you do want to specify resources, uncomment the following
-      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      ## Example:
+      ## limits:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      ##
       limits: {}
-      #   cpu: 100m
-      #   memory: 128Mi
+      ## Examples:
+      ## requests:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      ##
       requests: {}
-      #   cpu: 100m
-      #   memory: 128Mi
-
+    ## @param metrics.containerPort Port of the Prometheus metrics container
+    ##
+    containerPort: 9216
     ## Prometheus Exporter service configuration
     ##
     service:
-      ## Annotations for Prometheus Exporter pods. Evaluated as a template.
+      ## @param metrics.service.annotations [object] Annotations for Prometheus Exporter pods. Evaluated as a template.
       ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
       ##
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.metrics.service.port }}"
         prometheus.io/path: "/metrics"
+      ## @param metrics.service.type Type of the Prometheus metrics service
+      ##
       type: ClusterIP
+      ## @param metrics.service.port Port of the Prometheus metrics service
+      ##
       port: 9216
-
-    ## Metrics exporter liveness and readiness probes
+    ## Metrics exporter liveness probe
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+    ## @param metrics.livenessProbe.enabled Enable livenessProbe
+    ## @param metrics.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+    ## @param metrics.livenessProbe.periodSeconds Period seconds for livenessProbe
+    ## @param metrics.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+    ## @param metrics.livenessProbe.failureThreshold Failure threshold for livenessProbe
+    ## @param metrics.livenessProbe.successThreshold Success threshold for livenessProbe
     ##
     livenessProbe:
       enabled: true
@@ -1358,6 +1999,15 @@ mongodb:
       timeoutSeconds: 5
       failureThreshold: 3
       successThreshold: 1
+    ## Metrics exporter readiness probe
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+    ## @param metrics.readinessProbe.enabled Enable readinessProbe
+    ## @param metrics.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+    ## @param metrics.readinessProbe.periodSeconds Period seconds for readinessProbe
+    ## @param metrics.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+    ## @param metrics.readinessProbe.failureThreshold Failure threshold for readinessProbe
+    ## @param metrics.readinessProbe.successThreshold Success threshold for readinessProbe
+    ##
     readinessProbe:
       enabled: true
       initialDelaySeconds: 5
@@ -1365,41 +2015,49 @@ mongodb:
       timeoutSeconds: 1
       failureThreshold: 3
       successThreshold: 1
-
     ## Prometheus Service Monitor
     ## ref: https://github.com/coreos/prometheus-operator
     ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md
     ##
     serviceMonitor:
-      ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
-      enabled: false
-
-      ## Specify the namespace where Prometheus Operator is running
+      ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using Prometheus Operator
       ##
-      # namespace: monitoring
-
-      ## Specify the interval at which metrics should be scraped
+      enabled: false
+      ## @param metrics.serviceMonitor.namespace Namespace which Prometheus is running in
+      ##
+      namespace: ""
+      ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped
       ##
       interval: 30s
-      ## Specify the timeout after which the scrape is ended
+      ## @param metrics.serviceMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
+      ## e.g:
+      ## scrapeTimeout: 30s
       ##
-      # scrapeTimeout: 30s
-      ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
+      scrapeTimeout: ""
+      ## @param metrics.serviceMonitor.relabellings RelabelConfigs to apply to samples before scraping.
+      ##
+      relabellings: []
+      ## @param metrics.serviceMonitor.metricRelabelings MetricsRelabelConfigs to apply to samples before ingestion.
+      ##
+      metricRelabelings: []
+      ## @param metrics.serviceMonitor.additionalLabels Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
       ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
       ##
       additionalLabels: {}
-
     ## Custom PrometheusRule to be defined
     ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
     ##
     prometheusRule:
-      enabled: false
-      additionalLabels: {}
-      ## Specify the namespace where Prometheus Operator is running
+      ## @param metrics.prometheusRule.enabled Set this to true to create prometheusRules for Prometheus operator
       ##
-      # namespace: monitoring
-
-      ## Define individual alerting rules as required
+      enabled: false
+      ## @param metrics.prometheusRule.additionalLabels Additional labels that can be used so prometheusRules will be discovered by Prometheus
+      ##
+      additionalLabels: {}
+      ## @param metrics.prometheusRule.namespace Namespace where prometheusRules resource should be created
+      ##
+      namespace: ""
+      ## @param metrics.prometheusRule.rules Rules to be created, check values for an example
       ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#rulegroup
       ##      https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
       ##


### PR DESCRIPTION
This PR upgrades to the latest MongoDB subchart.

There are a lot of changes to that chart since we last upgraded it and some are "breaking-ish." (Lots of deprecated fields.)

It want to settle this now before we go RC/GA because if the subchart has changes of this magnitude in the future, we aren't going to want to take the upgrade because of how it will impact our own users who have MongoDB configuration embedded in their Brigade deployment's `values.yaml`.

Note to reviewer: Most of the changes are to `values.yaml`. The subchart's `values.yaml` was added wholesale to our own `values.yaml` and minimally modified for our purposes. (e.g. Specified creation of "`brigade` database and username/password.)

All the other changes to the chart, just adapt to those `values.yaml` changes. For instance, where we once accessed fields like `{{ Values.mongodb.auth.username }}`, we now use `{{ index .Values.mongodb.auth.userrnames 0 }}`