### PR TITLE
switch worker to alpine

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -2,7 +2,7 @@ import { events, Event, Job, ConcurrentGroup, SerialGroup, Container } from "@br
 
 const azImg = "mcr.microsoft.com/azure-cli"
 const goImg = "brigadecore/go-tools:v0.6.0"
-const jsImg = "node:16.11.0-bullseye"
+const jsImg = "node:16.14.0-bullseye"
 const dindImg = "docker:20.10.9-dind"
 const dockerClientImg = "brigadecore/docker-tools:v0.1.0"
 const helmImg = "brigadecore/helm-tools:v0.4.0"

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifneq ($(SKIP_DOCKER),true)
 		-w /workspaces/brigade \
 		$(GO_DEV_IMAGE)
 
-	JS_DEV_IMAGE := node:16.11.0-bullseye
+	JS_DEV_IMAGE := node:16.14.0-bullseye
 
 	JS_DOCKER_CMD := docker run \
 		-it \
@@ -267,14 +267,13 @@ build-git-initializer-windows:
 
 .PHONY: build-%
 build-%:
-	docker login $(DOCKER_REGISTRY) -u $(DOCKER_USERNAME) -p $${DOCKER_PASSWORD}
 	docker buildx build \
 		-f v2/$*/Dockerfile \
 		-t $(DOCKER_IMAGE_PREFIX)$*:$(IMMUTABLE_DOCKER_TAG) \
 		-t $(DOCKER_IMAGE_PREFIX)$*:$(MUTABLE_DOCKER_TAG) \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg COMMIT=$(GIT_VERSION) \
-		--platform linux/amd64,linux/arm64 \
+		--platform linux/amd64,linux/arm64v8 \
 		.
 
 .PHONY: build-cli
@@ -339,7 +338,7 @@ push-%:
 		-t $(DOCKER_IMAGE_PREFIX)$*:$(MUTABLE_DOCKER_TAG) \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg COMMIT=$(GIT_VERSION) \
-		--platform linux/amd64,linux/arm64 \
+		--platform linux/amd64,linux/arm64v8 \
 		--push \
 		.
 

--- a/v2/worker/Dockerfile
+++ b/v2/worker/Dockerfile
@@ -1,33 +1,44 @@
-FROM node:16.11.0-bullseye-slim
+FROM --platform=$BUILDPLATFORM debian:bullseye-slim
+
 ARG VERSION
-ENV WORKER_VERSION=${VERSION}
+
+WORKDIR /var/brigade-worker/brigadier
+COPY v2/brigadier/ .
+RUN bash -c 'if [[ $VERSION =~ ^v[0-9]+(\.[0-9]+)*(\-.+)?$ ]]; then \
+      sed -i s/0.0.1-placeholder/$(echo $VERSION | cut -c 2-)/ package.json ; \
+    fi \
+  '
+
+WORKDIR /var/brigade-worker/brigadier-polyfill
+COPY v2/brigadier-polyfill/ .
+RUN bash -c 'if [[ $VERSION =~ ^v[0-9]+(\.[0-9]+)*(\-.+)?$ ]]; then \
+      sed -i s/0.0.1-placeholder/$(echo $VERSION | cut -c 2-)/ package.json ; \
+    fi \
+  '
+
+WORKDIR /var/brigade-worker/worker
+COPY v2/worker/ .
+RUN bash -c 'if [[ $VERSION =~ ^v[0-9]+(\.[0-9]+)*(\-.+)?$ ]]; then \
+      sed -i s/0.0.1-placeholder/$(echo $VERSION | cut -c 2-)/ package.json ; \
+    fi \
+  '
+
+FROM $TARGETARCH/node:16.14.0-alpine3.15
 
 # Prevent update notices from appearing on npm/yarn install/run, etc.
 RUN npm config set update-notifier false \
   && yarn config set disable-self-update-check true
 
 WORKDIR /var/brigade-worker/brigadier
-COPY v2/brigadier/ .
-RUN bash -c 'if [[ $WORKER_VERSION =~ ^v[0-9]+(\.[0-9]+)*(\-.+)?$ ]]; then \
-      sed -i s/0.0.1-placeholder/$(echo $WORKER_VERSION | cut -c 2-)/ package.json ; \
-    fi ; \
-    yarn install --prod && yarn build \
-  '
+COPY --from=0 /var/brigade-worker/brigadier/ .
+RUN yarn install --prod && yarn build
 
 WORKDIR /var/brigade-worker/brigadier-polyfill
-COPY v2/brigadier-polyfill/ .
-RUN bash -c 'if [[ $WORKER_VERSION =~ ^v[0-9]+(\.[0-9]+)*(\-.+)?$ ]]; then \
-      sed -i s/0.0.1-placeholder/$(echo $WORKER_VERSION | cut -c 2-)/ package.json ; \
-    fi ; \
-    yarn install --prod && yarn build \
-  '
+COPY --from=0 /var/brigade-worker/brigadier-polyfill/ .
+RUN yarn install --prod && yarn build
 
 WORKDIR /var/brigade-worker/worker
-COPY v2/worker/ .
-RUN bash -c 'if [[ $WORKER_VERSION =~ ^v[0-9]+(\.[0-9]+)*(\-.+)?$ ]]; then \
-      sed -i s/0.0.1-placeholder/$(echo $WORKER_VERSION | cut -c 2-)/ package.json ; \
-    fi ; \
-    yarn install --prod && yarn build \
-  '
+COPY --from=0 /var/brigade-worker/worker/ .
+RUN yarn install --prod && yarn build
 
 CMD yarn -s start


### PR DESCRIPTION
Upgrades us to Node 1.16.14 everywhere we use it (for instance, running tests, linter, etc.) and specifically swaps the worker image to an alpine-based image. The alpine base image has significantly better results when scanned for known OS-level vulnerabilities.