### PR TITLE
streamline internal amqp components

### DIFF
--- a/v2/internal/amqp/receiver.go
+++ b/v2/internal/amqp/receiver.go
@@ -18,15 +18,3 @@ type Receiver interface {
 	// Close closes the Sender and AMQP link.
 	Close(ctx context.Context) error
 }
-
-type receiver struct {
-	receiver *amqp.Receiver
-}
-
-func (r *receiver) Receive(ctx context.Context) (*amqp.Message, error) {
-	return r.receiver.Receive(ctx)
-}
-
-func (r *receiver) Close(ctx context.Context) error {
-	return r.receiver.Close(ctx)
-}

--- a/v2/internal/amqp/sender.go
+++ b/v2/internal/amqp/sender.go
@@ -17,15 +17,3 @@ type Sender interface {
 	// Close closes the Sender and AMQP link.
 	Close(ctx context.Context) error
 }
-
-type sender struct {
-	sender *amqp.Sender
-}
-
-func (s *sender) Send(ctx context.Context, msg *amqp.Message) error {
-	return s.sender.Send(ctx, msg)
-}
-
-func (s *sender) Close(ctx context.Context) error {
-	return s.sender.Close(ctx)
-}

--- a/v2/internal/amqp/session.go
+++ b/v2/internal/amqp/session.go
@@ -27,17 +27,11 @@ type session struct {
 }
 
 func (s *session) NewSender(opts ...amqp.LinkOption) (Sender, error) {
-	sndr, err := s.session.NewSender(opts...)
-	return &sender{
-		sender: sndr,
-	}, err
+	return s.session.NewSender(opts...)
 }
 
 func (s *session) NewReceiver(opts ...amqp.LinkOption) (Receiver, error) {
-	rcvr, err := s.session.NewReceiver(opts...)
-	return &receiver{
-		receiver: rcvr,
-	}, err
+	return s.session.NewReceiver(opts...)
 }
 
 func (s *session) Close(ctx context.Context) error {


### PR DESCRIPTION
In the course of investigating #1821, I noticed these internal types that do nothing but wrap something else. They can go.