### PR TITLE
fix restrictions on allowed chars in label and qualifier keys

### DIFF
--- a/v2/apiserver/schemas/event.json
+++ b/v2/apiserver/schemas/event.json
@@ -70,7 +70,7 @@
 			],
 			"additionalProperties": false,
 			"patternProperties": {
-				"^[a-z][a-z\\d-]*[a-z\\d]$": {
+				"^[a-zA-Z][a-zA-Z\\d-]*[a-zA-Z\\d]$": {
 					"$ref": "common.json#/definitions/label"
 				}
 			},
@@ -83,7 +83,7 @@
 			],
 			"additionalProperties": false,
 			"patternProperties": {
-				"^[a-z][a-z\\d-]*[a-z\\d]$": {
+				"^[a-zA-Z][a-zA-Z\\d-]*[a-zA-Z\\d]$": {
 					"$ref": "common.json#/definitions/label"
 				}
 			},

--- a/v2/apiserver/schemas/project.json
+++ b/v2/apiserver/schemas/project.json
@@ -78,7 +78,7 @@
 					],
 					"additionalProperties": false,
 					"patternProperties": {
-						"^[a-z][a-z\\d-]*[a-z\\d]$": {
+						"^[a-zA-Z][a-zA-Z\\d-]*[a-zA-Z\\d]$": {
 							"$ref": "common.json#/definitions/label"
 						}
 					}
@@ -90,7 +90,7 @@
 					],
 					"additionalProperties": false,
 					"patternProperties": {
-						"^[a-z][a-z\\d-]*[a-z\\d]$": {
+						"^[a-zA-Z][a-zA-Z\\d-]*[a-zA-Z\\d]$": {
 							"$ref": "common.json#/definitions/label"
 						}
 					}

--- a/v2/apiserver/schemas/source-state.json
+++ b/v2/apiserver/schemas/source-state.json
@@ -14,7 +14,7 @@
 			"type": "object",
 			"additionalProperties": false,
 			"patternProperties": {
-				"^[a-z][a-z\\d-]*[a-z\\d]$": {
+				"^[a-zA-Z][a-zA-Z\\d-]*[a-zA-Z\\d]$": {
 					"type": "string"
 				}
 			},


### PR DESCRIPTION
Fixes #1736

This change is already applied to the dogfood cluster. Without it, we couldn't get anything to build because the GitHub gateway uses uppercase characters in some label and qualifier keys.