### PR TITLE
s/v2/main/ and other similar changes where applicable

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -286,7 +286,7 @@ const publishBrigadierDocsJob = (event: Event) => {
 jobs[publishBrigadierDocsJobName] = publishBrigadierDocsJob
 
 // Run the entire suite of tests WITHOUT publishing anything initially. If
-// EVERYTHING passes AND this was a push (merge, presumably) to the v2 branch,
+// EVERYTHING passes AND this was a push (merge, presumably) to the main branch,
 // then run jobs to publish "edge" images.
 async function runSuite(event: Event): Promise<void> {
   await new SerialGroup(
@@ -312,7 +312,7 @@ async function runSuite(event: Event): Promise<void> {
       buildCLIJob(event)
     )
   ).run()
-  if (event.worker?.git?.ref == "v2") {
+  if (event.worker?.git?.ref == "main") {
     // Push "edge" images.
     //
     // npm packages MUST be semantically versioned, so we DON'T publish an

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -1,9 +1,9 @@
-name: Brigade v2 Merge
+name: Brigade Merge
 
 on:
   push:
     branches:
-      - v2
+      - main
 
 jobs:
   build:
@@ -11,7 +11,7 @@ jobs:
     env:
       DOCKER_ORG: brigadecore
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@main
       - name: Build Windows logger agent
         run: make build-logger-windows
       - name: Build Windows git initializer

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,9 +1,9 @@
-name: Brigade v2 PR
+name: Brigade PR
 
 on:
   pull_request:
     branches:
-      - v2
+      - main
 
 jobs:
   build:
@@ -11,7 +11,7 @@ jobs:
     env:
       DOCKER_ORG: brigadecore
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@main
       - name: Build Windows logger agent
         run: |
           make build-logger-windows

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Brigade v2 Release
+name: Brigade Release
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     env:
       DOCKER_ORG: brigadecore
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@main
       - name: Build Windows logger agent
         run: $env:VERSION=$env:GITHUB_REF.substring(10, $env:GITHUB_REF.length-10); make build-logger-windows
       - name: Build Windows git initializer

--- a/README.md
+++ b/README.md
@@ -1,42 +1,38 @@
-# Brigade 2: Event-based Scripting for Kubernetes
+# Brigade: Event-based Scripting for Kubernetes
 
-![build](https://badgr.brigade2.io/v1/github/checks/brigadecore/brigade/badge.svg?appID=99005&branch=v2)
+![build](https://badgr.brigade2.io/v1/github/checks/brigadecore/brigade/badge.svg?appID=99005&branch=main)
 [![slack](https://img.shields.io/badge/slack-brigade-brightgreen.svg?logo=slack)](https://kubernetes.slack.com/messages/C87MF1RFD)
 
 <img width="100" align="left" src="logo.png">
 
-Brigade 2 has been lovingly re-engineered from the ground up. We believe we've
-remained faithful to the original vision of Brigade 1.x, and as such, much
-general knowledge of Brigade 1.x can be carried over.
+Brigade is a full-featured, event-driven scripting platform built on top of
+Kubernetes. It integrates with many different event sources, more are always
+being added, and it's easy to create your own if you need something specific.
+And the best part -- Kubernetes is well-abstracted so even team members without
+extensive Kubernetes experience or without direct access to a cluster can be
+productive.
 
 <br clear="left"/>
 
-_But we've also learned a lot from Brigade 1.x._ Brigade 2 has been designed,
-_explicitly_ to reduce the degree of Kubernetes knowledge required for success.
-While Brigade 1.x was hailed as "event driven scripting for Kubernetes," Brigade
-2 is "event driven scripting (for Kubernetes)." Moreover, great care has been
-taken to improve security and scalability, and with our all new API and
-complementary SDKs, we're also lowering barriers to integration.
-
-We hope you'll enjoy this product refresh as much as we are.
+> ⚠️ You are viewing docs and code for Brigade 2. If you are looking for legacy
+> Brigade 1.x documentation and code, visit
+> [the v1 branch](https://github.com/brigadecore/brigade/tree/v1) 
 
 ## Getting Started
 
-While comprehensive documentation remains a work in progress, our [quickstart]
-is well-polished and we refer users wishing to test drive Brigade 2 to
-[that documentation][quickstart].
+Ready to get started? Check out our
+[QuickStart](https://docs.brigade.sh/intro/quickstart/) for comprehensive
+instructions.
 
-[quickstart]: https://v2--brigade-docs.netlify.app/intro/quickstart/
+## The Brigade Ecosystem
 
-## The Brigade 2 Ecosystem
-
-Brigade 2's all new API lowers the bar to creating all manner of peripherals--
-tooling, event gateways, and more.
+Brigade's API makes it easy to create all manner of peripherals-- tooling, event
+gateways, and more.
 
 ### Gateways
 
-Gateways receive events from upstream systems (the "outside world") and convert
-them to Brigade events that are emitted into Brigade's event bus.
+Our event gateways receive events from upstream systems (the "outside world")
+and convert them to Brigade events that are emitted into Brigade's event bus.
 
 * [ACR (Azure Container Registry) Gateway](https://github.com/brigadecore/brigade-acr-gateway)
 * [Bitbucket Gateway](https://github.com/brigadecore/brigade-bitbucket-gateway/tree/v2)
@@ -45,22 +41,16 @@ them to Brigade events that are emitted into Brigade's event bus.
 * [GitHub Gateway](https://github.com/brigadecore/brigade-github-gateway)
 * [Slack Gateway](https://github.com/brigadecore/brigade-slack-gateway)
 
-The [Brigade GitHub Gateway](https://github.com/brigadecore/brigade-github-gateway),
-in particular, is already utilized extensively by the Brigade team in
-combination with Brigade 2 to implement the project's own CI/CD. This is our
-favorite gateway at the moment because it also reports event statuses upstream
-to GitHub, making it a true showcase for what can be done with gateways.
-
 ### Monitoring
 
 [Brigade Metrics](https://github.com/brigadecore/brigade-metrics) is a great way
-to obtain operational insights into a Brigade 2 installation.
+to obtain operational insights into a Brigade installation.
 
 ### Chaos Engineering
 
 The Brigade team is utilizing
 [Brigade Noisy Neighbor](https://github.com/brigadecore/brigade-noisy-neighbor)
-to keep our own internal Brigade 2 installation under a steady load. We hope the
+to keep our own internal Brigade installation under a steady load. We hope the
 larger event volumes than what we generate on our own will help us to identify
 and resolve bugs sooner.
 
@@ -68,9 +58,8 @@ and resolve bugs sooner.
 
 Use any of these to develop your own integrations!
 
-* [Brigade SDK for Go](https://github.com/brigadecore/brigade/tree/v2/sdk) (used by Brigade itself)
+* [Brigade SDK for Go](https://github.com/brigadecore/brigade/tree/main/sdk) (used by Brigade itself)
 * [Brigade SDK for JavaScript](https://github.com/krancour/brigade-sdk-for-js) (and TypeScript)]
-* [Brigade SDK for Rust](https://github.com/brigadecore/brigade-sdk-for-rust) (still a work-in-progress)
 
 ## Contributing
 

--- a/brigade.js
+++ b/brigade.js
@@ -43,7 +43,7 @@ jobs[testIntegrationJobName] = testIntegrationJob;
 
 // Run the entire suite of tests, builds, etc. concurrently WITHOUT publishing
 // anything initially. If EVERYTHING passes AND this was a push (merge,
-// presumably) to the v2 branch, then run jobs to publish "edge" images.
+// presumably) to the main branch, then run jobs to publish "edge" images.
 function runSuite(e, p) {
   // Important: To prevent Promise.all() from failing fast, we catch and
   // return all errors. This ensures Promise.all() always resolves. We then

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -191,7 +191,7 @@ relativeURLs = "true"
 
 [[menu.main]]
     name = "Examples"
-    url = "https://github.com/brigadecore/brigade/tree/v2/examples"
+    url = "https://github.com/brigadecore/brigade/tree/main/examples"
     weight = 2
 
 [[menu.main]]

--- a/docs/content/intro/_index.md
+++ b/docs/content/intro/_index.md
@@ -10,7 +10,7 @@ aliases:
 
 # Getting Started
 
-New to Brigade or looking to quickly get up to speed with v2? Well, you came to the right place: read this material to quickly get up and running.
+New to Brigade or looking to quickly get up to speed? Well, you came to the right place: read this material to quickly get up and running.
 
 ## How the documentation is organized
 

--- a/docs/content/topics/_index.md
+++ b/docs/content/topics/_index.md
@@ -50,4 +50,4 @@ If you don't see a topic guide here and have a reasonable level of knowledge on 
 - Examples
   - [Example Projects](examples): Example Brigade projects
 
-[write]: https://github.com/brigadecore/brigade/new/v2/content/docs/topics
+[write]: https://github.com/brigadecore/brigade/new/main/content/docs/topics

--- a/docs/content/topics/administrators/authentication.md
+++ b/docs/content/topics/administrators/authentication.md
@@ -94,7 +94,7 @@ permissions for users who have already logged in for the first time must be
 done via the brig CLI directly rather than re-deploying with differing
 configuration.
 
-[values.yaml]: https://github.com/brigadecore/brigade/blob/v2/charts/brigade/values.yaml
+[values.yaml]: https://github.com/brigadecore/brigade/blob/main/charts/brigade/values.yaml
 
 ### GitHub OAuth Provider
 

--- a/docs/content/topics/design.md
+++ b/docs/content/topics/design.md
@@ -199,5 +199,4 @@ required to position the project for greater success. Most insights led back to
 a fundamental need to better abstract Brigade users from the underlying
 complexities of Kubernetes. A formal proposal for Brigade v2 was drafted by
 maintainers and ratified by the community. Over the following two years, Brigade
-was re-written from the ground up. As of this writing (early Nov 2021), a GA
-release of Brigade v2 is expected in the coming weeks.
+was re-written from the ground up. Brigade v2 was released December 1, 2021.

--- a/docs/content/topics/developers.md
+++ b/docs/content/topics/developers.md
@@ -53,14 +53,6 @@ $ git clone git@github.com:brigadecore/brigade.git
 $ git clone https://github.com/brigadecore/brigade.git
 ```
 
-**Note**: this leaves you at the tip of **master** in the repository. As of
-writing, active development on Brigade v2 is happening on the `v2` branch. To
-switch branches, run the following command:
-
-```console
-$ git checkout v2
-```
-
 After cloning the project locally, you should run this command to
 [configure the remote](https://help.github.com/articles/configuring-a-remote-for-a-fork/): 
 

--- a/docs/content/topics/examples.md
+++ b/docs/content/topics/examples.md
@@ -13,7 +13,7 @@ aliases:
 Looking for ready-to-run Brigade project examples to use and/or learn from?
 Check out the [Examples] directory at the root of the Brigade repo.
 
-[Examples]: https://github.com/brigadecore/brigade/tree/v2/examples
+[Examples]: https://github.com/brigadecore/brigade/tree/main/examples
 ## Projects
 
 Here are some of the project types you'll find inside:
@@ -29,11 +29,11 @@ Here are some of the project types you'll find inside:
   * [First Payload][first-payload]: A project with an embedded script
     demonstrating use of the payload from a handled event
 
-[first-job]: https://github.com/brigadecore/brigade/tree/v2/examples/03-first-job
-[groups]: https://github.com/brigadecore/brigade/tree/v2/examples/05-groups
-[git]: https://github.com/brigadecore/brigade/tree/v2/examples/06-git
-[shared-workspace]: https://github.com/brigadecore/brigade/tree/v2/examples/10-shared-workspace
-[first-payload]: https://github.com/brigadecore/brigade/tree/v2/examples/12-first-payload
+[first-job]: https://github.com/brigadecore/brigade/tree/main/examples/03-first-job
+[groups]: https://github.com/brigadecore/brigade/tree/main/examples/05-groups
+[git]: https://github.com/brigadecore/brigade/tree/main/examples/06-git
+[shared-workspace]: https://github.com/brigadecore/brigade/tree/main/examples/10-shared-workspace
+[first-payload]: https://github.com/brigadecore/brigade/tree/main/examples/12-first-payload
 
 ## Gateways
 
@@ -43,7 +43,7 @@ Go SDK.
 For more context and a description of this example gateway, see the [Gateways]
 doc.
 
-[gateways]: https://github.com/brigadecore/brigade/tree/v2/examples/gateways
-[example gateway]: https://github.com/brigadecore/brigade/tree/v2/examples/gateways/example-gateway
+[gateways]: https://github.com/brigadecore/brigade/tree/main/examples/gateways
+[example gateway]: https://github.com/brigadecore/brigade/tree/main/examples/gateways/example-gateway
 [Gateways]: /topics/operators/gateways
 

--- a/docs/content/topics/operators/gateways.md
+++ b/docs/content/topics/operators/gateways.md
@@ -28,13 +28,13 @@ a message queue, run as a chat bot, or watch files on a file system.
 While Brigade ships without any gateways included, installing one alongside
 Brigade is as simple as a [Helm] chart install, along with any additional setup
 particular to a given gateway. See [below](#available-gateways) for a current
-listing of v2-compatible gateways.
+listing of compatible gateways.
 
 [Helm]: https://helm.sh
 
 ## Available Gateways
 
-Currently, the list of official Brigade v2 gateways is as follows:
+Currently, the list of official Brigade gateways is as follows:
 
 * [ACR (Azure Container Registry) Gateway](https://github.com/brigadecore/brigade-acr-gateway)
 * [BitBucket Gateway](https://github.com/brigadecore/brigade-bitbucket-gateway/tree/v2)
@@ -107,8 +107,8 @@ Let's look at the high-level sections in the event definition above.  They are:
 To explore the SDK definitions of an Event object, see the [Go SDK Event] and
 [JavaScript/TypeScript SDK Event].
 
-[01-hello-world sample project]: https://github.com/brigadecore/brigade/tree/v2/examples/01-hello-world
-[Go SDK Event]: https://github.com/brigadecore/brigade/blob/v2/sdk/v2/core/events.go
+[01-hello-world sample project]: https://github.com/brigadecore/brigade/tree/main/examples/01-hello-world
+[Go SDK Event]: https://github.com/brigadecore/brigade/blob/main/sdk/v2/core/events.go
 [JavaScript/TypeScript SDK Event]: https://github.com/brigadecore/brigade-sdk-for-js/blob/main/src/core/events.ts
 
 ## Creating Custom Gateways
@@ -124,8 +124,8 @@ to pick an [SDK] to use. For this example, we'll be using the [Go SDK]. As of
 this writing, a [Javascript/Typescript SDK] and a [Rust SDK] (work in
 progress) also exist.
 
-[SDK]: https://github.com/brigadecore/brigade/tree/v2#sdks
-[Go SDK]: https://github.com/brigadecore/brigade/tree/v2/sdk
+[SDK]: https://github.com/brigadecore/brigade/tree/main#sdks
+[Go SDK]: https://github.com/brigadecore/brigade/tree/main/sdk
 [Javascript/Typescript SDK]: https://github.com/brigadecore/brigade-sdk-for-js
 [Rust SDK]: https://github.com/brigadecore/brigade-sdk-for-rust
 
@@ -428,4 +428,4 @@ SDK was helpful. All of the sample code can be found in the
 We look forward to seeing the Brigade Gateway ecosystem expand with
 contributions from readers like you!
 
-[examples/gateways]: https://github.com/brigadecore/brigade/tree/v2/examples/gateways/example-gateway
+[examples/gateways]: https://github.com/brigadecore/brigade/tree/main/examples/gateways/example-gateway

--- a/docs/content/topics/operators/security.md
+++ b/docs/content/topics/operators/security.md
@@ -40,7 +40,7 @@ enabled and SSL certificates should not be self-signed.
 
 For more details on deploying Brigade securely, see the [Deployment] doc.
 
-[Helm chart]: https://github.com/brigadecore/brigade/tree/v2/charts/brigade
+[Helm chart]: https://github.com/brigadecore/brigade/tree/main/charts/brigade
 [ingress controller]: https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/
 [Deployment]: /topics/operators/deploy
 

--- a/docs/content/topics/operators/storage.md
+++ b/docs/content/topics/operators/storage.md
@@ -66,7 +66,7 @@ worker:
 [Azure File]: https://azure.microsoft.com/en-us/services/storage/files/
 [AKS]: https://azure.microsoft.com/en-us/services/kubernetes-service/
 [Azure Disk]: https://azure.microsoft.com/en-us/services/storage/disks/
-[Helm chart values]: https://github.com/brigadecore/brigade/blob/v2/charts/brigade/values.yaml
+[Helm chart values]: https://github.com/brigadecore/brigade/blob/main/charts/brigade/values.yaml
 
 ### Enabling Worker storage
 
@@ -113,7 +113,7 @@ events.process();
 ```
 
 [project file]: /topics/project-developers/projects#project-definition-files
-[08-shared-workspace example project]: https://github.com/brigadecore/brigade/blob/v2/examples/08-shared-workspace/project.yaml
+[08-shared-workspace example project]: https://github.com/brigadecore/brigade/blob/main/examples/08-shared-workspace/project.yaml
 
 ## Artemis storage
 

--- a/docs/content/topics/project-developers/brigterm.md
+++ b/docs/content/topics/project-developers/brigterm.md
@@ -37,31 +37,31 @@ should be greeted with a project listing on the main page.
 
 Here is a sample view of the main project overview page:
 
-![Project Overview](https://v2--brigade-docs.netlify.app/img/brigterm_project_overview.png)
+![Project Overview](https://docs.brigade.sh/img/brigterm_project_overview.png)
 
 From this view, you can navigate to a given project to see its full details and
 event listing using the arrow keys. Press the `Enter` key to select the project
 you wish to view. Here we have selected the `first-job` project:
 
-![Project view](https://v2--brigade-docs.netlify.app/img/brigterm_first-job_project.png)
+![Project view](https://docs.brigade.sh/img/brigterm_first-job_project.png)
 
 To view details for a specific event, select the ID you wish to explore. Here
 we select the one event available to us:
 
-![Event view](https://v2--brigade-docs.netlify.app/img/brigterm_first-job_event.png)
+![Event view](https://docs.brigade.sh/img/brigterm_first-job_event.png)
 
 Worker logs for the event can be seen by typing the `L` key:
 
-![Worker logs](https://v2--brigade-docs.netlify.app/img/brigterm_first-job_worker_logs.png)
+![Worker logs](https://docs.brigade.sh/img/brigterm_first-job_worker_logs.png)
 
 You can also select any job to view its full details. Here we navigate to the
 details for the `my-first-job` job:
 
-![Job view](https://v2--brigade-docs.netlify.app/img/brigterm_first-job_job.png)
+![Job view](https://docs.brigade.sh/img/brigterm_first-job_job.png)
 
 Finally, job logs can be seen by typing the `L` key:
 
-![Job logs](https://v2--brigade-docs.netlify.app/img/brigterm_first-job_job_logs.png)
+![Job logs](https://docs.brigade.sh/img/brigterm_first-job_job_logs.png)
 
 We hope this visualizer proves useful for tracking activity in a Brigade
 instance. We're excited to hear about your experiences with it! 

--- a/docs/content/topics/project-developers/events.md
+++ b/docs/content/topics/project-developers/events.md
@@ -133,7 +133,7 @@ To explore the SDK definitions of an Event object, see the [Go SDK Event] and
 [JavaScript/TypeScript SDK Event].
 
 [GitHub Gateway]: https://github.com/brigadecore/brigade-github-gateway
-[Go SDK Event]: https://github.com/brigadecore/brigade/blob/v2/sdk/v2/core/events.go
+[Go SDK Event]: https://github.com/brigadecore/brigade/blob/main/sdk/v2/core/events.go
 [JavaScript/TypeScript SDK Event]: https://github.com/brigadecore/brigade-sdk-for-js/blob/main/src/core/events.ts
 
 ## Event Subscriptions
@@ -243,4 +243,4 @@ git repository. For more scripting techniques and examples, check out the
 
 [Event Structure]: #event-structure
 [Scripting Guide]: /topics/scripting/index.md
-[Example Projects]: https://github.com/brigadecore/brigade/tree/v2/examples
+[Example Projects]: https://github.com/brigadecore/brigade/tree/main/examples

--- a/docs/content/topics/releasing.md
+++ b/docs/content/topics/releasing.md
@@ -39,7 +39,7 @@ and signed off upon by another maintainer.
 ## Release
 
 When the PR containing pre-release changes have been merged and post-merge CI
-has completed without error on the `v2` branch, it is safe to cut the release
+has completed without error on the `main` branch, it is safe to cut the release
 through application of a semver tag.
 
 The _safest_ way to do this is through the GitHub UI since that helps mitigate
@@ -47,7 +47,7 @@ the possibility of accidentally tagging the wrong commit.
 
 1. Go to
 [https://github.com/brigadecore/brigade/releases/new](https://github.com/brigadecore/brigade/releases/new).
-1. Apply the desired semver tag to the head of the `v2` branch.
+1. Apply the desired semver tag to the head of the `main` branch.
 1. Use the same value as the title of the release.
 1. Click __Publish release__.
 
@@ -58,9 +58,9 @@ the semver tag. Without this tag, Go's dependency management will be unable to
 locate this release of the SDK for Go. For lack of a better alternative, this
 really needs to be done via the `git` CLI.
 
-1. Make sure your local `v2` branch is up to date with respect to the remote
+1. Make sure your local `main` branch is up to date with respect to the remote
    `github.com/brigadecore/brigade` repository.
-1. On the head of the `v2` branch, run `git tag sdk/<semver>` where `<semver>`
+1. On the head of the `main` branch, run `git tag sdk/<semver>` where `<semver>`
    is equal to the semantic version applied to this release, _including the
    leading `v`_.
 

--- a/docs/content/topics/scripting/brigadier.md
+++ b/docs/content/topics/scripting/brigadier.md
@@ -154,11 +154,11 @@ locally:
 For further example usage of brigadier, please review the [Scripting guide]
 and/or peruse the [Examples].
 
-[brigadier]: https://github.com/brigadecore/brigade/tree/v2/v2/brigadier
+[brigadier]: https://github.com/brigadecore/brigade/tree/main/v2/brigadier
 [brigadier npm]: https://www.npmjs.com/package/@brigadecore/brigadier
-[brigadier-polyfill]: https://github.com/brigadecore/brigade/tree/v2/v2/brigadier-polyfill
+[brigadier-polyfill]: https://github.com/brigadecore/brigade/tree/main/v2/brigadier-polyfill
 [Scripting guide]: /topics/scripting/guide
-[events.ts]: https://github.com/brigadecore/brigade/tree/v2/v2/brigadier/src/events.ts
+[events.ts]: https://github.com/brigadecore/brigade/tree/main/v2/brigadier/src/events.ts
 [Examples]: /topics/examples
 
 ## Brigadier API Documentation

--- a/docs/content/topics/scripting/dependencies.md
+++ b/docs/content/topics/scripting/dependencies.md
@@ -176,4 +176,4 @@ Check out the [13-dependencies] example project to see both approaches
 incorporated into one project. Feel free to create the project, create events
 for the project, etc., to get a feel for how both methods work.
 
-[13-dependencies]: https://github.com/brigadecore/brigade/tree/v2/examples/13-dependencies
+[13-dependencies]: https://github.com/brigadecore/brigade/tree/main/examples/13-dependencies

--- a/docs/content/topics/scripting/guide.md
+++ b/docs/content/topics/scripting/guide.md
@@ -46,7 +46,7 @@ Let's begin!
 [`package.json`]: /topics/scripting/dependencies
 [secrets]: /topics/project-developers/secrets
 [project definition]: /topics/project-developers/projects#project-definition-files
-[example projects]: https://github.com/brigadecore/brigade/tree/v2/examples
+[example projects]: https://github.com/brigadecore/brigade/tree/main/examples
 [brig]: /topics/project-developers/brig
 
 ## A Basic Brigade Script
@@ -57,7 +57,7 @@ log:
 ```javascript
 console.log("Hello, World!");
 ```
-[01-hello-world](https://github.com/brigadecore/brigade/tree/v2/examples/01-hello-world)
+[01-hello-world](https://github.com/brigadecore/brigade/tree/main/examples/01-hello-world)
 
 First let's create the example project:
 
@@ -114,7 +114,7 @@ events.on("brigade.sh/cli", "exec", async event => {
 
 events.process();
 ```
-[02-first-event](https://github.com/brigadecore/brigade/tree/v2/examples/02-first-event)
+[02-first-event](https://github.com/brigadecore/brigade/tree/main/examples/02-first-event)
 
 There are a few things to note about this script:
 
@@ -308,7 +308,7 @@ events.on("brigade.sh/cli", "exec", async event => {
 
 events.process();
 ```
-[03-first-job](https://github.com/brigadecore/brigade/tree/v2/examples/03-first-job)
+[03-first-job](https://github.com/brigadecore/brigade/tree/main/examples/03-first-job)
 
 A command can be anything that is supported by the job's image. In the example
 above, our command invokes the `echo` binary with the arguments supplied.
@@ -371,7 +371,7 @@ events.on("brigade.sh/cli", "exec", async event => {
 
 events.process();
 ```
-[04-simple-pipeline](https://github.com/brigadecore/brigade/tree/v2/examples/04-simple-pipeline)
+[04-simple-pipeline](https://github.com/brigadecore/brigade/tree/main/examples/04-simple-pipeline)
 
 In this example we create two jobs (`my-first-job` and `my-second-job`). Each
 starts a Debian container and prints a message, then exits. On account of the
@@ -430,7 +430,7 @@ events.on("brigade.sh/cli", "exec", async event => {
 
 events.process();
 ```
-[05-groups](https://github.com/brigadecore/brigade/tree/v2/examples/05-groups)
+[05-groups](https://github.com/brigadecore/brigade/tree/main/examples/05-groups)
 
 There are two things to notice in the example above:
 
@@ -487,10 +487,10 @@ spec:
     configFilesDirectory: examples/06-git/.brigade
     git:
       cloneURL: https://github.com/brigadecore/brigade.git
-      ref: refs/heads/v2
+      ref: refs/heads/main
 
 ```
-[06-git](https://github.com/brigadecore/brigade/tree/v2/examples/06-git)
+[06-git](https://github.com/brigadecore/brigade/tree/main/examples/06-git)
 
 Notice that there is no embedded script in this project definition. Rather, the
 project specifies where the Brigade config file directory
@@ -616,7 +616,7 @@ events.on("brigade.sh/cli", "exec", async event => {
 
 events.process();
 ```
-[07-first-payload](https://github.com/brigadecore/brigade/tree/v2/examples/07-first-payload)
+[07-first-payload](https://github.com/brigadecore/brigade/tree/main/examples/07-first-payload)
 
 When we create an event with a payload for the script above, we'll see output
 like this:
@@ -703,7 +703,7 @@ events.on("brigade.sh/cli", "exec", async event => {
 
 events.process();
 ```
-[08-shared-workspace](https://github.com/brigadecore/brigade/tree/v2/examples/08-shared-workspace)
+[08-shared-workspace](https://github.com/brigadecore/brigade/tree/main/examples/08-shared-workspace)
 
 ```console
 $ brig event create --project shared-workspace
@@ -915,4 +915,4 @@ for further reading:
 Happy Scripting!
 
 [Advanced Scripting Guide]: /topics/scripting/advanced
-[Examples]: https://github.com/brigadecore/brigade/tree/v2/examples
+[Examples]: https://github.com/brigadecore/brigade/tree/main/examples

--- a/docs/content/topics/scripting/workers.md
+++ b/docs/content/topics/scripting/workers.md
@@ -113,7 +113,7 @@ project would be the following:
     and then excute, mostly by using one of the [Brigade SDKs] to create/schedule
     jobs
 
-[Brigade SDKs]: https://github.com/brigadecore/brigade/blob/v2/README.md#sdks
+[Brigade SDKs]: https://github.com/brigadecore/brigade/blob/main/README.md#sdks
 
 # Building and Publishing a Custom Worker Image
 
@@ -162,7 +162,7 @@ worker:
 You can then use Helm's [upgrade command] to update Brigade with these new
 values.
 
-[Brigade chart]: https://github.com/brigadecore/brigade/tree/v2/charts/brigade
+[Brigade chart]: https://github.com/brigadecore/brigade/tree/main/charts/brigade
 [upgrade command]: https://helm.sh/docs/helm/helm_upgrade/
 ## Project Overrides
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,7 +1,7 @@
 # Brigade Docs
 
-* Browse the [docs on GitHub](https://github.com/brigadecore/brigade/tree/v2/docs/content)
-* Browse the [v2 staging docs website](https://v2--brigade-docs.netlify.app)
+* Browse the [docs on GitHub](https://github.com/brigadecore/brigade/tree/main/docs/content)
+* Browse the [docs website](https://docs.brigade.sh)
 
 ---
 
@@ -9,7 +9,7 @@
 
 The docs site is rendered using the [Hugo](https://gohugo.io/) static site generator, and a custom theme which borrows from the [Porter](https://github.com/getporter/porter) and [Helm](https://github.com/helm/helm-www) projects.
 
-Commits to the v2 branch are auto deployed to the staging site via Netlify.
+Commits to the main branch are auto deployed to the site via Netlify.
 
 ## Weights
 

--- a/docs/themes/techdoc-brigade/layouts/partials/header.html
+++ b/docs/themes/techdoc-brigade/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <header>
-<section class="sticky-banner">You are viewing docs for Brigade v2. Click <a href="https://docs.brigade.sh/">here for v1 docs</a>.</section>
+<section class="sticky-banner">You are viewing docs for Brigade v2. Click <a href="https://v1--brigade-docs.netlify.app/">here for v1 docs</a>.</section>
 <h1>{{ .Site.Title }}</h1>
 {{ with .Site.Params.version }}
  <span class="version">Version {{ . }}</span>

--- a/examples/06-git/project.yaml
+++ b/examples/06-git/project.yaml
@@ -14,4 +14,4 @@ spec:
     configFilesDirectory: examples/06-git/.brigade
     git:
       cloneURL: https://github.com/brigadecore/brigade.git
-      ref: refs/heads/v2
+      ref: refs/heads/main

--- a/examples/09-npm/project.yaml
+++ b/examples/09-npm/project.yaml
@@ -14,4 +14,4 @@ spec:
     configFilesDirectory: examples/09-npm/.brigade
     git:
       cloneURL: https://github.com/brigadecore/brigade.git
-      ref: refs/heads/v2
+      ref: refs/heads/main

--- a/examples/10-yarn/project.yaml
+++ b/examples/10-yarn/project.yaml
@@ -14,4 +14,4 @@ spec:
     configFilesDirectory: examples/10-yarn/.brigade
     git:
       cloneURL: https://github.com/brigadecore/brigade.git
-      ref: refs/heads/v2
+      ref: refs/heads/main

--- a/examples/12-kitchen-sink/project.yaml
+++ b/examples/12-kitchen-sink/project.yaml
@@ -14,4 +14,4 @@ spec:
     configFilesDirectory: examples/12-kitchen-sink/.brigade
     git:
       cloneURL: https://github.com/brigadecore/brigade.git
-      ref: refs/heads/v2
+      ref: refs/heads/main

--- a/examples/13-dependencies/project.yaml
+++ b/examples/13-dependencies/project.yaml
@@ -14,4 +14,4 @@ spec:
     configFilesDirectory: examples/13-dependencies/.brigade
     git:
       cloneURL: https://github.com/brigadecore/brigade.git
-      ref: refs/heads/v2
+      ref: refs/heads/main

--- a/v2/brigadier/README.md
+++ b/v2/brigadier/README.md
@@ -29,10 +29,10 @@ $ yarn add @brigadecore/brigadier
 ## Versioning
 
 The 0.x Brigadier npm releases are compatible with
-[Brigade v1.x and under](https://github.com/brigadecore/brigade/tree/master).
+[Brigade v1.x and under](https://github.com/brigadecore/brigade/tree/v1).
 
 The 2.x brigadier npm releases are compatible with
-[Brigade v2.x](https://github.com/brigadecore/brigade/tree/v2).
+[Brigade v2.x](https://github.com/brigadecore/brigade/tree/main).
 
 ## Usage
 
@@ -83,7 +83,7 @@ To learn more, visit the [official scripting guide] or explore the Brigade
 [example projects].
 
 [official scripting guide]: https://docs.brigade.sh/topics/scripting
-[example projects]: https://github.com/brigadecore/brigade/tree/v2/examples
+[example projects]: https://github.com/brigadecore/brigade/tree/main/examples
 
 ## Contributing
 


### PR DESCRIPTION
This PR straightens out links that break as a result of v2 being pushed onto the main branch (and the existing v2 branch presumably not being long for this world now).