### PR TITLE
mount fluentd config to the correct location in a windows-based logger agent

### DIFF
--- a/charts/brigade/templates/logger/windows-daemonset.yaml
+++ b/charts/brigade/templates/logger/windows-daemonset.yaml
@@ -30,7 +30,7 @@ spec:
           mountPath: /ProgramData/docker/containers
           readOnly: true
         - name: logger-config
-          mountPath: /fluentd/etc
+          mountPath: /fluent/conf
       volumes:
       - name: var-log
         hostPath:


### PR DESCRIPTION
Fixes #1735 