### PR TITLE
Code highlighting fixes

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -32,3 +32,7 @@ relativeURLs = "true"
     name = "Github"
     url = "https://github.com/brigadecore/brigade"
     weight = 4
+
+[markup]
+  [markup.highlight]
+    style = 'pygments'

--- a/docs/content/intro/quickstart.md
+++ b/docs/content/intro/quickstart.md
@@ -59,7 +59,7 @@ environments:
 
 **Linux**
 
-```bash
+```shell
 $ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.3.1/brig-linux-amd64
 $ chmod +x /usr/local/bin/brig
 ```
@@ -69,14 +69,14 @@ $ chmod +x /usr/local/bin/brig
 The popular [Homebrew](https://brew.sh/) package manager provides the most
 convenient method of installing the Brigade CLI on a Mac:
 
-```bash
+```shell
 $ brew install brigade-cli
 ```
 
 Alternatively, you can install manually by directly downloading a pre-built
 binary:
 
-```bash
+```shell
 $ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.3.1/brig-darwin-amd64
 $ chmod +x /usr/local/bin/brig
 ```
@@ -105,7 +105,7 @@ To install server-side components on your local, development-grade cluster:
 1. Enable Helm's experimental OCI support:
 
     **POSIX**
-    ```bash
+    ```shell
     $ export HELM_EXPERIMENTAL_OCI=1
     ```
 
@@ -116,7 +116,7 @@ To install server-side components on your local, development-grade cluster:
 
 1. Run the following commands to install Brigade with default configuration:
 
-    ```
+    ```shell
     $ helm install brigade \
         oci://ghcr.io/brigadecore/brigade \
         --version v2.3.1 \
@@ -137,7 +137,7 @@ Since you are running Brigade locally, use port forwarding to make the Brigade
 API available via the local network interface:
 
 **POSIX**
-```bash
+```shell
 $ kubectl --namespace brigade port-forward service/brigade-apiserver 8443:443 &>/dev/null &
 ```
 
@@ -154,7 +154,7 @@ To authenticate to Brigade as the root user, you first need to acquire the
 auto-generated root user password:
 
 **POSIX**
-```bash
+```shell
 $ export APISERVER_ROOT_PASSWORD=$(kubectl get secret --namespace brigade brigade-apiserver --output jsonpath='{.data.root-user-password}' | base64 --decode)
 ```
 
