### PR TITLE
bug: fix user list endpoint

### DIFF
--- a/v2/apiserver/internal/api/rest/users_endpoints.go
+++ b/v2/apiserver/internal/api/rest/users_endpoints.go
@@ -53,22 +53,19 @@ func (u *UsersEndpoints) list(w http.ResponseWriter, r *http.Request) {
 		Continue: r.URL.Query().Get("continue"),
 	}
 	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
-		limitStr := r.URL.Query().Get("limit")
-		if limitStr != "" {
-			var err error
-			if opts.Limit, err = strconv.ParseInt(limitStr, 10, 64); err != nil ||
-				opts.Limit < 1 || opts.Limit > 100 {
-				restmachinery.WriteAPIResponse(
-					w,
-					http.StatusBadRequest,
-					&meta.ErrBadRequest{
-						Reason: fmt.Sprintf(
-							`Invalid value %q for "limit" query parameter`,
-							limitStr,
-						),
-					},
-				)
-			}
+		var err error
+		if opts.Limit, err = strconv.ParseInt(limitStr, 10, 64); err != nil ||
+			opts.Limit < 1 || opts.Limit > 100 {
+			restmachinery.WriteAPIResponse(
+				w,
+				http.StatusBadRequest,
+				&meta.ErrBadRequest{
+					Reason: fmt.Sprintf(
+						`Invalid value %q for "limit" query parameter`,
+						limitStr,
+					),
+				},
+			)
 			return
 		}
 	}


### PR DESCRIPTION
`return` should have immediately followed `restmachinery.WriteAPIResponse()`. It was misplaced and was causing a return with an empty response body if the request specified a valid limit.

Removal of the redundant conditionals is incidental to the fix.