### PR TITLE
update v1 docs link in v2 docs banner

### DIFF
--- a/docs/themes/techdoc-brigade/layouts/partials/header.html
+++ b/docs/themes/techdoc-brigade/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <header>
-<section class="sticky-banner">You are viewing docs for Brigade v2. Click <a href="https://v1--brigade-docs.netlify.app/">here for v1 docs</a>.</section>
+<section class="sticky-banner">You are viewing docs for Brigade v2. Click <a href="https://v1.docs.brigade.sh/">here for v1 docs</a>.</section>
 <h1>{{ .Site.Title }}</h1>
 {{ with .Site.Params.version }}
  <span class="version">Version {{ . }}</span>


### PR DESCRIPTION
Related to #1758

https://v1.docs.brigade.sh exists now. This PR just updates the header in the v2 docs to use this new address.