### PR TITLE
add qualifiers and labels fields to brigadier event type

### DIFF
--- a/v2/brigadier/src/events.ts
+++ b/v2/brigadier/src/events.ts
@@ -13,6 +13,10 @@ export interface Event {
   source: string
   /** The type of event. Values and meanings are source-specific. */
   type: string
+  /** Event's type disambiguators. */
+  qualifiers?: { [key: string]: string }
+  /** Supplementary Event details. */
+  labels?: { [key: string]: string }
   /** A short title for the event, suitable for display in space-limited UI such as lists. */
   shortTitle?: string
   /** A detailed title for the event. */


### PR DESCRIPTION
When a worker is created, it receives the event as a JSON file that's mounted into the container. That JSON already includes qualifiers and labels, but they were not accessible in scripts because the `Event` type in the Brigadier library was mistakenly missing those fields.

I am correcting this because further work on the GitHub gateway has uncovered the fact that there are times that gateways can and should extract meaningful information from payloads, do some pre-processing, and apply corresponding values to qualifiers or labels. It would be helpful if scripts had access to that information.

A good example of the above is a `check_run` webhook from GitHub. It will contain the `check_run`'s name and that name will be of the form `<project id>:<job name>`. The gateway can parse that and label events with the job name so that scripts do not need to dig through the payload and parse this themselves. It makes for an easier and more consistent experience. This is but one example of the usefulness.

My intention is to cut a release of Brigade sooner rather than later, as this feature is required in order to complete work on the GitHub gateway -- which is probably our most important and most useful gateway.

@vdice I am torn on whether this should be a 2.1.0 release or a 2.0.1 release. The argument in favor of a feature release is that this certainly has the appearance of a new feature. The argument in favor of a patch release is that these fields were previously omitted quite by accident and the evidence to support that is that this information is already included in the JSON representation of events that a worker receives. If you feel strongly one way or the other, I'm happy to go along. I've added this to the 2.1.0 milestone for now, but that can change.