### PR TITLE
fix bug in message writing abstaction

### DIFF
--- a/v2/apiserver/internal/lib/queue/amqp/writer.go
+++ b/v2/apiserver/internal/lib/queue/amqp/writer.go
@@ -63,10 +63,11 @@ func (w *writerFactory) connect() error {
 			if w.amqpClient != nil {
 				w.amqpClient.Close()
 			}
-			var err error
-			if w.amqpClient, err = myamqp.Dial(w.address, w.dialOpts...); err != nil {
+			amqpClient, err := myamqp.Dial(w.address, w.dialOpts...)
+			if err != nil {
 				return true, errors.Wrap(err, "error dialing endpoint")
 			}
+			w.amqpClient = amqpClient
 			return false, nil
 		},
 	)


### PR DESCRIPTION
I've discovered the source of a known bug while investigating #1821.

This AMQP client connect/re-connect logic is managed by `retries.ManageRetries(...)`. The retry logic works well when refreshing a stale connection, however, if there is no connection and it attempts to dial the message server for the first time, and fails, the AMQP client is no longer nil, but _also_ is not fully initialized. On the _next_ retry, the call to `w.amqpClient.Close()` will trigger a nil pointer dereference. 😦 

We've _frequently_ seen panics related to this in API server startup logs.

The reason this hasn't been a bigger problem than it has been to date is that Artemis usually comes up faster than MongoDB. The API server ends up crashing and restarting itself several times before MongoDB is up and running, and by the time it is, Artemis is usually up and running and the very first attempt to dial the messaging server succeeds without a hitch.

Once #1821 is addressed, DB unavailability won't trigger immediate API server restarts, which means, when combined with the above, that we'll _never_ get a good connection to the message server.

This PR fixes the nil pointer dereference so the retry logic for dialing the message server works as intended.