### PR TITLE
chart: change default svc type for artemis to ClusterIP

### DIFF
--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -2127,7 +2127,7 @@ artemis:
   tolerations: []
 
   service:
-    type: NodePort
+    type: ClusterIP
 
 externalAMQP:
   address:


### PR DESCRIPTION
There's no good reason for this to be `NodePort` by default.