### PR TITLE
Smoother startup

### DIFF
--- a/v2/scheduler/main.go
+++ b/v2/scheduler/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"log"
+	"time"
 
+	"github.com/brigadecore/brigade-foundations/retries"
 	"github.com/brigadecore/brigade-foundations/signals"
 	"github.com/brigadecore/brigade-foundations/version"
 	"github.com/brigadecore/brigade/sdk/v3"
@@ -26,7 +29,16 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		coreClient = sdk.NewCoreClient(address, token, &opts)
+		client := sdk.NewAPIClient(address, token, &opts)
+		// No network I/O occurs when creating the API client, so we'll test it
+		// here. This will block until the underlying connection is verified or max
+		// retries are exhausted. What we're trying to prevent is both 1. moving on
+		// in the startup process without the API server available AND 2. crashing
+		// too prematurely while waiting for the API server to become available.
+		if err := testClient(ctx, client); err != nil {
+			log.Fatal(err)
+		}
+		coreClient = client.Core()
 	}
 
 	// Message receiving abstraction
@@ -56,4 +68,21 @@ func main() {
 
 	// Run it!
 	log.Println(scheduler.run(ctx))
+}
+
+func testClient(ctx context.Context, client sdk.APIClient) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	return retries.ManageRetries(
+		ctx, // The retry loop will exit when this context expires
+		"api server ping",
+		0,              // "Infinite" retries
+		10*time.Second, // Max backoff
+		func() (bool, error) {
+			if _, err := client.System().Ping(ctx, nil); err != nil {
+				return true, err // Retry
+			}
+			return false, nil // Success
+		},
+	)
 }


### PR DESCRIPTION
Fixes #1821 

On a brand new KinD cluster (image cache not primed) on my MBP, `helm install` now succeeds in about 1 minute with no services restarting in the process.

__Edit:__ This is such a significant improvement that I'm going to plan on a v2.3.1 release to put this in people's hands as soon as possible.