### PR TITLE
fix windows example

### DIFF
--- a/examples/15-windows/project.yaml
+++ b/examples/15-windows/project.yaml
@@ -16,13 +16,11 @@ spec:
         const { events, Job } = require("@brigadecore/brigadier");
 
         events.on("brigade.sh/cli", "exec", async event => {
-          let job = new Job("hello", "mcr.microsoft.com/windows/nanoserver", event);
-          job.primaryContainer.command = ["echo"];
-          job.primaryContainer.arguments = ["Hello from Windows!"];
+          let job = new Job("hello", "mcr.microsoft.com/windows/nanoserver:1809", event);
+          job.primaryContainer.command = ["cmd.exe"];
+          job.primaryContainer.arguments = ["/k", "echo Hello from Windows!"];
           job.host = {
-            nodeSelector: {
-              os: "windows"
-            }
+            os: "windows"
           };
           await job.run();
         });


### PR DESCRIPTION
This PR fixes 3 issues with the Windows example:

* There is no `mcr.microsoft.com/windows/nanoserver:latest`, so we need to explicitly specify a version of Windows. `mcr.microsoft.com/windows/nanoserver:1809` works well on a Windows-based AKS node.

* Host selection was previously done incorrectly in this example.

* `echo` is not a recognized command in and of itself. We need to start the `cmd.exe` shell and execute `echo` within it.