### PR TITLE
switch from scratch base images to gcr.io/distroless/static:nonroot

### DIFF
--- a/v2/apiserver/Dockerfile
+++ b/v2/apiserver/Dockerfile
@@ -18,8 +18,7 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -ldflags "-w -X github.com/brigadecore/brigade-foundations/version.version=$VERSION -X github.com/brigadecore/brigade-foundations/version.commit=$COMMIT" \
   ./apiserver
 
-FROM scratch
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /src/bin/ /brigade/bin/
 COPY v2/apiserver/assets/ /brigade/assets/
 COPY v2/apiserver/schemas/ /brigade/schemas/

--- a/v2/git-initializer/Dockerfile
+++ b/v2/git-initializer/Dockerfile
@@ -18,7 +18,6 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -ldflags "-w -X github.com/brigadecore/brigade-foundations/version.version=$VERSION -X github.com/brigadecore/brigade-foundations/version.commit=$COMMIT" \
   ./git-initializer
 
-FROM scratch
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /src/bin/ /brigade/bin/
 ENTRYPOINT ["/brigade/bin/git-initializer"]

--- a/v2/observer/Dockerfile
+++ b/v2/observer/Dockerfile
@@ -18,7 +18,6 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -ldflags "-w -X github.com/brigadecore/brigade-foundations/version.version=$VERSION -X github.com/brigadecore/brigade-foundations/version.commit=$COMMIT" \
   ./observer
 
-FROM scratch
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /src/bin/ /brigade/bin/
 ENTRYPOINT ["/brigade/bin/observer"]

--- a/v2/scheduler/Dockerfile
+++ b/v2/scheduler/Dockerfile
@@ -18,7 +18,6 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -ldflags "-w -X github.com/brigadecore/brigade-foundations/version.version=$VERSION -X github.com/brigadecore/brigade-foundations/version.commit=$COMMIT" \
   ./scheduler
 
-FROM scratch
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /src/bin/ /brigade/bin/
 ENTRYPOINT ["/brigade/bin/scheduler"]


### PR DESCRIPTION
It's been suggested to me by @carolynvs that this may actually be more secure than using `scratch` as the base image. (Please do correct me if I'm wrong! 🙏 )