### PR TITLE
re-enable the validate example job

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -297,8 +297,8 @@ async function runSuite(event: Event): Promise<void> {
       lintJSJob(event),
       yarnAuditJob(event),
       lintChartJob(event),
-      validateSchemasJob(event)
-      // validateExamplesJob(event)
+      validateSchemasJob(event),
+      validateExamplesJob(event)
     ),
     new ConcurrentGroup( // Build everything
       buildArtemisJob(event),


### PR DESCRIPTION
This job had temporarily been disabled at a point in time (which we are now past) where the schemas and examples didn't agree on API version.