### PR TITLE
use prettier to enforce TS/JS styles

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -148,6 +148,12 @@ const testUnitJSJob = (event: Event) => {
 }
 jobs[testUnitJSJobName] = testUnitJSJob
 
+const styleCheckJSJobName = "style-check-js"
+const styleCheckJSJob = (event: Event) => {
+  return new MakeTargetJob(styleCheckJSJobName, jsImg, event)
+}
+jobs[styleCheckJSJobName] = styleCheckJSJob
+
 const lintJSJobName = "lint-js"
 const lintJSJob = (event: Event) => {
   return new MakeTargetJob(lintJSJobName, jsImg, event)
@@ -325,6 +331,7 @@ events.on("brigade.sh/github", "ci:pipeline_requested", async event => {
       testUnitGoJob(event),
       lintGoJob(event),
       testUnitJSJob(event),
+      styleCheckJSJob(event),
       lintJSJob(event),
       yarnAuditJob(event),
       lintChartJob(event),

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,20 @@ test-unit-go:
 			./... \
 	'
 
+.PHONY: style-check-js
+style-check-js:
+	$(JS_DOCKER_CMD) sh -c ' \
+		cd v2/brigadier && \
+		yarn install && \
+		yarn style:check && \
+		cd ../brigadier-polyfill && \
+		yarn install && \
+		yarn style:check && \
+		cd ../worker && \
+		yarn install && \
+		yarn style:check \
+	'
+
 .PHONY: lint-js
 lint-js:
 	$(JS_DOCKER_CMD) sh -c ' \

--- a/v2/brigadier-polyfill/.eslintrc.json
+++ b/v2/brigadier-polyfill/.eslintrc.json
@@ -1,33 +1,22 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "prettier"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 12,
-        "sourceType": "module"
-    },
-    "plugins": [
-        "@typescript-eslint"
-    ],
-    "rules": {
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "double"
-        ],
-        "semi": [
-            "error",
-            "never"
-        ]
-    }
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "linebreak-style": ["error", "unix"],
+    "quotes": ["error", "double"],
+    "semi": ["error", "never"]
+  }
 }

