### PR TITLE
docs: fix several headings

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -3,38 +3,34 @@ title: Brigade Documentation
 description: Homepage of the Brigade Documentation
 ---
 
-# Brigade Documentation
-
-Everything you need to know about Brigade.  
-
-### First Steps
+## First Steps
 
 Are you new to Brigade or looking to quickly get up to speed? [This is the place to start!](intro/index)
 
-### Topic Guides
+## Topic Guides
 
 Learn about the different roles in Brigade, integration with other tools, and
 writing advanced Brigade scripts. [Dive deep into what makes Brigade, Brigade](topics/index).
 
-### Design/Architecture
+## Design/Architecture
 
 An overview of Brigade's design and architecture can be found in the [Design doc](topics/design).
 
-### Developers Guide
+## Developers Guide
 
 To start developing on the Brigade project, check out the [Developer's guide](topics/developers)
 and the [Contributing guide](https://github.com/brigadecore/community/blob/main/contributing.md).
 
-### Releasing Brigade
+## Releasing Brigade
 
 For maintainers of this project, steps on cutting a new release of Brigade can be found [here](topics/releasing).
 
-### Related Resources
+## Related Resources
 
 - [The Brigade Blog](https://blog.brigade.sh/): Read the latest posts from Brigade maintainers and contributors.
 - [Brigade's Community Repo](https://github.com/brigadecore/community): Find community resources for the Brigade project,
   including community meeting details, communication channels, contributing guides and more.
 
-### Articles and Videos
+## Articles and Videos
 
 Coming soon!

--- a/docs/content/intro/_index.md
+++ b/docs/content/intro/_index.md
@@ -8,8 +8,6 @@ aliases:
   - /intro/index/
 ---
 
-# Getting Started
-
 New to Brigade or looking to quickly get up to speed? Well, you came to the right place: read this material to quickly get up and running.
 
 ## How the documentation is organized

--- a/docs/content/intro/readnext.md
+++ b/docs/content/intro/readnext.md
@@ -8,8 +8,6 @@ aliases:
   - /intro/readnext.md
 ---
 
-# What to Read Next
-
 Now that you've read all of the introductory material, we hope you are as enthusiastic as we are about Brigade.
 
 Henceforth, the documentation will be more in-depth and contextual.  In the [Advanced Topics] sections, we'll

--- a/docs/content/topics/_index.md
+++ b/docs/content/topics/_index.md
@@ -7,8 +7,6 @@ aliases:
   - /topics/index/
 ---
 
-# Topic Guides
-
 This section of the documentation dives deep into individual parts of Brigade. We'll look at Brigade's architecture,
 explore the three main roles of interaction with Brigade, go over Brigade's scripting API and much more.
 This is probably where you’ll want to spend most of your time; if you work your way through these guides you

--- a/docs/content/topics/administrators/_index.md
+++ b/docs/content/topics/administrators/_index.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/administrators/index.md
 ---
 
-# Brigade Administrators
-
 Users who are in charge of authentication and authorization concerns within the
 Brigade system are known as Administrators.
 

--- a/docs/content/topics/administrators/authentication.md
+++ b/docs/content/topics/administrators/authentication.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/administrators/authentication.md
 ---
 
-# Brigade Authentication
-
 Brigade utilizes third-party providers for its user authentication strategy.
 We'll go over the available options and their configuration in this document.
 

--- a/docs/content/topics/administrators/authorization.md
+++ b/docs/content/topics/administrators/authorization.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/administrators/authorization.md
 ---
 
-# Brigade Authorization
-
 Authorization in Brigade consists of roles with particular scopes, which are
 granted to users and service accounts. When users interact with Brigade via
 the brig CLI or when a service account interacts with Brigade via an SDK,

--- a/docs/content/topics/contributing.md
+++ b/docs/content/topics/contributing.md
@@ -4,6 +4,5 @@ description: 'Contributing Guide'
 section: topics
 weight: 10
 ---
-# Contributing Guide
 
 See our Brigade project [Contributing Guide](https://github.com/brigadecore/community/blob/main/contributing.md).

--- a/docs/content/topics/developers.md
+++ b/docs/content/topics/developers.md
@@ -8,8 +8,6 @@ aliases:
   - /topics/developers.md
 ---
 
-# Developer Guide
-
 This document explains how to get started developing Brigade.
 
 Brigade is composed of numerous parts.  The following represent the core

--- a/docs/content/topics/examples.md
+++ b/docs/content/topics/examples.md
@@ -8,8 +8,6 @@ aliases:
   - /topics/examples.md
 ---
 
-# Brigade Examples
-
 Looking for ready-to-run Brigade project examples to use and/or learn from?
 Check out the [Examples] directory at the root of the Brigade repo.
 

--- a/docs/content/topics/operators/_index.md
+++ b/docs/content/topics/operators/_index.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/operators/index.md
 ---
 
-# Brigade Operators
-
 Users who are in charge of the operational concerns around deploying and
 managing the Brigade server and any auxiliary systems are known as
 Operators.

--- a/docs/content/topics/operators/gateways.md
+++ b/docs/content/topics/operators/gateways.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/operators/gateways.md
 ---
 
-# Brigade Gateways
-
 This guide explains how gateways work, and provides guidance for creating your
 own.
 

--- a/docs/content/topics/operators/security.md
+++ b/docs/content/topics/operators/security.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/security.md
 ---
 
-# Securing Brigade
-
 The execution of Brigade scripts involves dynamically creating (and destroying)
 a number of Kubernetes objects, including pods, secrets, and persistent volume
 claims. For that reason, it is prudent to configure security.

--- a/docs/content/topics/operators/storage.md
+++ b/docs/content/topics/operators/storage.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/storage.md
 ---
 
-# Storage in Brigade
-
 Brigade utilizes storage in the following ways:
 
   * [Shared Worker storage](#shared-worker-storage) wherein a Brigade Worker's

--- a/docs/content/topics/project-developers/_index.md
+++ b/docs/content/topics/project-developers/_index.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/project-developers/index.md
 ---
 
-# Brigade Project Developers
-
 Users who interact with Brigade at the project-level are known as Project
 Developers.
 

--- a/docs/content/topics/project-developers/brig.md
+++ b/docs/content/topics/project-developers/brig.md
@@ -1,6 +1,5 @@
 ---
-linkTitle: Using the brig CLI
-title: Brig
+title: The brig CLI
 description: Using the brig CLI
 weight: 4
 aliases:
@@ -8,8 +7,6 @@ aliases:
   - /topics/brig.md
   - /topics/project-developers/brig.md
 ---
-
-## The command line interface for interacting with Brigade
 
 The `brig` CLI provides access to the full repertoire of supported user
 interactions in Brigade, whether it's logging into Brigade with `brig login`,
@@ -22,7 +19,7 @@ of the [suite of commands] that brig provides.
 [install brig]: #install-brig
 [suite of commands]: #suite-of-commands
 
-## Install Brig
+## Install brig
 
 In general, `brig` can be installed by downloading the appropriate pre-built
 binary from our [releases page](https://github.com/brigadecore/brigade/releases)

--- a/docs/content/topics/project-developers/brigterm.md
+++ b/docs/content/topics/project-developers/brigterm.md
@@ -1,5 +1,5 @@
 ---
-title: Brigterm
+title: brig term
 description: Using Brigade's text-based visualization utility
 section: project-developers
 weight: 5
@@ -9,14 +9,12 @@ aliases:
   - /topics/project-developers/brigterm.md
 ---
 
-# Brig term
-
 Brigade offers a text-based user interface (TUI) for visualizing the activity
 in a Brigade system. This can be a convenient utility for viewing all projects
 and monitoring their events, as well as digging down into worker and job
 logs for an event.
 
-# How to use
+## How to use
 
 To start, log in to the Brigade server that you wish to explore:
 
@@ -33,7 +31,7 @@ $ brig term
 The visualizer will expand to encompass the entire terminal window and you
 should be greeted with a project listing on the main page.
 
-# Sample views
+## Sample views
 
 Here is a sample view of the main project overview page:
 

--- a/docs/content/topics/project-developers/events.md
+++ b/docs/content/topics/project-developers/events.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/project-developers/events.md
 ---
 
-# Brigade Events
-
 Events are the _lingua franca_ in Brigade: [Gateways] emit events and [Project]
 developers write logic to handle them.
 

--- a/docs/content/topics/project-developers/projects.md
+++ b/docs/content/topics/project-developers/projects.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/project-developers/projects.md
 ---
 
-# Managing Projects in Brigade
-
 In Brigade, a project is a conceptual grouping of event subscriptions paired
 with logic expressing how to handle those events.
 

--- a/docs/content/topics/project-developers/secrets.md
+++ b/docs/content/topics/project-developers/secrets.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/project-developers/secrets.md
 ---
 
-# Secret Management
-
 Brigade provides tools for storing sensitive data outside of your Brigade
 scripts, and then passing that information into the jobs that need them.
 

--- a/docs/content/topics/releasing.md
+++ b/docs/content/topics/releasing.md
@@ -9,9 +9,7 @@ aliases:
   - /topics/releasing.md
 ---
 
-# Releasing Brigade 2
-
-Releasing Brigade 2 is, generally speaking, easy, and mostly automated. Some
+Releasing Brigade is, generally speaking, easy, and mostly automated. Some
 complications are introduced in the _rare_ event that the API version supported
 by the server is changing.
 

--- a/docs/content/topics/scripting/_index.md
+++ b/docs/content/topics/scripting/_index.md
@@ -8,8 +8,6 @@ aliases:
   - /topics/scripting/index.md
 ---
 
-# Brigade Scripting
-
 By now, you've successfully [deployed] and/or [logged in] to Brigade.
 You may have also created a [project] or two and are now ready to focus on
 writing Brigade scripts for these projects. This scripting guide will go over

--- a/docs/content/topics/scripting/advanced.md
+++ b/docs/content/topics/scripting/advanced.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/scripting/advanced.md
 ---
 
-# Advanced Scripting Guide
-
 This guide provides some tips and ideas for advanced scripting. It assumes
 familiarity with [the scripting guide] and the [Brigadier API].
 

--- a/docs/content/topics/scripting/brigadier.md
+++ b/docs/content/topics/scripting/brigadier.md
@@ -1,6 +1,5 @@
 ---
-linkTitle: The Brigadier Library
-title: The Brigade scripting API
+title: The Brigadier Library
 description: Describing the public APIs typically used for writing Brigade scripts
 section: scripting
 weight: 2
@@ -9,8 +8,6 @@ aliases:
   - /topics/brigadier.md
   - /topics/scripting/brigadier.md
 ---
-
-# The Brigade scripting API
 
 This document describes the public APIs typically used for writing Brigade
 scripts in either JavaScript or TypeScript. It does not describe internal

--- a/docs/content/topics/scripting/dependencies.md
+++ b/docs/content/topics/scripting/dependencies.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/scripting/dependencies.md
 ---
 
-# Import dependencies in your Brigade script
-
 A Brigade worker is responsible for executing your Brigade script. By default,
 Brigade comes with a general purpose worker which does not have any external
 dependency that is not critical to executing event handlers in Brigade.

--- a/docs/content/topics/scripting/guide.md
+++ b/docs/content/topics/scripting/guide.md
@@ -9,13 +9,11 @@ aliases:
   - /topics/scripting/guide.md
 ---
 
-# Scripting Guide
-
 This guide explains the basics of how to create and structure Brigade scripts,
 which can be written in either JavaScript (`brigade.js`) or TypeScript
 (`brigade.ts`).
 
-# Brigade Scripts, Projects, and Repositories
+## Brigade Scripts, Projects, and Repositories
 
 At the very core, a Brigade script is simply a JavaScript (or TypeScript) file
 defined by a project, which Brigade executes in the context of a worker to

--- a/docs/content/topics/scripting/workers.md
+++ b/docs/content/topics/scripting/workers.md
@@ -9,8 +9,6 @@ aliases:
   - /topics/scripting/workers.md
 ---
 
-# What is a Brigade Worker?
-
 A worker is the Brigade component that is launched in response to an event that
 a project subscribes to. There is a one-to-one relationship between events and
 workers.
@@ -23,7 +21,7 @@ defining project/event-specific configuration or logic.
 The remainder of this page covers the general approach of creating and using
 custom workers.
 
-# Creating a Custom Worker
+## Creating a Custom Worker
 
 Although it is possible to extend the default Brigade Worker with additional
 Node.js libraries and/or custom JavaScript or TypeScript code (indeed, we've
@@ -42,7 +40,7 @@ for processing an event.
 
 [Dependencies]: /topics/scripting/dependencies
 
-## Event Data
+### Event Data
 
 Workers get the data they need to process an event via JSON mounted to its pod
 by Brigade, each time it runs. This JSON contains configuration that the worker
@@ -54,7 +52,7 @@ inapplicable to the custom behavior they implement. For instance, a field that
 conveys the expected location of the `brigade.js` file is not applicable to a
 worker that does not utilize such configuration.
 
-### Fields
+#### Fields
 
 Here's a rundown on the data present in the event JSON:
 
@@ -90,7 +88,7 @@ Here's a rundown on the data present in the event JSON:
 [long title]: /topics/project-developers/events#long-title
 [payload]: /topics/project-developers/events#payload
 
-## Exit Code
+### Exit Code
 
 Brigade determines the ultimate success or failure of an event by the return
 code from the worker.
@@ -100,7 +98,7 @@ return code 0.
 
 Worker executions that fail MUST exit with a non-zero return code.
 
-# General Worker flow
+## General Worker flow
 
 At a high level, the flow of a custom worker when handling an event for a
 project would be the following:
@@ -115,7 +113,7 @@ project would be the following:
 
 [Brigade SDKs]: https://github.com/brigadecore/brigade/blob/main/README.md#sdks
 
-# Building and Publishing a Custom Worker Image
+## Building and Publishing a Custom Worker Image
 
 When the custom worker code is ready to be used in Brigade, the next step is to
 build a Docker image from your `Dockerfile`.
@@ -136,12 +134,12 @@ Minikube, you do this by running `eval $(minikube docker-env)`.)
 Now that we have our image pushed to a usable location, we can configure Brigade
 to use this new image.
 
-# Configuring Brigade to Use Your Custom Worker Image
+## Configuring Brigade to Use Your Custom Worker Image
 
 The worker image for Brigade can be set globally as well as individually per
 project.
 
-## Global default
+### Global default
 
 To set the version globally, you should supply values for the `repository`,
 `tag` and, optionally, `pullPolicy` fields under the `worker.image` section in
@@ -164,7 +162,8 @@ values.
 
 [Brigade chart]: https://github.com/brigadecore/brigade/tree/main/charts/brigade
 [upgrade command]: https://helm.sh/docs/helm/helm_upgrade/
-## Project Overrides
+
+### Project Overrides
 
 To configure the worker image per-project, you'll supply the same repository,
 tag and pullPolicy values to the project definition under the
@@ -180,7 +179,7 @@ spec:
 
 Then, update the project via `brig project update --file project.yaml`
 
-## Using Your Custom Worker
+### Using Your Custom Worker
 
 Once you have Brigade and/or individual projects updated, your new Brigade
 workers will automatically switch to using this new image.


### PR DESCRIPTION
The main fix in this PR is that a superfluous h1 heading is removed from the top of most doc pages. Documents should have only _one_ top-level heading and Hugo automatically uses the title found in the front matter to generate an h1 heading, so in most cases, we had duplicate or near duplicate text. The stylesheet is clever about changing the stying of a _second_ h1, but it's still superfluous and afaik breaks the rules of semantic HTML.

There are other various heading-related fixes here, too, and I'll drop some comments in-line to explain wherever warranted.