### PR TITLE
switch to stable API

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -297,8 +297,8 @@ async function runSuite(event: Event): Promise<void> {
       lintJSJob(event),
       yarnAuditJob(event),
       lintChartJob(event),
-      validateSchemasJob(event),
-      validateExamplesJob(event)
+      validateSchemasJob(event)
+      // validateExamplesJob(event)
     ),
     new ConcurrentGroup( // Build everything
       buildArtemisJob(event),

--- a/sdk/v2/meta/meta.go
+++ b/sdk/v2/meta/meta.go
@@ -4,7 +4,7 @@ import "time"
 
 // APIVersion represents the API and major version thereof with which this
 // version of the Brigade SDK is compatible.
-const APIVersion = "brigade.sh/v2-beta"
+const APIVersion = "brigade.sh/v2"
 
 // TypeMeta represents metadata about a resource type to help clients and
 // servers mutually head off potential confusion over types (and versions

--- a/v2/apiserver/internal/meta/meta.go
+++ b/v2/apiserver/internal/meta/meta.go
@@ -4,7 +4,7 @@ import "time"
 
 // APIVersion represents the API and major version thereof with which this
 // version of the Brigade API server is compatible.
-const APIVersion = "brigade.sh/v2-beta"
+const APIVersion = "brigade.sh/v2"
 
 // TypeMeta represents metadata about a resource type to help clients and
 // servers mutually head off potential confusion over types (and versions of

--- a/v2/apiserver/internal/meta/testing/meta.go
+++ b/v2/apiserver/internal/meta/testing/meta.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const apiVersion = "brigade.sh/v2-beta"
+const apiVersion = "brigade.sh/v2"
 
 func RequireAPIVersionAndType(
 	t *testing.T,

--- a/v2/apiserver/schemas/common.json
+++ b/v2/apiserver/schemas/common.json
@@ -8,7 +8,7 @@
 		"apiVersion": {
 			"type": "string",
 			"description": "The major version of the Brigade API with which this object conforms",
-			"enum": ["brigade.sh/v2-beta"]
+			"enum": ["brigade.sh/v2"]
 		},
 
 		"description": {

--- a/v2/brigadier-polyfill/package.json
+++ b/v2/brigadier-polyfill/package.json
@@ -26,7 +26,7 @@
     "ts-node": "^10.2.1"
   },
   "dependencies": {
-    "@brigadecore/brigade-sdk": "^v2.0.0-beta.4",
+    "@brigadecore/brigade-sdk": "^v2.0.0-rc.1",
     "@brigadecore/brigadier": "../brigadier",
     "@types/node": "^16.10.3",
     "typescript": "4.4.3",

--- a/v2/brigadier-polyfill/yarn.lock
+++ b/v2/brigadier-polyfill/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@brigadecore/brigade-sdk@^v2.0.0-beta.4":
-  version "2.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@brigadecore/brigade-sdk/-/brigade-sdk-2.0.0-beta.4.tgz#016c4195cc0db6ead2f8fbe0e764a51aa874553c"
-  integrity sha512-YzGVZYyn8Rt9ZonUopYgRDnYzaM5nbduUVxbWNXPKtoarY3w5fN2EDrlNOgPINGV8JHJRT0fPepaMYaHAFMpwQ==
+"@brigadecore/brigade-sdk@^v2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@brigadecore/brigade-sdk/-/brigade-sdk-2.0.0-rc.1.tgz#cb77c1cb6aab825290fab48c82f1a87774866c8a"
+  integrity sha512-qw21geKGdcf2rrHkJrmtOBVere52GpQMqfrBXjCMzG/AUTJGiYArLuQ2pXLI5KH1NhStYweuqvPY+cZtz0kYwQ==
   dependencies:
     axios "^0.21.0"
     event-source-polyfill "^1.0.22"

--- a/v2/cli/init_templates.go
+++ b/v2/cli/init_templates.go
@@ -10,7 +10,7 @@ import (
 // Template project.yaml file for Brigade projects
 // nolint: lll
 var projectTemplate = []byte(`# yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-beta
+apiVersion: brigade.sh/v2
 kind: Project
 metadata:
   id: {{ .ProjectID }}


### PR DESCRIPTION
In preparation for the RC.1 release, this PR transitions client and server components to using the stable API.

Note that we're not updating example yet. If we did so, no one would be able to run them until after rc.1 is released. So we'll update them later in a separate PR-- this means example validation during CI is also, temporarily, disabled.