### PR TITLE
release automation: fix windows image publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build Windows logger agent
-        run: make build-logger-windows
+        run: $env:VERSION=$env:GITHUB_REF.substring(10, $env:GITHUB_REF.length-10); make build-logger-windows
       - name: Build Windows git initializer
-        run: make build-git-initializer-windows
+        run: $env:VERSION=$env:GITHUB_REF.substring(10, $env:GITHUB_REF.length-10); make build-git-initializer-windows
       - name: Login to Dockerhub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
This PR remediates the only issue we encountered with release automation during the rc.1 release.

Correct tags were not applied to the images when they were built, so the pushes, which did use correct tags, failed.

A reminder to any reviewer... we are currently leaning on GitHub Actions only for building and publishing our very few Windows-based Docker images because it doesn't yet seem possible to build a Windows-based image inside a container (ala Docker-in-Docker) yet. So we need a Windows VM to accomplish this and that rules out doing it with Brigade itself. GitHub Actions has us covered.