### PR TITLE
ci: make yarn audit job fallible

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -124,7 +124,9 @@ jobs[lintJSJobName] = lintJSJob
 
 const yarnAuditJobName = "yarn-audit"
 const yarnAuditJob = (event: Event) => {
-  return new MakeTargetJob(yarnAuditJobName, jsImg, event)
+  const job = new MakeTargetJob(yarnAuditJobName, jsImg, event) 
+  job.fallible = true
+  return job
 }
 jobs[yarnAuditJobName] = yarnAuditJob
 


### PR DESCRIPTION
`yarn audit` failures are recently causing PRs that don't even touch any TS/JS to fail.

Those issues will be addressed, of course, but in the meantime, we don't want them creating a bottleneck, so this PR marks that job fallible in our CI pipeline.

We've already implemented this strategy on other repos and even on the `v1` branch of this repo.