### PR TITLE
pre-release version bumps

### DIFF
--- a/docs/content/intro/quickstart.md
+++ b/docs/content/intro/quickstart.md
@@ -113,7 +113,7 @@ environments:
 **Linux**
 
 ```bash
-$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.2.0/brig-linux-amd64
+$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.3.0/brig-linux-amd64
 $ chmod +x /usr/local/bin/brig
 ```
 
@@ -130,7 +130,7 @@ Alternatively, you can install manually by directly downloading a pre-built
 binary:
 
 ```bash
-$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.2.0/brig-darwin-amd64
+$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.3.0/brig-darwin-amd64
 $ chmod +x /usr/local/bin/brig
 ```
 
@@ -138,7 +138,7 @@ $ chmod +x /usr/local/bin/brig
 
 ```powershell
 > mkdir -force $env:USERPROFILE\bin
-> (New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.2.0/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
+> (New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.3.0/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
 > $env:PATH+=";$env:USERPROFILE\bin"
 ```
 
@@ -172,7 +172,7 @@ To install server-side components on your local, development-grade cluster:
     ```
     $ helm install brigade \
         oci://ghcr.io/brigadecore/brigade \
-        --version v2.2.0 \
+        --version v2.3.0 \
         --create-namespace \
         --namespace brigade \
         --wait \
@@ -322,7 +322,7 @@ Below is example output:
 Created event "2cb85062-f964-454d-ac5c-526cdbdd2679".
 
 Waiting for event's worker to be RUNNING...
-2021-08-10T16:52:01.699Z INFO: brigade-worker version: v2.2.0
+2021-08-10T16:52:01.699Z INFO: brigade-worker version: v2.3.0
 2021-08-10T16:52:01.701Z DEBUG: writing default brigade.ts to /var/vcs/.brigade/brigade.ts
 2021-08-10T16:52:01.702Z DEBUG: using npm as the package manager
 2021-08-10T16:52:01.702Z DEBUG: path /var/vcs/.brigade/node_modules/@brigadecore does not exist; creating it
@@ -382,7 +382,7 @@ using the following commands:
 $ helm uninstall brigade -n brigade
 $ helm install brigade \
     oci://ghcr.io/brigadecore/brigade \
-    --version v2.2.0 \
+    --version v2.3.0 \
     --namespace brigade \
     --wait \
     --timeout 300s

--- a/docs/content/topics/operators/deploy.md
+++ b/docs/content/topics/operators/deploy.md
@@ -74,7 +74,7 @@ cluster, view our [QuickStart](/intro/quickstart/) instead.
 
 ```console
 $ helm inspect values oci://ghcr.io/brigadecore/brigade \
-    --version v2.2.0 > ~/brigade-values.yaml
+    --version v2.3.0 > ~/brigade-values.yaml
 ```
 
 In the next steps, we'll edit `~/brigade-values.yaml` to configure a
@@ -301,7 +301,7 @@ suitable for production, we can proceed with installation:
 ```console
 $ helm install brigade \
     oci://ghcr.io/brigadecore/brigade \
-    --version v2.2.0 \
+    --version v2.3.0 \
     --create-namespace \
     --namespace brigade \
     --values ~/brigade-values.yaml \
@@ -361,7 +361,7 @@ instructions for common environments:
 **Linux**
 
 ```bash
-$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.2.0/brig-linux-amd64
+$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.3.0/brig-linux-amd64
 $ chmod +x /usr/local/bin/brig
 ```
 
@@ -378,7 +378,7 @@ Alternatively, you can install manually by directly downloading a pre-built
 binary:
 
 ```bash
-$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.2.0/brig-darwin-amd64
+$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.3.0/brig-darwin-amd64
 $ chmod +x /usr/local/bin/brig
 ```
 
@@ -386,7 +386,7 @@ $ chmod +x /usr/local/bin/brig
 
 ```powershell
 > mkdir -force $env:USERPROFILE\bin
-> (New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.2.0/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
+> (New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.3.0/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
 > $env:PATH+=";$env:USERPROFILE\bin"
 ```
 

--- a/docs/content/topics/project-developers/brig.md
+++ b/docs/content/topics/project-developers/brig.md
@@ -34,7 +34,7 @@ You can also build brig from source; see the [Developers] guide for more info.
 **linux**
 
 ```bash
-curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.2.0/brig-linux-amd64
+curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.3.0/brig-linux-amd64
 chmod +x /usr/local/bin/brig
 ```
 
@@ -51,7 +51,7 @@ Alternatively, you can install manually by directly downloading a pre-built
 binary:
 
 ```bash
-curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.2.0/brig-darwin-amd64
+curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.3.0/brig-darwin-amd64
 chmod +x /usr/local/bin/brig
 ```
 
@@ -59,7 +59,7 @@ chmod +x /usr/local/bin/brig
 
 ```powershell
 mkdir -force $env:USERPROFILE\bin
-(New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.2.0/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
+(New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.3.0/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
 $env:PATH+=";$env:USERPROFILE\bin"
 ```
 

--- a/docs/content/topics/scripting/brigadier.md
+++ b/docs/content/topics/scripting/brigadier.md
@@ -92,7 +92,7 @@ Then, create a `package.json` file with our brigadier dependency added:
 ```json
 {
   "dependencies": {
-    "@brigadecore/brigadier": "^2.2.0"
+    "@brigadecore/brigadier": "^2.3.0"
   }
 }
 ```

--- a/v2/cli/init_templates.go
+++ b/v2/cli/init_templates.go
@@ -136,7 +136,7 @@ var secretsTemplate = []byte(`## This file was created by brig init.
 var packageTemplate = []byte(`{
   "name": "{{ .ProjectID }}",
   "dependencies": {
-    "@brigadecore/brigadier": "^2.2.0"
+    "@brigadecore/brigadier": "^2.3.0"
   }
 }
 `)


### PR DESCRIPTION
There's quite a number of small but useful new features that have accumulated in the `main` branch, and I'd personally like to make use of some in the ongoing work to prototype a new v2-compatible Kashti.

I'd like to prep for the v2.3.0 release.