--- a/v2/brigadier-polyfill/.eslintrc.json
+++ b/v2/brigadier-polyfill/.eslintrc.json
@@ -5,7 +5,8 @@
     },
     "extends": [
         "eslint:recommended",
-        "plugin:@typescript-eslint/recommended"
+        "plugin:@typescript-eslint/recommended",
+        "prettier"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
@@ -16,9 +17,9 @@
         "@typescript-eslint"
     ],
     "rules": {
-        "indent": [
+        "linebreak-style": [
             "error",
-            2
+            "unix"
         ],
         "quotes": [
             "error",

--- a/v2/brigadier-polyfill/.prettierignore
+++ b/v2/brigadier-polyfill/.prettierignore
@@ -1,0 +1,5 @@
+/dist
+/node_modules
+
+*.md
+*.yaml

--- a/v2/brigadier-polyfill/.prettierrc.json
+++ b/v2/brigadier-polyfill/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "trailingComma": "none"
+}

--- a/v2/brigadier-polyfill/package.json
+++ b/v2/brigadier-polyfill/package.json
@@ -8,6 +8,8 @@
   "license": "Apache-2.0",
   "scripts": {
     "test": "mocha --require ts-node/register --recursive ./test/**/*.ts",
+    "style:check": "prettier --check .",
+    "style:fix": "prettier --write .",
     "lint": "eslint ./",
     "build": "tsc"
   },
@@ -22,7 +24,9 @@
     "@typescript-eslint/parser": "^4.33.0",
     "chai": "^4.2.0",
     "eslint": "^7.15.0",
+    "eslint-config-prettier": "^8.5.0",
     "mocha": "^9.2.0",
+    "prettier": "^2.6.0",
     "ts-node": "^10.2.1"
   },
   "dependencies": {

--- a/v2/brigadier-polyfill/src/events.ts
+++ b/v2/brigadier-polyfill/src/events.ts
@@ -1,11 +1,13 @@
-import { Event, EventRegistry as BrigadierEventRegistry } from "@brigadecore/brigadier"
+import {
+  Event,
+  EventRegistry as BrigadierEventRegistry
+} from "@brigadecore/brigadier"
 
 import { core } from "@brigadecore/brigade-sdk"
 
 import { logger } from "./logger"
 
 class EventRegistry extends BrigadierEventRegistry {
-
   public async process(): Promise<void> {
     const event: Event = require("/var/event/event.json") // eslint-disable-line @typescript-eslint/no-var-requires
 
@@ -18,7 +20,7 @@ class EventRegistry extends BrigadierEventRegistry {
       exitCode = 1
     })
 
-    process.on("exit", code => {
+    process.on("exit", (code) => {
       if (code != 0) {
         process.exit(code)
       }
@@ -32,12 +34,11 @@ class EventRegistry extends BrigadierEventRegistry {
       const eventsClient = new core.EventsClient(
         event.worker.apiAddress,
         event.worker.apiToken,
-        {allowInsecureConnections: true},
+        { allowInsecureConnections: true }
       )
-      eventsClient.updateSummary(event.id, {text: summary})
+      eventsClient.updateSummary(event.id, { text: summary })
     }
   }
-
 }
 
 export const events = new EventRegistry()

--- a/v2/brigadier-polyfill/src/index.ts
+++ b/v2/brigadier-polyfill/src/index.ts
@@ -5,7 +5,13 @@
 // Brigade API server.
 
 // Export these things directly from Brigadier
-export { Container, ConcurrentGroup, Event, JobHost, SerialGroup }  from "@brigadecore/brigadier"
+export {
+  Container,
+  ConcurrentGroup,
+  Event,
+  JobHost,
+  SerialGroup
+} from "@brigadecore/brigadier"
 
 // These are custom implementations of resources ordinarily found in Brigadier
 export { events } from "./events"

--- a/v2/brigadier-polyfill/src/jobs.ts
+++ b/v2/brigadier-polyfill/src/jobs.ts
@@ -1,4 +1,4 @@
-import { Logger } from "winston" 
+import { Logger } from "winston"
 
 import { Event, Job as BrigadierJob } from "@brigadecore/brigadier"
 
@@ -20,7 +20,7 @@ export class Job extends BrigadierJob {
       const jobsClient = new core.JobsClient(
         this.event.worker.apiAddress,
         this.event.worker.apiToken,
-        {allowInsecureConnections: true},
+        { allowInsecureConnections: true }
       )
 
       const sdkJob: core.Job = {
@@ -33,8 +33,7 @@ export class Job extends BrigadierJob {
         }
       }
       await jobsClient.create(this.event.id, sdkJob)
-    }
-    catch(e) {
+    } catch (e) {
       throw new Error(`Error creating job "${this.name}": ${e.message}`)
     }
     return this.wait()
@@ -45,7 +44,7 @@ export class Job extends BrigadierJob {
       const jobsClient = new core.JobsClient(
         this.event.worker.apiAddress,
         this.event.worker.apiToken,
-        {allowInsecureConnections: true},
+        { allowInsecureConnections: true }
       )
 
       const statusStream = jobsClient.watchStatus(this.event.id, this.name)
@@ -53,24 +52,26 @@ export class Job extends BrigadierJob {
         this.logger.debug(`Current job phase is ${status.phase}`)
         if (!this.fallible) {
           switch (status.phase) {
-          case core.JobPhase.Aborted:
-            reject(new Error(`Job "${this.name}" was aborted`))
-            break
-          case core.JobPhase.Canceled:
-            reject(new Error(`Job "${this.name}" was canceled before starting`))
-            break
-          case core.JobPhase.Failed:
-            reject(new Error(`Job "${this.name}" failed`))
-            break
-          case core.JobPhase.SchedulingFailed:
-            reject(new Error(`Job "${this.name}" scheduling failed`))
-            break
-          case core.JobPhase.Succeeded:
-            resolve()
-            break
-          case core.JobPhase.TimedOut:
-            reject(new Error(`Job "${this.name}" timed out`))
-            break
+            case core.JobPhase.Aborted:
+              reject(new Error(`Job "${this.name}" was aborted`))
+              break
+            case core.JobPhase.Canceled:
+              reject(
+                new Error(`Job "${this.name}" was canceled before starting`)
+              )
+              break
+            case core.JobPhase.Failed:
+              reject(new Error(`Job "${this.name}" failed`))
+              break
+            case core.JobPhase.SchedulingFailed:
+              reject(new Error(`Job "${this.name}" scheduling failed`))
+              break
+            case core.JobPhase.Succeeded:
+              resolve()
+              break
+            case core.JobPhase.TimedOut:
+              reject(new Error(`Job "${this.name}" timed out`))
+              break
           }
         }
       })
@@ -83,7 +84,7 @@ export class Job extends BrigadierJob {
           this.logger.warn(msg)
           resolve()
         } else {
-          reject(new Error(msg)) 
+          reject(new Error(msg))
         }
       })
       statusStream.onError((e: Error) => {
@@ -106,13 +107,13 @@ export class Job extends BrigadierJob {
       const logsClient = new core.LogsClient(
         this.event.worker.apiAddress,
         this.event.worker.apiToken,
-        {allowInsecureConnections: true},
+        { allowInsecureConnections: true }
       )
 
       const logsStream = logsClient.stream(
         this.event.id,
-        {job: this.name},
-        {follow: false},
+        { job: this.name },
+        { follow: false }
       )
       let logs = ""
       logsStream.onData((logEntry: core.LogEntry) => {
@@ -131,7 +132,11 @@ export class Job extends BrigadierJob {
         reject("log stream closed")
       })
       logsStream.onError((e: Error) => {
-        reject(new Error(`Error retrieving logs for job "${this.name}": ${e.message}`))
+        reject(
+          new Error(
+            `Error retrieving logs for job "${this.name}": ${e.message}`
+          )
+        )
       })
       logsStream.onDone(() => {
         resolve(logs)

--- a/v2/brigadier-polyfill/src/logger.ts
+++ b/v2/brigadier-polyfill/src/logger.ts
@@ -12,10 +12,12 @@ export const logger = winston.createLogger({
     winston.format.timestamp(),
     winston.format.printf((info: TransformableInfo) => {
       if (info.job) {
-        return `${info.timestamp} [job: ${info.job}] ${info.level.toUpperCase()}: ${info.message}`
+        return `${info.timestamp} [job: ${
+          info.job
+        }] ${info.level.toUpperCase()}: ${info.message}`
       }
       return `${info.timestamp} ${info.level.toUpperCase()}: ${info.message}`
     })
   ),
-  transports: [ new winston.transports.Console() ]
+  transports: [new winston.transports.Console()]
 })

--- a/v2/brigadier-polyfill/test/index.ts
+++ b/v2/brigadier-polyfill/test/index.ts
@@ -10,7 +10,7 @@ describe("brigadier", () => {
     // TODO: Figure out how to assert that an interface was exported.
     // assert.property(brigadier, "Event")
     assert.property(brigadier, "events")
-    assert.property(brigadier, "Job")    
+    assert.property(brigadier, "Job")
     assert.property(brigadier, "JobHost")
     assert.property(brigadier, "logger")
     assert.property(brigadier, "SerialGroup")

--- a/v2/brigadier-polyfill/test/jobs.ts
+++ b/v2/brigadier-polyfill/test/jobs.ts
@@ -5,7 +5,6 @@ import { Container, Event, Job, JobHost } from "../src"
 import { ImagePullPolicy } from "../../brigadier/dist/jobs"
 
 describe("jobs", () => {
-
   describe("Job", () => {
     describe("#constructor", () => {
       const event: Event = {
@@ -27,7 +26,10 @@ describe("jobs", () => {
       it("initializes fields properly", () => {
         assert.equal(job.name, "my-name")
         assert.deepEqual(job.primaryContainer, new Container("debian:latest"))
-        assert.deepEqual(job.primaryContainer.imagePullPolicy, ImagePullPolicy.IfNotPresent)
+        assert.deepEqual(
+          job.primaryContainer.imagePullPolicy,
+          ImagePullPolicy.IfNotPresent
+        )
         assert.deepEqual(job.sidecarContainers, {})
         assert.equal(job.timeoutSeconds, 60 * 15)
         assert.deepEqual(job.host, new JobHost())
@@ -35,5 +37,4 @@ describe("jobs", () => {
       })
     })
   })
-
 })

--- a/v2/brigadier-polyfill/tsconfig.json
+++ b/v2/brigadier-polyfill/tsconfig.json
@@ -1,27 +1,21 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es6",
-        "outDir": "dist",
-        "lib": [
-            "es6"
-        ],
-        "declaration": true,
-        "sourceMap": true,
-        "rootDir": "src",
-        /* Strict Type-Checking Option */
-        "strict": true,   /* enable all strict type-checking options */
-        /* Additional Checks */
-        "noUnusedLocals": true, /* Report errors on unused locals. */
-        // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-        // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
-        // "noUnusedParameters": true,  /* Report errors on unused parameters. */
-        "typeRoots": [
-            "node_modules/@types"
-        ],
-        "useUnknownInCatchVariables": false
-    },
-    "include": [
-        "src/**/*"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "dist",
+    "lib": ["es6"],
+    "declaration": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    /* Strict Type-Checking Option */
+    "strict": true /* enable all strict type-checking options */,
+    /* Additional Checks */
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+    // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+    "typeRoots": ["node_modules/@types"],
+    "useUnknownInCatchVariables": false
+  },
+  "include": ["src/**/*"]
 }

--- a/v2/brigadier-polyfill/yarn.lock
+++ b/v2/brigadier-polyfill/yarn.lock
@@ -593,6 +593,11 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+eslint-config-prettier@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
+  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -1265,6 +1270,11 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.0.tgz#12f8f504c4d8ddb76475f441337542fa799207d4"
+  integrity sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==
 
 progress@^2.0.0:
   version "2.0.3"

--- a/v2/brigadier/.eslintrc.json
+++ b/v2/brigadier/.eslintrc.json
@@ -1,33 +1,22 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "prettier"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 12,
-        "sourceType": "module"
-    },
-    "plugins": [
-        "@typescript-eslint"
-    ],
-    "rules": {
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "double"
-        ],
-        "semi": [
-            "error",
-            "never"
-        ]
-    }
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "linebreak-style": ["error", "unix"],
+    "quotes": ["error", "double"],
+    "semi": ["error", "never"]
+  }
 }

--- a/v2/brigadier/.eslintrc.json
+++ b/v2/brigadier/.eslintrc.json
@@ -5,7 +5,8 @@
     },
     "extends": [
         "eslint:recommended",
-        "plugin:@typescript-eslint/recommended"
+        "plugin:@typescript-eslint/recommended",
+        "prettier"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
@@ -16,9 +17,9 @@
         "@typescript-eslint"
     ],
     "rules": {
-        "indent": [
+        "linebreak-style": [
             "error",
-            2
+            "unix"
         ],
         "quotes": [
             "error",

--- a/v2/brigadier/.prettierignore
+++ b/v2/brigadier/.prettierignore
@@ -1,0 +1,5 @@
+/dist
+/node_modules
+
+*.md
+*.yaml

--- a/v2/brigadier/.prettierrc.json
+++ b/v2/brigadier/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "trailingComma": "none"
+}

--- a/v2/brigadier/package.json
+++ b/v2/brigadier/package.json
@@ -12,7 +12,9 @@
   },
   "scripts": {
     "test": "mocha --require ts-node/register --recursive ./test/**/*.ts",
-    "lint": "eslint src/ test/",
+    "style:check": "prettier --check .",
+    "style:fix": "prettier --write .",
+    "lint": "eslint ./",
     "build": "tsc",
     "build-docs": "rm -rf docs && mkdir -p docs && jsdoc dist/ --destination ./docs/js && typedoc src/ --out ./docs/ts",
     "publish-docs": "gh-pages --dist docs --repo https://brigadeci:${GH_TOKEN}@github.com/brigadecore/brigade.git --user 'Brigade CI <brigade-ci@brigadecore>' --message 'Publish Brigadier documentation'"
@@ -32,9 +34,11 @@
     "@typescript-eslint/parser": "^4.33.0",
     "chai": "^4.2.0",
     "eslint": "^7.32.0",
+    "eslint-config-prettier": "^8.5.0",
     "gh-pages": "3.0.0",
     "jsdoc": "^3.6.9",
     "mocha": "^9.2.0",
+    "prettier": "^2.6.0",
     "ts-node": "^10.2.1",
     "typedoc": "^0.22.11"
   },

--- a/v2/brigadier/src/events.ts
+++ b/v2/brigadier/src/events.ts
@@ -32,27 +32,31 @@ export type EventHandler = (event: Event) => void
 
 /**
  * Contains event handler registrations for a script.
- * 
+ *
  * Access the registry through the global `events` object.
  */
 export class EventRegistry {
   protected handlers: { [key: string]: EventHandler } = {}
-  
+
   /**
    * Registers a handler to be run when a particular kind of event occurs.
    * When Brigade receives a matching event, it will run the specified
    * handler.
-   * 
+   *
    * Possible event sources depend on the gateways configured in your Brigade
    * system, and possible event types depend on the gateway. See the Brigade
    * and gateway documentation for details.
-   * 
+   *
    * @param eventSource The event source (gateway) to register the handler for
    * @param eventType The event type to register the handler for
    * @param eventHandler The handler to run when an event with the given source and
    * type occurs
    */
-  public on(eventSource: string, eventType: string, eventHandler: EventHandler): this {
+  public on(
+    eventSource: string,
+    eventType: string,
+    eventHandler: EventHandler
+  ): this {
     this.handlers[`${eventSource}:${eventType}`] = eventHandler
     return this
   }
@@ -60,7 +64,9 @@ export class EventRegistry {
   public process(): void {
     let event: Event
     if (process.env.BRIGADE_EVENT_FILE) {
-      console.log(`Loading dummy event from file ${process.env.BRIGADE_EVENT_FILE}`)
+      console.log(
+        `Loading dummy event from file ${process.env.BRIGADE_EVENT_FILE}`
+      )
       event = require(process.env.BRIGADE_EVENT_FILE)
     } else {
       console.log("No dummy event file provided")
@@ -80,12 +86,16 @@ export class EventRegistry {
         }
         source = eventTokens[1]
         type = eventTokens[2]
-        console.log(`Using specified dummy event with source "${source}" and type "${type}"`)
+        console.log(
+          `Using specified dummy event with source "${source}" and type "${type}"`
+        )
       } else {
         console.log("No dummy event type provided")
         source = "brigade.sh/cli"
         type = "exec"
-        console.log(`Using default dummy event with source "${source}" and type "${type}"`)
+        console.log(
+          `Using default dummy event with source "${source}" and type "${type}"`
+        )
       }
       event = {
         id: this.newUUID(),
@@ -114,17 +124,20 @@ export class EventRegistry {
       handlerFn = this.handlers[`${event.source}:*`]
     }
     if (handlerFn) {
-      return handlerFn(event) 
+      return handlerFn(event)
     }
   }
 
   private newUUID(): string {
-    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function(c) {
-      const r = Math.random() * 16 | 0, v = c == "x" ? r : (r & 0x3 | 0x8)
-      return v.toString(16)
-    })
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
+      /[xy]/g,
+      function (c) {
+        const r = (Math.random() * 16) | 0,
+          v = c == "x" ? r : (r & 0x3) | 0x8
+        return v.toString(16)
+      }
+    )
   }
-
 }
 
 /** Contains event handler registrations for a script. */

--- a/v2/brigadier/src/groups.ts
+++ b/v2/brigadier/src/groups.ts
@@ -4,7 +4,7 @@ import { Runnable } from "./runnables"
  * The base type for Runnables composed of other Runnables.
  * Do not construct the base Group type; use Job.sequential (or SerialGroup)
  * or Job.concurrent (or ConcurrentGroup) instead.
- * 
+ *
  * @abstract
  */
 class Group {
@@ -31,7 +31,7 @@ class Group {
  * A new Runnable is started only when the previous one completes.
  * The sequence completes when the last Runnable has completed (or when any
  * Runnable fails).
- * 
+ *
  * @param runnables The work items to be run in sequence
  */
 export class SerialGroup extends Group implements Runnable {
@@ -41,7 +41,7 @@ export class SerialGroup extends Group implements Runnable {
 
   /**
    * Runs the serial group.
-   * 
+   *
    * @returns A Promise which completes when the last item in the group completes (or
    * any item fails). If all items ran successfully, the Promise resolves; if any
    * item failed (that is, its Runnable#run Promise rejected), the Promise
@@ -52,7 +52,6 @@ export class SerialGroup extends Group implements Runnable {
       await runnable.run()
     }
   }
-
 }
 
 /**
@@ -61,7 +60,7 @@ export class SerialGroup extends Group implements Runnable {
  * When run, all Runnables are started simultaneously (subject to
  * scheduling constraints).
  * The concurrent group completes when all Runnables have completed.
- * 
+ *
  * @param runnables The work items to be run in parallel
  */
 export class ConcurrentGroup extends Group implements Runnable {
@@ -71,7 +70,7 @@ export class ConcurrentGroup extends Group implements Runnable {
 
   /**
    * Runs the concurrent group.
-   * 
+   *
    * @returns A Promise which completes when all items in the group complete.
    * If all items ran successfully, the Promise resolves; if any
    * item failed (that is, its Runnable#run Promise rejected), the Promise
@@ -85,9 +84,8 @@ export class ConcurrentGroup extends Group implements Runnable {
     try {
       await Promise.all(promises)
       return Promise.resolve()
-    } catch(e) {
+    } catch (e) {
       return Promise.reject(e)
     }
   }
-
 }

--- a/v2/brigadier/src/jobs.ts
+++ b/v2/brigadier/src/jobs.ts
@@ -6,17 +6,17 @@ const defaultTimeoutSeconds: number = 60 * 15
 
 /**
  * A Brigade job.
- * 
+ *
  * Instances of Job represent containers that your Brigade script can
  * run using the Job#run method.
- * 
+ *
  * The Job#primaryContainer, initialized from the constructor image argument, determines
  * how long the job runs and whether it is considered successful. By default, the container is simply
  * executed (via its default entry point). Set the Job#primaryContainer#command
  * property to run a specific command in the container instead.
  * Other containers, specified via Job#sidecarContainers, are automatically
  * terminated a short time after the primary container completes.
- * 
+ *
  * Job also provides static methods for building up runnable
  * elements out of more basic ones. For example, to compose
  * a set of workloads into a sequence, you can use the
@@ -56,11 +56,7 @@ export class Job implements Runnable {
    * @param image The OCI image reference for the primary container
    * @param event The event that triggered the job
    */
-  constructor(
-    name: string,
-    image: string,
-    event: Event
-  ) {
+  constructor(name: string, image: string, event: Event) {
     this.name = name
     this.primaryContainer = new Container(image)
     this.event = event
@@ -68,15 +64,15 @@ export class Job implements Runnable {
 
   /**
    * Runs the job.
-   * 
+   *
    * When you run the job, Brigade runs all the containers, primary and sidecar.
    * When the primary container exits, the job ends. If sidecars are still running
    * at this point, Brigade terminates them after a short delay.
-   * 
+   *
    * NOTE: In a local test environment, this function does not run the containers,
    * but instead automatically succeeds. In the real Brigade runtime environment,
    * the containers run as described.
-   * 
+   *
    * @returns A Promise which completes when the primary container completes. If the
    * primary container succeeded (exited with code 0), the Promise resolves; if the
    * primary container failed (exited with nonzero code) or timed out, the Promise
@@ -89,14 +85,16 @@ export class Job implements Runnable {
 
   /**
    * Gets the job logs.
-   * 
+   *
    * If the job has multiple containers, this aggregates the logs from them all.
-   * 
+   *
    * NOTE: In a local test environment, this function returns a dummy log. In the
    * real Brigade runtime environment, it returns the actual container logs.
    */
   public logs(): Promise<string> {
-    console.log(`The Brigade worker would returns logs from job ${this.name} here.`)
+    console.log(
+      `The Brigade worker would returns logs from job ${this.name} here.`
+    )
     return Promise.resolve("skipped logs")
   }
 
@@ -109,20 +107,16 @@ export class Job implements Runnable {
    * property to run a specific command in the container instead.
    * Other containers, specified via Job#sidecarContainers, are automatically
    * terminated after the primary container completes.
-   * 
+   *
    * (Note: This is equivalent to `new Job(...)`. It is provided so that
    * script authors have the option of a consistent style for creating
    * and composing jobs and groups.)
-   * 
+   *
    * @param name The name of the job
    * @param image The OCI image reference for the primary container
    * @param event The event that triggered the job
    */
-  public static container(
-    name: string,
-    image: string,
-    event: Event
-  ): Job {
+  public static container(name: string, image: string, event: Event): Job {
     return new Job(name, image, event)
   }
 
@@ -132,7 +126,7 @@ export class Job implements Runnable {
    * A new Runnable is started only when the previous one completes.
    * The sequence completes when the last Runnable has completed (or when any
    * Runnable fails).
-   * 
+   *
    * @param runnables The work items to be run in sequence
    */
   public static sequence(...runnables: Runnable[]): SerialGroup {
@@ -145,7 +139,7 @@ export class Job implements Runnable {
    * When run, all Runnables are started simultaneously (subject to
    * scheduling constraints).
    * The concurrent group completes when all Runnables have completed.
-   * 
+   *
    * @param runnables The work items to be run in parallel
    */
   public static concurrent(...runnables: Runnable[]): ConcurrentGroup {
@@ -189,12 +183,12 @@ export class Container {
   /**
    * The command to run in the container. If not specified, the default entry point
    * of the container is called.
-   * 
+   *
    * Only the first element of the array is the actual command. Subsequent elements
    * are treated as arguments. For example, a command of ["echo", "hello"] is
    * equivalent to running 'echo hello'. A common convention is to use the command
    * array for subcommands and the arguments array for argument values.
-   * 
+   *
    * @example
    * job.primaryContainer.command = ["helm", "install"]
    * job.primaryContainer.arguments = ["stable/nginx", "-g"]
@@ -204,20 +198,20 @@ export class Container {
    * The arguments to pass to Container#command.  If the command includes arguments
    * already, the arguments property are appended. A common convention is to use the command
    * array for subcommands and the arguments array for argument values.
-   * 
+   *
    * @example
    * job.primaryContainer.command = ["helm", "install"]
    * job.primaryContainer.arguments = ["stable/nginx", "-g"]
-   * 
+   *
    */
   public arguments: string[] = []
   /**
    * Environment variables to set in the container. These are often derived from
    * project settings such as secrets.
-   * 
+   *
    * You can safely pass secrets via environment variables, because Brigade treats
    * all environment variables as secrets.
-   * 
+   *
    * @example
    * job.primaryContainer.env.AUTH_TOKEN = e.project.secrets.authToken  // e is event that triggered the handler
    */
@@ -226,7 +220,7 @@ export class Container {
    * The path in the container's file system where, if applicable, the
    * Brigade worker's shared workspace should be mounted. If empty (the default),
    * the Job does not have access to the shared workspace.
-   * 
+   *
    * The shared workspace must be enabled at the project configuration level
    * for containers to access it. If it is not enabled, you should leave this
    * property empty.
@@ -237,7 +231,7 @@ export class Container {
    * source code retrieved from a version control system repository should be
    * mounted. If empty (the default), Brigade will not mount any source
    * code automatically.
-   * 
+   *
    * Source code mounting must be enabled at the project configuration level
    * for containers to access it. If it is not enabled, you should leave this
    * property empty.
@@ -247,7 +241,7 @@ export class Container {
    * Whether the container should run with privileged permissions. This is
    * typically required only for "Docker in Docker" scenarios where the
    * container must run its own Docker daemon.
-   * 
+   *
    * Privileged execution may be disallowed by Brigade project configuration.
    * If so, the container will run unprivileged.
    */
@@ -257,15 +251,15 @@ export class Container {
    * file system. This is typically required only for "Docker-out-of-Docker" ("DooD")
    * scenarios where the container needs to use the host's Docker daemon.
    * This is strongly discouraged for almost all use cases.
-   * 
+   *
    * Host Docker socket access may be disallowed by Brigade project configuration.
    * If so, the container will run without such access.
-   * 
+   *
    * Note: This is being removed for the 2.0.0 release because of security
    * issues AND declining usefulness. (Many Kubernetes distros now use
    * containerd instead of Docker.) This can be put back in the future if the
    * need is proven AND if it can be done safely.
-   * 
+   *
    * For more details, see https://github.com/brigadecore/brigade/issues/1666
    */
   // public useHostDockerSocket = false

--- a/v2/brigadier/src/logger.ts
+++ b/v2/brigadier/src/logger.ts
@@ -2,15 +2,14 @@
 
 /**
  * Provides logging services for a script.
- * 
+ *
  * Access the logger through the global `logger` object.
- * 
+ *
  * NOTE: In a local test environment, the logger writes to the normal JavaScript
  * console. In the real Brigade runtime environment, a levelled logger is
  * used which responds appropriately to the configured level.
  */
 export class Logger {
-
   /**
    * Logs a message at Debug level.
    * @param message The message to log
@@ -50,7 +49,6 @@ export class Logger {
     console.error(message, ...meta)
     return this
   }
-
 }
 
 /** Provides logging for a script. */

--- a/v2/brigadier/test/events.ts
+++ b/v2/brigadier/test/events.ts
@@ -4,14 +4,16 @@ import { assert } from "chai"
 import { EventRegistry, EventHandler } from "../src/events"
 
 describe("events", () => {
-
   describe("EventRegistry", () => {
     describe("#on", () => {
       // We cannot see directly into EventRegistry's protected internal map of
       // handlers to assert it is managed correctly, but we CAN extend
       // EventRegistry and add an accessor so that we can get at handlers.
       class ER extends EventRegistry {
-        public getHandler(source: string, type: string): EventHandler | undefined {
+        public getHandler(
+          source: string,
+          type: string
+        ): EventHandler | undefined {
           return this.handlers[`${source}:${type}`]
         }
       }
@@ -25,5 +27,4 @@ describe("events", () => {
       })
     })
   })
-
 })

--- a/v2/brigadier/test/groups.ts
+++ b/v2/brigadier/test/groups.ts
@@ -6,7 +6,6 @@ import { SerialGroup, ConcurrentGroup } from "../src/groups"
 import { MockJob } from "./mocks"
 
 describe("groups", () => {
-
   describe("SerialGroup", () => {
     const event: Event = {
       id: "123456789",
@@ -60,18 +59,28 @@ describe("groups", () => {
       context("when job fails", () => {
         it("stops processing with an error", (done) => {
           const group = new SerialGroup()
-          const job0 = new MockJob("first", "debian:latest", event, () => () => {
-            // Do nothing
-          })
-          const job1 = new MockJob("second", "debian:latest", event, () => () => {
-            // Do nothing
-          })
+          const job0 = new MockJob(
+            "first",
+            "debian:latest",
+            event,
+            () => () => {
+              // Do nothing
+            }
+          )
+          const job1 = new MockJob(
+            "second",
+            "debian:latest",
+            event,
+            () => () => {
+              // Do nothing
+            }
+          )
           job1.fail = true
           const job2 = new MockJob("third", "debian:latest", event, () => {
             done("expected error on job 1")
           })
           group.add(job0, job1, job2)
-          group.run().catch(msg => {
+          group.run().catch((msg) => {
             assert.equal(msg, "Failed")
             done()
           })
@@ -138,26 +147,43 @@ describe("groups", () => {
       context("when job fails", () => {
         const group = new ConcurrentGroup()
         it("stops processing with an error", (done) => {
-          const job0 = new MockJob("first", "debian:latest", event, () => () => {
-            // Do nothing
-          })
-          const job1 = new MockJob("second", "debian:latest", event, () => () => {
-            // Do nothing
-          })
+          const job0 = new MockJob(
+            "first",
+            "debian:latest",
+            event,
+            () => () => {
+              // Do nothing
+            }
+          )
+          const job1 = new MockJob(
+            "second",
+            "debian:latest",
+            event,
+            () => () => {
+              // Do nothing
+            }
+          )
           job1.fail = true
-          const job2 = new MockJob("third", "debian:latest", event, () => () => {
-            // Do nothing
-          })
+          const job2 = new MockJob(
+            "third",
+            "debian:latest",
+            event,
+            () => () => {
+              // Do nothing
+            }
+          )
           group.add(job0, job1, job2)
-          group.run().then(() => {
-            done("expected error on job 2")
-          }).catch(msg => {
-            assert.equal(msg, "Failed")
-            done()
-          })
+          group
+            .run()
+            .then(() => {
+              done("expected error on job 2")
+            })
+            .catch((msg) => {
+              assert.equal(msg, "Failed")
+              done()
+            })
         })
       })
     })
   })
-
 })

--- a/v2/brigadier/test/index.ts
+++ b/v2/brigadier/test/index.ts
@@ -10,7 +10,7 @@ describe("brigadier", () => {
     // TODO: Figure out how to assert that an interface was exported.
     // assert.property(brigadier, "Event")
     assert.property(brigadier, "events")
-    assert.property(brigadier, "Job")    
+    assert.property(brigadier, "Job")
     assert.property(brigadier, "JobHost")
     assert.property(brigadier, "logger")
     assert.property(brigadier, "SerialGroup")

--- a/v2/brigadier/test/jobs.ts
+++ b/v2/brigadier/test/jobs.ts
@@ -5,7 +5,6 @@ import { Event } from "../src/events"
 import { Job, Container, JobHost, ImagePullPolicy } from "../src/jobs"
 
 describe("jobs", () => {
-
   describe("Job", () => {
     describe("#constructor", () => {
       const event: Event = {
@@ -27,7 +26,10 @@ describe("jobs", () => {
       it("initializes fields properly", () => {
         assert.equal(job.name, "my-name")
         assert.deepEqual(job.primaryContainer, new Container("debian:latest"))
-        assert.deepEqual(job.primaryContainer.imagePullPolicy, ImagePullPolicy.IfNotPresent)
+        assert.deepEqual(
+          job.primaryContainer.imagePullPolicy,
+          ImagePullPolicy.IfNotPresent
+        )
         assert.deepEqual(job.sidecarContainers, {})
         assert.equal(job.timeoutSeconds, 60 * 15)
         assert.deepEqual(job.host, new JobHost())
@@ -62,5 +64,4 @@ describe("jobs", () => {
       })
     })
   })
-
 })

--- a/v2/brigadier/test/mocks.ts
+++ b/v2/brigadier/test/mocks.ts
@@ -10,12 +10,7 @@ export class MockJob extends Job {
   public delay = 1 // Just enough to cause the event loop to sleep.
   public handler: () => void
 
-  constructor(
-    name: string,
-    image: string,
-    event: Event,
-    handler: () => void
-  ) {
+  constructor(name: string, image: string, event: Event, handler: () => void) {
     super(name, image, event)
     this.handler = handler
   }

--- a/v2/brigadier/tsconfig.json
+++ b/v2/brigadier/tsconfig.json
@@ -1,27 +1,21 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es6",
-        "outDir": "dist",
-        "lib": [
-            "es6"
-        ],
-        "declaration": true,
-        "sourceMap": true,
-        "rootDir": "src",
-        /* Strict Type-Checking Option */
-        "strict": true,   /* enable all strict type-checking options */
-        /* Additional Checks */
-        "noUnusedLocals": true, /* Report errors on unused locals. */
-        // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-        // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
-        // "noUnusedParameters": true,  /* Report errors on unused parameters. */
-        "typeRoots": [
-            "node_modules/@types"
-        ],
-        "useUnknownInCatchVariables": false
-    },
-    "include": [
-        "src/**/*"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "dist",
+    "lib": ["es6"],
+    "declaration": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    /* Strict Type-Checking Option */
+    "strict": true /* enable all strict type-checking options */,
+    /* Additional Checks */
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+    // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+    "typeRoots": ["node_modules/@types"],
+    "useUnknownInCatchVariables": false
+  },
+  "include": ["src/**/*"]
 }

--- a/v2/brigadier/yarn.lock
+++ b/v2/brigadier/yarn.lock
@@ -595,6 +595,11 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
+eslint-config-prettier@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
+  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -1397,6 +1402,11 @@ prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
+prettier@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.0.tgz#12f8f504c4d8ddb76475f441337542fa799207d4"
+  integrity sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==
 
 progress@^2.0.0:
   version "2.0.3"

--- a/v2/worker/.eslintrc.json
+++ b/v2/worker/.eslintrc.json
@@ -5,7 +5,8 @@
     },
     "extends": [
         "eslint:recommended",
-        "plugin:@typescript-eslint/recommended"
+        "plugin:@typescript-eslint/recommended",
+        "prettier"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
@@ -16,10 +17,6 @@
         "@typescript-eslint"
     ],
     "rules": {
-        "indent": [
-            "error",
-            2
-        ],
         "linebreak-style": [
             "error",
             "unix"

--- a/v2/worker/.eslintrc.json
+++ b/v2/worker/.eslintrc.json
@@ -1,33 +1,22 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "prettier"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 12,
-        "sourceType": "module"
-    },
-    "plugins": [
-        "@typescript-eslint"
-    ],
-    "rules": {
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "double"
-        ],
-        "semi": [
-            "error",
-            "never"
-        ]
-    }
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "linebreak-style": ["error", "unix"],
+    "quotes": ["error", "double"],
+    "semi": ["error", "never"]
+  }
 }

--- a/v2/worker/.prettierignore
+++ b/v2/worker/.prettierignore
@@ -1,0 +1,5 @@
+/dist
+/node_modules
+
+*.md
+*.yaml

--- a/v2/worker/.prettierrc.json
+++ b/v2/worker/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "trailingComma": "none"
+}

--- a/v2/worker/package.json
+++ b/v2/worker/package.json
@@ -7,6 +7,8 @@
   "author": "Brigade Core Maintainers",
   "license": "Apache-2.0",
   "scripts": {
+    "style:check": "prettier --check .",
+    "style:fix": "prettier --write .",
     "lint": "eslint ./",
     "build": "tsc",
     "start": "node --no-deprecation ./dist/prestart.js"
@@ -22,7 +24,9 @@
     "@typescript-eslint/parser": "^4.33.0",
     "chai": "^4.2.0",
     "eslint": "^7.15.0",
+    "eslint-config-prettier": "^8.5.0",
     "mocha": "^9.2.0",
+    "prettier": "^2.6.0",
     "ts-node": "^10.2.1"
   },
   "dependencies": {

--- a/v2/worker/src/prestart.ts
+++ b/v2/worker/src/prestart.ts
@@ -28,7 +28,9 @@ if (event.worker.defaultConfigFiles) {
   for (const filename in event.worker.defaultConfigFiles) {
     const fullFilePath = path.join(configFilesPath, filename)
     if (fs.existsSync(fullFilePath)) {
-      logger.warn(`${fullFilePath} already exists; refusing to overwrite it with default ${filename}`)
+      logger.warn(
+        `${fullFilePath} already exists; refusing to overwrite it with default ${filename}`
+      )
     } else {
       logger.debug(`writing default ${filename} to ${fullFilePath}`)
       fs.writeFileSync(fullFilePath, event.worker.defaultConfigFiles[filename])
@@ -82,7 +84,11 @@ if (packageJSON && packageJSON.dependencies) {
 }
 
 // Add/replace @brigadecore/brigadier with the worker's brigadier polyfill
-const moduleNamespacePath = path.join(configFilesPath, "node_modules", moduleNamespace)
+const moduleNamespacePath = path.join(
+  configFilesPath,
+  "node_modules",
+  moduleNamespace
+)
 if (!fs.existsSync(moduleNamespacePath)) {
   logger.debug(`path ${moduleNamespacePath} does not exist; creating it`)
   fs.mkdirSync(moduleNamespacePath, { recursive: true })
@@ -93,7 +99,9 @@ if (fs.existsSync(modulePath)) {
   fs.rmSync(modulePath, { recursive: true, force: true })
 }
 const modulePolyfillPath = "/var/brigade-worker/brigadier-polyfill"
-logger.debug(`polyfilling ${moduleNamespace}/${moduleName} with ${modulePolyfillPath}`)
+logger.debug(
+  `polyfilling ${moduleNamespace}/${moduleName} with ${modulePolyfillPath}`
+)
 fs.symlinkSync(modulePolyfillPath, modulePath)
 
 // Build, if applicable
@@ -126,7 +134,7 @@ function yarnInstall(): void {
   logger.debug("installing dependencies using yarn")
   try {
     execFileSync(nodePath, [yarnPath, "install", "--prod"], prepExecOpts)
-  } catch(e) {
+  } catch (e) {
     throw new Error(`error executing yarn install:\n\n${e.output}`)
   }
 }
@@ -135,7 +143,7 @@ function npmInstall(): void {
   logger.debug("installing dependencies using npm")
   try {
     execFileSync(nodePath, [npmPath, "install", "--prod"], prepExecOpts)
-  } catch(e) {
+  } catch (e) {
     throw new Error(`error executing npm install:\n\n${e.output}`)
   }
 }
@@ -144,34 +152,50 @@ function yarnBuild(): void {
   logger.debug("running build script with yarn")
   try {
     execFileSync(nodePath, [yarnPath, "build"], prepExecOpts)
-  } catch(e) {
+  } catch (e) {
     throw new Error(`error executing yarn build:\n\n${e.output}`)
-  } 
+  }
 }
 
 function npmBuild(): void {
   logger.debug("running build script with npm")
   try {
     execFileSync(nodePath, [npmPath, "run-script", "build"], prepExecOpts)
-  } catch(e) {
+  } catch (e) {
     throw new Error(`error executing npm run-script build:\n\n${e.output}`)
   }
 }
 
 function compileWithTSCConfig() {
-  logger.debug("compiling typescript project with configuration from tsconfig.json")
+  logger.debug(
+    "compiling typescript project with configuration from tsconfig.json"
+  )
   try {
     execFileSync(nodePath, [tscPath], prepExecOpts)
-  } catch(e) {
+  } catch (e) {
     throw new Error(`error executing tsc:\n\n${e.output}`)
   }
 }
 
 function defaultCompile() {
-  logger.debug("compiling brigade.ts with flags --target ES6 --module commonjs --esModuleInterop")
+  logger.debug(
+    "compiling brigade.ts with flags --target ES6 --module commonjs --esModuleInterop"
+  )
   try {
-    execFileSync(nodePath, [tscPath, "--target", "ES6", "--module", "commonjs", "--esModuleInterop", "brigade.ts"], prepExecOpts)
-  } catch(e) {
+    execFileSync(
+      nodePath,
+      [
+        tscPath,
+        "--target",
+        "ES6",
+        "--module",
+        "commonjs",
+        "--esModuleInterop",
+        "brigade.ts"
+      ],
+      prepExecOpts
+    )
+  } catch (e) {
     throw new Error(`error compiling brigade.ts:\n\n${e.output}`)
   }
 }
@@ -180,7 +204,7 @@ function yarnRun(): void {
   logger.debug("running script with yarn")
   try {
     execFileSync(nodePath, [yarnPath, "run", "run"], runExecOpts)
-  } catch(e) {
+  } catch (e) {
     throw new Error(`error executing yarn run run:\n\n${e.output}`)
   }
 }
@@ -189,7 +213,7 @@ function npmRun(): void {
   logger.debug("running script with npm")
   try {
     execFileSync(nodePath, [npmPath, "run-script", "run"], runExecOpts)
-  } catch(e) {
+  } catch (e) {
     throw new Error(`error executing npm run-script run:\n\n${e.output}`)
   }
 }
@@ -198,7 +222,7 @@ function nodeRun(): void {
   logger.debug("running node brigade.js")
   try {
     execFileSync(nodePath, ["brigade.js"], runExecOpts)
-  } catch(e) {
+  } catch (e) {
     throw new Error(`error executing node brigade.js:\n\n${e.output}`)
   }
 }

--- a/v2/worker/tsconfig.json
+++ b/v2/worker/tsconfig.json
@@ -1,27 +1,21 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es6",
-        "outDir": "dist",
-        "lib": [
-            "es6"
-        ],
-        "declaration": true,
-        "sourceMap": true,
-        "rootDir": "src",
-        /* Strict Type-Checking Option */
-        "strict": true,   /* enable all strict type-checking options */
-        /* Additional Checks */
-        "noUnusedLocals": true, /* Report errors on unused locals. */
-        // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-        // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
-        // "noUnusedParameters": true,  /* Report errors on unused parameters. */
-        "typeRoots": [
-            "node_modules/@types"
-        ],
-        "useUnknownInCatchVariables": false
-    },
-    "include": [
-        "src/**/*"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "dist",
+    "lib": ["es6"],
+    "declaration": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    /* Strict Type-Checking Option */
+    "strict": true /* enable all strict type-checking options */,
+    /* Additional Checks */
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+    // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+    "typeRoots": ["node_modules/@types"],
+    "useUnknownInCatchVariables": false
+  },
+  "include": ["src/**/*"]
 }

--- a/v2/worker/yarn.lock
+++ b/v2/worker/yarn.lock
@@ -1007,6 +1007,11 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+eslint-config-prettier@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
+  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -2340,6 +2345,11 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.0.tgz#12f8f504c4d8ddb76475f441337542fa799207d4"
+  integrity sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==
 
 proc-log@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #1862 

This PR sets up prettier for the three TS-based components, similar to how we have already done for the SDK for JS/TS and the Dashboard.

The difference here is that there's separate prettier config for each of the three components in question, because the tool seems to expect that its config and `package.json` live in the same dir. Event if you use the `--config` to point it elsewhere for config, it ends up looking for your `package.json` there also. 🤷‍♂️ 

The PR is decomposed into separate commits for:

* Setting up prettier for:
    * brigadier
    * brigadier-polyfill
    * worker
* Add a make target to run style checks across all three
* Incorporate checks into CI
* Run `yarn style:fix` on each of the following, with no manual changes:
    * brigadier
    * brigadier-polyfill
    * worker