### PR TITLE
upgrade to go-tools v0.8.0 -- includes go 1.18

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -1,7 +1,7 @@
 import { events, Event, Job, ConcurrentGroup, SerialGroup, Container } from "@brigadecore/brigadier"
 
 const azImg = "mcr.microsoft.com/azure-cli"
-const goImg = "brigadecore/go-tools:v0.7.0"
+const goImg = "brigadecore/go-tools:v0.8.0"
 const jsImg = "node:16.11.0-bullseye"
 const dindImg = "docker:20.10.9-dind"
 const dockerClientImg = "brigadecore/docker-tools:v0.2.0"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty --match=NeVeRmAtC
 
 ifneq ($(SKIP_DOCKER),true)
 	PROJECT_ROOT := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-	GO_DEV_IMAGE := brigadecore/go-tools:v0.7.0
+	GO_DEV_IMAGE := brigadecore/go-tools:v0.8.0
 
 	GO_DOCKER_CMD := docker run \
 		-it \

--- a/examples/gateways/example-gateway/go.mod
+++ b/examples/gateways/example-gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/brigadecore/brigade/examples/gateways/example-gateway
 
-go 1.17
+go 1.18
 
 require github.com/brigadecore/brigade/sdk/v3 v3.0.0
 

--- a/examples/gateways/example-gateway/go.sum
+++ b/examples/gateways/example-gateway/go.sum
@@ -1,6 +1,5 @@
 github.com/brigadecore/brigade/sdk/v3 v3.0.0 h1:jCjKQuoDYK8J+P2Zpuc/IQK/GKx0M678AbD0GgxOvcM=
 github.com/brigadecore/brigade/sdk/v3 v3.0.0/go.mod h1:Ow91x3wvUtkyMsV6hwbPtVZevrcHqoH0Pjh0OID4Sh0=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
@@ -13,10 +12,6 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -6,7 +6,7 @@ run:
 linters:
   disable-all: true
   enable:
-  - bodyclose
+  # - bodyclose # Not yet working with Go 1.18
   - depguard
   # - dupl
   - errcheck
@@ -25,8 +25,8 @@ linters:
   - prealloc
   - revive
   - unconvert
-  - unparam
-  - unused
+  # - unparam # Not yet working with Go 1.18
+  # - unused # Not yet working with Go 1.18
 
 # all available settings for all linters
 linters-settings:

--- a/sdk/v3/go.mod
+++ b/sdk/v3/go.mod
@@ -1,6 +1,6 @@
 module github.com/brigadecore/brigade/sdk/v3
 
-go 1.17
+go 1.18
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.6.7

--- a/v2/apiserver/Dockerfile
+++ b/v2/apiserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.7.0 as builder
+FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.8.0 as builder
 
 ARG VERSION
 ARG COMMIT

--- a/v2/git-initializer/Dockerfile
+++ b/v2/git-initializer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.7.0 as builder
+FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.8.0 as builder
 
 ARG VERSION
 ARG COMMIT

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/brigadecore/brigade/v2
 
-go 1.17
+go 1.18
 
 replace github.com/brigadecore/brigade/sdk/v3 => ../sdk/v3
 

--- a/v2/observer/Dockerfile
+++ b/v2/observer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.7.0 as builder
+FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.8.0 as builder
 
 ARG VERSION
 ARG COMMIT

--- a/v2/scheduler/Dockerfile
+++ b/v2/scheduler/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.7.0 as builder
+FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.8.0 as builder
 
 ARG VERSION
 ARG COMMIT


### PR DESCRIPTION
This PR upgrades us to Go 1.18 across the board. Even though the SDK is build with Go 1.18, we're not using any Go 1.18-specific features because we don't want to force SDK users to upgrade to Go 1.18 yet if they're not ready.

We'll start taking advantage of generics (server side) in a follow-up to avoid this simple PR becoming unnecessarily bloated.