@@ -166,7 +166,7 @@ $ export APISERVER_ROOT_PASSWORD=$(kubectl get secret --namespace brigade brigad
 Then:
 
 **POSIX**
-```bash
+```shell
 $ brig login --insecure --server https://localhost:8443 --root --password "${APISERVER_ROOT_PASSWORD}"
 ```
 
@@ -190,7 +190,7 @@ subscriptions with worker (event handler) configuration.
 1. Rather than create a project definition from scratch, we'll accelerate the
    process using the `brig init` command:
 
-    ```console
+    ```shell
     $ mkdir first-project
     $ cd first-project
     $ brig init --id first-project
@@ -239,13 +239,13 @@ subscriptions with worker (event handler) configuration.
 1. The previous command only generated a project definition from a template. We
    still need to upload this definition to Brigade to complete project creation:
 
-    ```console
+    ```shell
     $ brig project create --file .brigade/project.yaml
     ```
 
 1. To see that Brigade now knows about this project, use `brig project list`:
 
-    ```console
+    ```shell
     $ brig project list
 
     ID           	DESCRIPTION                         	AGE
@@ -257,13 +257,13 @@ subscriptions with worker (event handler) configuration.
 With our project defined, we are now ready to manually create an event and watch
 Brigade handle it:
 
-```console
+```shell
 $ brig event create --project first-project --follow
 ```
 
 Below is example output:
 
-```console
+```plain
 Created event "2cb85062-f964-454d-ac5c-526cdbdd2679".
 
 Waiting for event's worker to be RUNNING...
@@ -286,13 +286,13 @@ Waiting for event's worker to be RUNNING...
 If you want to keep your Brigade installation, run the following command to
 remove the example project created in this QuickStart:
 
-```console
+```shell
 $ brig project delete --id first-project
 ```
 
 Otherwise, you can remove _all_ resources created in this QuickStart using:
 
-```console
+```shell
 $ helm delete brigade -n brigade
 ```
 
@@ -322,7 +322,7 @@ one way to recover disk space.
 After you have freed up disk space, remove the bad installation, and then retry
 using the following commands:
 
-```console
+```shell
 $ helm uninstall brigade -n brigade
 $ helm install brigade \
     oci://ghcr.io/brigadecore/brigade \

--- a/docs/content/topics/administrators/authorization.md
+++ b/docs/content/topics/administrators/authorization.md
@@ -46,7 +46,7 @@ lock, unlock and delete users. All of these management functions exist under
 the `brig users` suite of commands. To see the full suite, issue the following
 help command:
 
-```console
+```shell
 $ brig users --help
 ```
 
@@ -61,7 +61,7 @@ Administrators may create, list, get, lock, unlock and delete service accounts.
 All of these management functions exist under the `brig service-accounts` suite
 of commands. To see the full suite, issue the following help command:
 
-```console
+```shell
 $ brig service-accounts --help
 ```
 
@@ -77,7 +77,7 @@ the project-level. All of these management functions exist under the
 `brig roles` or `brig project roles` suites of commands. To see the full
 suites, issue the following help commands:
 
-```console
+```shell
 $ brig roles --help
 $ brig project roles --help
 ```
@@ -99,7 +99,7 @@ Each role is itself a sub-command under `brig role grant` or
 `brig role revoke`. For example, to grant the `ADMIN` role to user `Mary`, the
 following command would be issued:
 
-```console
+```shell
 $ brig role grant ADMIN --user Mary
 ```
 
@@ -122,7 +122,7 @@ Each role is itself a sub-command under `brig project role grant` or
 `brig project role revoke`. For example, to grant the `PROJECT_ADMIN` role to
 user `Mary` for project `Arecibo`, the following command would be issued:
 
-```console
+```shell
 $ brig project role grant ADMIN --id Arecibo --user Mary
 ```
 

--- a/docs/content/topics/developers.md
+++ b/docs/content/topics/developers.md
@@ -43,7 +43,7 @@ The first step to begin developing on Brigade is to clone the repo locally,
 if you haven't already done so.  First navigate to your preferred work
 directory and then issue the clone command:
 
-```console
+```shell
 # Clone via ssh:
 $ git clone git@github.com:brigadecore/brigade.git
 
@@ -54,13 +54,13 @@ $ git clone https://github.com/brigadecore/brigade.git
 After cloning the project locally, you should run this command to
 [configure the remote](https://help.github.com/articles/configuring-a-remote-for-a-fork/): 
 
-```console
+```shell
 $ git remote add fork https://github.com/<your GitHub username>/brigade
 ```
 
 To push your changes to your fork, run:
 
-```console
+```shell
 $ git push --set-upstream fork <branch>
 ```
 
@@ -97,32 +97,32 @@ Windows Subsystem for Linux 2.  See more details
 
 To run lint checks:
 
-```console
+```shell
 $ make lint-go
 ```
 
 To run the unit tests:
 
-```console
+```shell
 $ make test-unit-go
 ```
 ## Working with JS Code (for the Brigade Worker)
 
 To lint the Javascript files:
 
-```console
+```shell
 $ make lint-js
 ```
 
 To run the tests:
 
-```console
+```shell
 $ make test-unit-js
 ```
 
 To clear the JS dependency cache:
 
-```console
+```shell
 $ make clean-js
 ```
 
@@ -138,33 +138,33 @@ the corresponding publishing flags added.
 
 To build all of the source, run:
 
-```console
+```shell
 $ make build
 ```
 
 To build just the Docker images, run:
 
-```console
+```shell
 $ make build-images
 ```
 
 To build images via Docker directly and preserve images in the Docker cache,
 run:
 
-```console
+```shell
 $ make hack-build-images
 ```
 
 To build all of the supported client binaries (for Mac, Linux, and Windows on
 amd64), run:
 
-```console
+```shell
 $ make build-cli
 ```
 
 To build only the client binary for your current environment, run:
 
-```console
+```shell
 $ make hack-build-cli
 ```
 
@@ -182,27 +182,27 @@ The following, for instance, will build images that can be pushed to the
 specified). Here we use the targets that utilize Docker directly, so that the
 images exist in the local cache: 
 
-```console
+```shell
 $ DOCKER_ORG=krancour make hack-build-images
 ```
 
 To build for the `krancour` org on a different registry, such as `quay.io`:
 
-```console
+```shell
 $ DOCKER_REGISTRY=quay.io DOCKER_ORG=krancour make hack-build-images
 ```
 
 Now you can push these images.  Note also that you _must_ be logged into the
 registry in question _before_ attempting this.
 
-```console
+```shell
 $ make hack-push-images
 ```
 
 Otherwise, when using the kaniko-based targets, the images will be built and
 pushed in one go.  Be sure to export the same registry/org values as above:
 
-```console
+```shell
 $ DOCKER_REGISTRY=quay.io DOCKER_ORG=krancour make push-images
 ```
 
@@ -215,7 +215,7 @@ Start Minikube with the following required addons enabled:
 
 To view all Minikube addons:
 
-```console
+```shell
 $ minikube addons list
 ```
 
@@ -224,7 +224,7 @@ Additionally, for local development, it will be efficient to enable the
 details in the [registry addon docs].  Here is an example on how to enable
 the addon and redirect port 5000 on the Docker VM over to the Minikube machine:
 
-```console
+```shell
 $ minikube addons enable registry
 $ docker run -d --rm --network=host alpine ash \
   -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
@@ -233,14 +233,14 @@ $ docker run -d --rm --network=host alpine ash \
 Now to build and push images to the local registry and deploy Brigade, simply
 run:
 
-```console
+```shell
 $ export DOCKER_REGISTRY=localhost:5000
 $ make hack
 ```
 
 During active development, the overall flow might then look like this:
 
-```console
+```shell
 $ # make code changes, commit
 $ make hack
 $ # (repeat)
@@ -251,7 +251,7 @@ For finer-grained control over installation, you may opt to create a custom
 `values.yaml` file for the chart and set various values in addition to the
 latest image tags:
 
-```console
+```shell
 $ helm inspect values charts/brigade > myvalues.yaml
 $ open myvalues.yaml    # Change all `registry:` and `tag:` fields as appropriate
 ```
@@ -259,13 +259,13 @@ $ open myvalues.yaml    # Change all `registry:` and `tag:` fields as appropriat
 From here, you can install or upgrade Brigade into Minikube using the Helm
 directly:
 
-```console
+```shell
 $ helm upgrade --install -n brigade brigade charts/brigade -f myvalues.yaml
 ```
 
 To expose the apiserver port, run the following command:
 
-```console
+```shell
 $ make hack-expose-apiserver
 ```
 
@@ -275,7 +275,7 @@ follow the steps provided in the `Notes` section after deployment.
 
 You can then log in to the apiserver with the following `brig` command:
 
-```console
+```shell
 $ brig login -s https://localhost:7000 -r -p <root user password> -k
 ```
 
@@ -295,14 +295,14 @@ script that will create a new kind cluster with a local private registry
 enabled. It also configures nfs as the local storage provisioner and maps
 `localhost:31600` to the API server port. To use this script, run:
 
-```console
+```shell
 $ make hack-new-kind-cluster
 ```
 
 Now you're ready to build and push images to the local registry and deploy
 Brigade:
 
-```console
+```shell
 $ export DOCKER_REGISTRY=localhost:5000
 $ make hack
 ```
@@ -313,7 +313,7 @@ value is hard-coded to `F00Bar!!!`.
 
 You can then log in to the apiserver with the following `brig` command:
 
-```console
+```shell
 $ brig login -s https://localhost:31600 -r -p 'F00Bar!!!' -k
 ```
 
@@ -323,7 +323,7 @@ see how it's done.
 When you're done, if you'd like to clean up the kind cluster and registry
 resources, run the following commands:
 
-```console
+```shell
 $ kind delete cluster --name brigade
 $ docker rm -f kind-registry
 ```
@@ -353,7 +353,7 @@ the following checks:
 
 To run the tests, issue the following command:
 
-```console
+```shell
 $ make test-integration
 ```
 

--- a/docs/content/topics/operators/deploy.md
+++ b/docs/content/topics/operators/deploy.md
@@ -58,7 +58,7 @@ cluster, view our [QuickStart](/intro/quickstart/) instead.
 1. Enable Helm's experimental OCI support:
 
     **POSIX**
-    ```bash
+    ```shell
     $ export HELM_EXPERIMENTAL_OCI=1
     ```
 
@@ -73,7 +73,7 @@ cluster, view our [QuickStart](/intro/quickstart/) instead.
    the remainder of this document, but if you save it to a different location,
    make the appropriate substitutions wherever you see that path.
 
-```console
+```shell
 $ helm inspect values oci://ghcr.io/brigadecore/brigade \
     --version v2.3.1 > ~/brigade-values.yaml
 ```
@@ -299,7 +299,7 @@ tune. The file itself is liberally commented with detailed instructions.
 Finally, it's time. With `~/brigade-values.yaml` updated with configuration
 suitable for production, we can proceed with installation:
 
-```console
+```shell
 $ helm install brigade \
     oci://ghcr.io/brigadecore/brigade \
     --version v2.3.1 \
@@ -322,7 +322,7 @@ server. Which of these is applicable depends on the choice you made in the
 * If you are _not_ using an ingress controller to route inbound traffic to your
   API server, use the following command to determine the API server's public IP:
 
-  ```console
+  ```shell
   $ kubectl get svc brigade-apiserver --namespace brigade \
       --output jsonpath='{.status.loadBalancer.ingress[0].ip}'
   ```
@@ -335,7 +335,7 @@ server. Which of these is applicable depends on the choice you made in the
   determination for our own cluster's
   [Nginx Ingress Controller](https://kubernetes.github.io/ingress-nginx/):
 
-  ```console
+  ```shell
   $ kubectl get svc nginx-ingress-nginx-controller --namespace nginx \
       --output jsonpath='{.status.loadBalancer.ingress[0].ip}'
   ```
@@ -359,7 +359,7 @@ instructions for common environments:
 
 **Linux**
 
-```bash
+```shell
 $ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.3.1/brig-linux-amd64
 $ chmod +x /usr/local/bin/brig
 ```
@@ -369,14 +369,14 @@ $ chmod +x /usr/local/bin/brig
 The popular [Homebrew](https://brew.sh/) package manager provides the most
 convenient method of installing the Brigade CLI on a Mac:
 
-```bash
+```shell
 $ brew install brigade-cli
 ```
 
 Alternatively, you can install manually by directly downloading a pre-built
 binary:
 
-```bash
+```shell
 $ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.3.1/brig-darwin-amd64
 $ chmod +x /usr/local/bin/brig
 ```
@@ -403,7 +403,7 @@ if you want to make the change permanent:
 Now you're ready to log in to Brigade! For the server URL value, use the DNS
 hostname configured above. In the example below, we use `brigade.example.com`:
 
-```console
+```shell
 $ brig login --server https://brigade.example.com
 ```
 

--- a/docs/content/topics/operators/gateways.md
+++ b/docs/content/topics/operators/gateways.md
@@ -171,7 +171,7 @@ Brigade when submitting an event into the system. As preparation, we'll create
 a service account for this gateway and save the generated token for use in our
 program.
 
-```console
+```shell
 $ brig service-account create \
 	--id example-gateway \
 	--description example-gateway
@@ -182,7 +182,7 @@ your only opportunity to access this value, as Brigade does not save it.
 
 Authorize this service account to create new events of a given source:
 
-```console
+```shell
 $ brig role grant EVENT_CREATOR \
     --service-account example-gateway \
     --source example.org/example-gateway
@@ -208,7 +208,7 @@ Let's create a directory where our program's `main.go` file can reside and
 perform bootstrapping for our Go program, including initializing its Go module
 and fetching the Brigade SDK dependency:
 
-```console
+```shell
 $ mkdir example-gateway
 $ cd example-gateway
 $ go mod init example-gateway
@@ -381,7 +381,7 @@ spec:
 We can save this to `project.yaml` and create it in Brigade via the following
 command:
 
-```console
+```shell
 $ brig project create --file project.yaml
 ```
 
@@ -391,7 +391,7 @@ Now that we have a project subscribing to events from this gateway, we're ready
 to run our program! We export the values required by the gateway and then run
 it:
 
-```console
+```shell
 $ export APISERVER_ADDRESS=<Brigade API server address>
 
 $ export API_TOKEN=<Brigade service account token from above>
@@ -403,7 +403,7 @@ Event created with ID 46a40cff-0689-466a-9cab-05f4bb9ef9f1
 Finally, we can inspect the logs to verify the event was processed by the
 worker successfully and that the event payload came through:
 
-```console
+```shell
 $ brig event logs --id 46a40cff-0689-466a-9cab-05f4bb9ef9f1
 
 2021-08-13T22:10:12.726Z INFO: brigade-worker version: 0d7546a

--- a/docs/content/topics/operators/storage.md
+++ b/docs/content/topics/operators/storage.md
@@ -36,7 +36,7 @@ its default configured as NFS (Network File System). Therefore, NFS will need
 to be deployed on the same Kubernetes cluster as Brigade. You can use the
 [NFS Server Provisioner][NFS] chart for this purpose:
 
-```console
+```shell
 $ helm repo add stable ttps://charts.helm.sh/stable
 $ helm install nfs stable/nfs-server-provisioner \
   --create-namespace --namespace nfs

--- a/docs/content/topics/project-developers/brig.md
+++ b/docs/content/topics/project-developers/brig.md
@@ -32,7 +32,7 @@ You can also build brig from source; see the [Developers] guide for more info.
 
 **linux**
 
-```bash
+```shell
 curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.3.1/brig-linux-amd64
 chmod +x /usr/local/bin/brig
 ```
@@ -42,24 +42,24 @@ chmod +x /usr/local/bin/brig
 The popular [Homebrew](https://brew.sh/) package manager provides the most
 convenient method of installing the Brigade CLI on a Mac:
 
-```bash
+```shell
 $ brew install brigade-cli
 ```
 
 Alternatively, you can install manually by directly downloading a pre-built
 binary:
 
-```bash
-curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.3.1/brig-darwin-amd64
-chmod +x /usr/local/bin/brig
+```shell
+$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.3.1/brig-darwin-amd64
+$ chmod +x /usr/local/bin/brig
 ```
 
 **windows**
 
 ```powershell
-mkdir -force $env:USERPROFILE\bin
-(New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.3.1/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
-$env:PATH+=";$env:USERPROFILE\bin"
+> mkdir -force $env:USERPROFILE\bin
+> (New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.3.1/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
+> $env:PATH+=";$env:USERPROFILE\bin"
 ```
 
 The script above downloads brig.exe and adds it to your PATH for the current
@@ -67,7 +67,7 @@ session. Add the following line to your [PowerShell Profile] to make the change
 permanent.
 
 ```powershell
-$env:PATH+=";$env:USERPROFILE\bin"
+> $env:PATH+=";$env:USERPROFILE\bin"
 ```
 
 [releases]: https://github.com/brigadecore/brigade/releases
@@ -91,7 +91,7 @@ include:
 Type any of these commands to get a help menu and start digging deeper into the
 full selection of functionality that each provides. For example:
 
-```console
+```plain
  $ brig event
 
 NAME:

--- a/docs/content/topics/project-developers/brigterm.md
+++ b/docs/content/topics/project-developers/brigterm.md
@@ -18,13 +18,13 @@ logs for an event.
 
 To start, log in to the Brigade server that you wish to explore:
 
-```console
+```shell
 $ brig login --server https://my-brigade-server.example.com
 ```
 
 Then, simply invoke the following:
 
-```console
+```shell
 $ brig term
 ```
 

--- a/docs/content/topics/project-developers/projects.md
+++ b/docs/content/topics/project-developers/projects.md
@@ -118,20 +118,20 @@ For example, to initialize a project named `myproject` with default settings,
 which includes TypeScript as the scripting language and no git configuration,
 run the following:
 
-```console
+```shell
 $ brig init --id myproject
 ```
 
 Or, if the alternate scripting language option of JavaScript is preferred, run:
 
-```console
+```shell
 $ brig init --id myproject --language js
 ```
 
 If the project is git-based, supply the git repository name where the Brigade
 script for this project will reside:
 
-```console
+```shell
 $ brig init --id myproject --git https://github.com/<org>/<repo>.git
 ```
 
@@ -148,7 +148,7 @@ With a project definition file in hand, you're now ready to create the project
 with brig. For purposes of demonstration, let's say the `project.yaml` file
 exists in the same directory as the command being run:
 
-```console
+```shell
 $ brig project create --file project.yaml
 ```
 
@@ -161,7 +161,7 @@ the backing database.
 
 You can update a project at any time with the following command:
 
-```console
+```shell
 $ brig project update --file project.yaml
 ```
 
@@ -169,7 +169,7 @@ $ brig project update --file project.yaml
 
 To delete a project, run:
 
-```console
+```shell
 $ brig project delete --id myproject
 ```
 
@@ -177,14 +177,14 @@ $ brig project delete --id myproject
 
 You can list all projects via:
 
-```console
+```shell
 $ brig project list
 ```
 
 You can also directly inspect your project with `brig project get`. To see the
 full project definition, add `--output [yaml|json]`:
 
-```console
+```shell
 $ brig project get --id myproject --output yaml
 ```
 
@@ -193,7 +193,7 @@ $ brig project get --id myproject --output yaml
 To manage project secrets, the `brig project secret` suite of commands can be
 used. For example, to set secrets for a project via a secrets file, run:
 
-```console
+```shell
 $ brig project secret set --file secrets.yaml
 ```
 
@@ -214,7 +214,7 @@ inspect resources under a project namespace on the substrate, to see which
 unique namespace a project is assigned, run the `brig project get` command and
 note the `kubernetes.namespace` value.  For example:
 
-```console
+```plain
 $ brig project get --id hello-world --output yaml
 
 apiVersion: brigade.sh/v2
@@ -262,7 +262,7 @@ gitSSHKey: |-
 
 The project secrets can then be updated via the usual brig command:
 
-```console
+```shell
 $ brig project secrets set --file secrets.yaml
 ```
 

--- a/docs/content/topics/project-developers/secrets.md
+++ b/docs/content/topics/project-developers/secrets.md
@@ -29,13 +29,13 @@ command:
 
  * Set a secret in-line:
 
-  ```console
+  ```shell
   $ brig project secret set --project my-project --set foo=bar
   ```
 
   * Setting a secret via a `secrets.yaml` file:
 
-  ```console
+  ```shell
   $ echo "foo: bar" >> ./secrets.yaml
   $ brig project secret set --project my-project --file ./secrets.yaml
   ```
@@ -65,7 +65,7 @@ events.process();
 
 Here is the output when this event is handled:
 
-```console
+```plain
 $ brig event create --project my-project --follow
 
 Created event "8b44098e-cd4a-416c-9d4e-b361ff300409".
@@ -185,7 +185,7 @@ dedicated to a project for use by that project's Worker/Jobs.
 As a reminder, a project's namespace can be found under `kubernetes.namespace`
 when inspecting a project via:
 
-```console
+```shell
 $ brig project get --id <project name> -o yaml
 ```
 

--- a/docs/content/topics/scripting/advanced.md
+++ b/docs/content/topics/scripting/advanced.md
@@ -56,7 +56,7 @@ returns a `Promise`, and we call that `Promise`'s `then()` method.
 
 Here's what it looks like when the script is run:
 
-```console
+```plain
 $ brig event create --project promises --payload world --follow
 
 Created event "882f832a-c156-4afc-9936-00d3b2d61083".
@@ -188,7 +188,7 @@ receive.
 
 If we run this, we'll see something like this:
 
-```console
+```plain
 $ brig event create --project await --payload world --follow
 
 Created event "69b5713f-b612-434f-9b52-9bcd57f044c5".
@@ -206,7 +206,7 @@ Note, however, we didn't configure the worker to fail when we caught the
 exception in the example above; we simply logged it. Although the `j2` job
 fails, the worker succeeds. We see this when looking at the event afterwards:
 
-```console
+```plain
 $ brig event get --id 69b5713f-b612-434f-9b52-9bcd57f044c5
 
 ID                                  	PROJECT	SOURCE        	TYPE	AGE	WORKER PHASE
@@ -290,7 +290,7 @@ events.process();
 
 If we were to look at the output of these two jobs, we'd see something like this:
 
-```console
+```plain
 $ brig event create --project jobs --payload world --follow
 
 Created event "c4906ec3-fec1-400f-8d8f-89fd6a379475".

--- a/docs/content/topics/scripting/brigadier.md
+++ b/docs/content/topics/scripting/brigadier.md
@@ -97,7 +97,7 @@ Then, create a `package.json` file with our brigadier dependency added:
 
 Next, fetch the brigadier dependency (and in turn, its dependencies):
 
-```console
+```plain
 $ npm install
 
 added 3 packages, and audited 4 packages in 1s
@@ -108,7 +108,7 @@ found 0 vulnerabilities
 Now we're ready to run our Brigade script in a development capacity, using only
 the core `brigadier` library: 
 
-```console
+```plain
 $ node brigade.js
 No dummy event file provided
 Generating a dummy event

--- a/docs/content/topics/scripting/dependencies.md
+++ b/docs/content/topics/scripting/dependencies.md
@@ -151,7 +151,7 @@ events.process();
 Here is the output when we create an event via `brig` for a project using this
 script (plus `logLevel: DEBUG`):
 
-```console
+```plain
 $ brig event create --project dependencies --follow
 
 Created event "8aa3c5dd-a685-493a-a366-a6183a9e2650".

--- a/docs/content/topics/scripting/guide.md
+++ b/docs/content/topics/scripting/guide.md
@@ -33,7 +33,7 @@ using the [brig] CLI. See the [Quickstart] if you have not already done so.
 
 Then, each example project can be created like so:
 
-```console
+```shell
 $ brig project create -f examples/<project>/project.yaml
 ```
 
@@ -59,7 +59,7 @@ console.log("Hello, World!");
 
 First let's create the example project:
 
-```console
+```plain
 $ brig project create --file examples/01-hello-world/project.yaml
 
 Created project "hello-world".
@@ -73,7 +73,7 @@ configured under the `eventSubscriptions` section of its definition file
 Next, let's trigger execution of the project script by creating an event of
 this type:
 
-```console
+```plain
 $ brig event create --project hello-world --follow
 
 Created event "261229dc-1140-4f6a-bf91-bd2a69f31721".
@@ -134,7 +134,7 @@ There are a few things to note about this script:
 Similarly to our first script, this event handler function displays a message
 to a log, producing the following output:
 
-```console
+```plain
 $ brig event create --project first-event --follow
 
 Created event "5b0bd00a-4f31-40da-ad01-0d2f62f4d70e".
@@ -235,7 +235,7 @@ the beginning, we explained that we think of Brigade scripts as "shell scripts
 for your cluster." When you execute a shell script, it is typically some glue
 code that manages calling one or more external programs in a specific way.
 
-```bash
+```shell
 #!/bin/bash
 
 ps -ef "hello" | grep chrome
@@ -270,8 +270,8 @@ state.
 
 If we run the code above, we'll get output that looks something like this:
 
-```console
-$ b event create --project first-job --follow
+```plain
+$ brig event create --project first-job --follow
 
 Created event "aa8fff14-0b8d-4903-9109-ccadc1d9d3fe".
 
@@ -323,7 +323,7 @@ associated with the project or adding it to a [custom Worker image]).
 
 Let's run the example:
 
-```console
+```plain
 $ brig event create --project first-job --follow
 
 Created event "046c09cd-76cb-49ea-b40c-d3e0e557de62".
@@ -336,7 +336,7 @@ Waiting for event's worker to be RUNNING...
 Now, to see the logs from `my-first-job`, we issue the following brig command
 utilizing the generated event ID.
 
-```console
+```plain
 $ brig event logs --id 046c09cd-76cb-49ea-b40c-d3e0e557de62 --job my-first-job
 
 My first job!
@@ -505,7 +505,7 @@ console.log("Hello, Git!");
 
 Let's run the example:
 
-```console
+```plain
 $ brig event create --project git --follow
 
 Created event "5ff386ed-060e-49fa-8292-0bade75f8840".
@@ -619,7 +619,7 @@ events.process();
 When we create an event with a payload for the script above, we'll see output
 like this:
 
-```console
+```plain
 $ brig event create --project first-payload --payload "Brigade" --follow
 
 Created event "05e31d97-945b-4727-b710-7d983d137d40".
@@ -644,7 +644,7 @@ events.process();
 
 The following output is generated:
 
-```console
+```plain
 $ brig event create --project first-payload --payload "Brigade" --follow
 
 Created event "b45720c4-115c-4c9b-b668-a872479f2210".
@@ -703,7 +703,7 @@ events.process();
 ```
 [08-shared-workspace](https://github.com/brigadecore/brigade/tree/main/examples/08-shared-workspace)
 
-```console
+```plain
 $ brig event create --project shared-workspace
 
 Created event "2eee9044-4469-49bd-a58b-aa659951a502".
@@ -800,7 +800,7 @@ events.process();
 
 Here's the output from creating an event and then looking at the job logs:
 
-```console
+```plain
 $ brig event create --project dind --follow
 
 Created event "94d0fcd5-61dc-49be-bb81-3e5784e66a4a".
@@ -824,7 +824,7 @@ docker.io/library/busybox:latest
 
 Note we could also take a look at the sidecar container logs on the job like so:
 
-```console
+```plain
 $ brig event logs --id 94d0fcd5-61dc-49be-bb81-3e5784e66a4a --job dind --container docker
 
 time="2021-09-23T19:00:11.230907700Z" level=info msg="Starting up"
@@ -874,7 +874,7 @@ events.process();
 
 Here's the output when we create an event for the script above:
 
-```console
+```plain
 $ brig event create --project dood --follow
 
 Created event "283be00c-5481-43ae-8634-bd9bd194488b".

--- a/docs/content/topics/scripting/workers.md
+++ b/docs/content/topics/scripting/workers.md
@@ -118,7 +118,7 @@ project would be the following:
 When the custom worker code is ready to be used in Brigade, the next step is to
 build a Docker image from your `Dockerfile`.
 
-```console
+```shell
 $ docker build -t myregistry/myworker:latest .
 $ docker push myregistry/myworker:latest
 ```


### PR DESCRIPTION
I recently bumped the version of Hugo that we're using on Netlify to a much newer one and all doc preview deployments since have poor contrast in the code blocks.

Digging into this, the reason is that Hugo, at some point, changed the component they use internally for source code highlighting. This PR does two things:

1. Explicitly select the code syntax highlighting style that most closely resembles what Hugo previously used (pyment).
2. Updates "code fences" in all content because `console` is not a valid/supported language in the new syntax highlighter.

No other doc PRs can be merged until this one is or else we'll be deploying with the poor contrast issue.