### PR TITLE
fix role/project-role grant/revoke bug

### DIFF
--- a/sdk/v3/principals.go
+++ b/sdk/v3/principals.go
@@ -1,15 +1,5 @@
 package sdk
 
-import (
-	"encoding/json"
-
-	"github.com/brigadecore/brigade/sdk/v3/meta"
-)
-
-// PrincipalReferenceKind represents the canonical PrincipalReference kind
-// string
-const PrincipalReferenceKind = "PrincipalReference"
-
 // PrincipalType is a type whose values can be used to disambiguate one type of
 // principal from another. For instance, when assigning a Role to a principal
 // via a RoleAssignment, a PrincipalType field is used to indicate whether the
@@ -25,22 +15,4 @@ type PrincipalReference struct {
 	// ID references a principal. The Type qualifies what type of principal that
 	// is-- for instance, a User or a ServiceAccount.
 	ID string `json:"id,omitempty"`
-}
-
-// MarshalJSON amends PrincipalReference instances with type metadata so that
-// clients do not need to be concerned with the tedium of doing so.
-func (p PrincipalReference) MarshalJSON() ([]byte, error) {
-	type Alias PrincipalReference
-	return json.Marshal(
-		struct {
-			meta.TypeMeta `json:",inline"`
-			Alias         `json:",inline"`
-		}{
-			TypeMeta: meta.TypeMeta{
-				APIVersion: meta.APIVersion,
-				Kind:       PrincipalReferenceKind,
-			},
-			Alias: (Alias)(p),
-		},
-	)
 }


### PR DESCRIPTION
This bug was introduced in #1796 and only exists in `main` and has not ever been released.

In #1796, `PrincipalReference` objects where returned as a "top level" object in an API response for the first time and to match everything else "top level" in the API, we started augmenting them with `APIVersion` and `Kind` when marshaling to JSON.

For consistency, _outbound_ `PrincipalReference` objects from the SDK got the same treatment, even though they're never used as "top level" objects on an outbound request. But the existing JSON schema used to validate inbound requests doesn't permit those fields there.

I considered updating the schema to make those fields optional for a `PrincipalReference`, but the result would be that newer clients that include this info in and outbound `PrincipalReference` would have trouble with older API servers that don't have the new schema.

The option we have to settle for is not including this information in outbound `PrincipalReference` objects, same as before #1796.