### PR TITLE
brigadier: allow jobs to be marked as fallible

### DIFF
--- a/v2/brigadier/src/jobs.ts
+++ b/v2/brigadier/src/jobs.ts
@@ -42,6 +42,11 @@ export class Job implements Runnable {
   /** Specifies requirements for the job execution environment. */
   public host: JobHost = new JobHost()
 
+  /** Specifies whether the job is permitted to fail WITHOUT causing the worker
+   * process to fail.
+   */
+  public fallible = false
+
   /** The event that triggered the job. */
   protected event: Event
 

--- a/v2/tests/integration_test.go
+++ b/v2/tests/integration_test.go
@@ -160,12 +160,13 @@ func assertJobPhase(
 	t *testing.T,
 	ctx context.Context, // nolint: revive
 	eventID string,
+	jobName string,
 	expectedPhase core.JobPhase,
 ) {
 	statusCh, errCh, err := client.Core().Events().Workers().Jobs().WatchStatus(
 		ctx,
 		eventID,
-		testJobName,
+		jobName,
 	)
 	require.NoError(t, err, "error encountered attempting to watch job status")
 


### PR DESCRIPTION
Fixes #1768

This sample project demonstrates a job that fails and a worker that succeeds regardless.

```
# yaml-language-server: $schema=https://schemas.brigade.sh/schemas-v2/project.json
apiVersion: brigade.sh/v2
kind: Project
metadata:
  id: experiment
description: My new Brigade project
spec:
  eventSubscriptions:
  - source: brigade.sh/cli
    types:
    - exec
  workerTemplate:
    logLevel: DEBUG
    defaultConfigFiles:
      brigade.ts: |
        import { events, Job } from "@brigadecore/brigadier"

        events.on("brigade.sh/cli", "exec", async event => {
          let job = new Job("hello", "debian:latest", event)
          job.primaryContainer.command = ["false"]
          job.fallible = true
          await job.run()
        })

        events.process()
```