### PR TITLE
add generic List type to API server and use throughout

### DIFF
--- a/v2/apiserver/internal/api/events.go
+++ b/v2/apiserver/internal/api/events.go
@@ -242,7 +242,7 @@ func (d DeleteManyEventsResult) MarshalJSON() ([]byte, error) {
 type EventsService interface {
 	// Create creates a new Event.
 	Create(context.Context, Event) (
-		EventList,
+		meta.List[Event],
 		error,
 	)
 	// List retrieves an EventList, with its Items (Events) ordered by age, newest
@@ -252,7 +252,7 @@ type EventsService interface {
 		context.Context,
 		EventsSelector,
 		meta.ListOptions,
-	) (EventList, error)
+	) (meta.List[Event], error)
 	// Get retrieves a single Event specified by its identifier. If no such event
 	// is found, implementations MUST return a *meta.ErrNotFound error.
 	Get(context.Context, string) (Event, error)
@@ -333,8 +333,8 @@ func NewEventsService(
 func (e *eventsService) Create(
 	ctx context.Context,
 	event Event,
-) (EventList, error) {
-	events := EventList{}
+) (meta.List[Event], error) {
+	events := meta.List[Event]{}
 
 	if event.ProjectID == "" {
 		// This event doesn't reference a discrete project and is instead going to
@@ -382,28 +382,9 @@ func (e *eventsService) Create(
 		)
 	}
 
-	if event.ProjectID != "" {
-		project, err := e.projectsStore.Get(ctx, event.ProjectID)
-		if err != nil {
-			return events, errors.Wrapf(
-				err,
-				"error retrieving project %q from store",
-				event.ProjectID,
-			)
-		}
-
-		if !subscribers.Contains(project) {
-			return events, nil
-		}
-
-		evt, err := e.createSingleEventFn(ctx, project, event)
-		events.Items = []Event{evt}
-		return events, err
-	}
-
 	// If we get to here, no project ID is specified, so we iterate over all
 	// subscribed projects in the list and create a discrete event for each.
-	events.Items = make([]Event, len(subscribers.Items))
+	events.Items = make([]Event, subscribers.Len())
 	for i, project := range subscribers.Items {
 		event.ProjectID = project.ID
 		evt, err := e.createSingleEventFn(ctx, project, event)
@@ -496,9 +477,9 @@ func (e *eventsService) List(
 	ctx context.Context,
 	selector EventsSelector,
 	opts meta.ListOptions,
-) (EventList, error) {
+) (meta.List[Event], error) {
 	if err := e.authorize(ctx, RoleReader, ""); err != nil {
-		return EventList{}, err
+		return meta.List[Event]{}, err
 	}
 
 	// If no worker phase filters were applied, retrieve all phases
@@ -918,7 +899,7 @@ type EventsStore interface {
 		context.Context,
 		EventsSelector,
 		meta.ListOptions,
-	) (EventList, error)
+	) (meta.List[Event], error)
 	// Get retrieves a single Event from the underlying data store. If the
 	// specified Event does not exist, implementations MUST return a
 	// *meta.ErrNotFound error.

--- a/v2/apiserver/internal/api/events.go
+++ b/v2/apiserver/internal/api/events.go
@@ -187,31 +187,6 @@ type EventsSelector struct {
 	Labels map[string]string
 }
 
-// EventList is an ordered and pageable list of Events.
-type EventList struct {
-	// ListMeta contains list metadata.
-	meta.ListMeta `json:"metadata"`
-	// Items is a slice of Events.
-	Items []Event `json:"items,omitempty"`
-}
-
-// MarshalJSON amends EventList instances with type metadata.
-func (e EventList) MarshalJSON() ([]byte, error) {
-	type Alias EventList
-	return json.Marshal(
-		struct {
-			meta.TypeMeta `json:",inline"`
-			Alias         `json:",inline"`
-		}{
-			TypeMeta: meta.TypeMeta{
-				APIVersion: meta.APIVersion,
-				Kind:       "EventList",
-			},
-			Alias: (Alias)(e),
-		},
-	)
-}
-
 // CancelManyEventsResult represents a summary of a mass Event cancellation
 // operation.
 type CancelManyEventsResult struct {

--- a/v2/apiserver/internal/api/events_test.go
+++ b/v2/apiserver/internal/api/events_test.go
@@ -14,10 +14,6 @@ func TestEventMarshalJSON(t *testing.T) {
 	metaTesting.RequireAPIVersionAndType(t, &Event{}, EventKind)
 }
 
-func TestEventListMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(t, &EventList{}, "EventList")
-}
-
 func TestCancelManyEventsResultMarshalJSON(t *testing.T) {
 	metaTesting.RequireAPIVersionAndType(
 		t,

--- a/v2/apiserver/internal/api/events_test.go
+++ b/v2/apiserver/internal/api/events_test.go
@@ -55,39 +55,16 @@ func TestEventsServiceCreate(t *testing.T) {
 		name       string
 		event      Event
 		service    EventsService
-		assertions func(EventList, error)
+		assertions func(meta.List[Event], error)
 	}{
 		{
 			name: "unauthorized",
 			service: &eventsService{
 				authorize: neverAuthorize,
 			},
-			assertions: func(_ EventList, err error) {
+			assertions: func(_ meta.List[Event], err error) {
 				require.Error(t, err)
 				require.IsType(t, &meta.ErrAuthorization{}, err)
-			},
-		},
-		{
-			name: "create single event for specified project; error getting " +
-				"project from store",
-			event: Event{
-				ProjectID: "blue-book",
-			},
-			service: &eventsService{
-				projectAuthorize: alwaysProjectAuthorize,
-				projectsStore: &mockProjectsStore{
-					GetFn: func(context.Context, string) (Project, error) {
-						return Project{}, errors.New("projects store error")
-					},
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{}, nil
-					},
-				},
-			},
-			assertions: func(_ EventList, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "error retrieving project")
-				require.Contains(t, err.Error(), "projects store error")
 			},
 		},
 		{
@@ -98,22 +75,12 @@ func TestEventsServiceCreate(t *testing.T) {
 			service: &eventsService{
 				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
-					GetFn: func(context.Context, string) (Project, error) {
-						return Project{
-							ObjectMeta: meta.ObjectMeta{
-								ID: "blue-book",
-							},
-						}, nil
-					},
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{
-							Items: []Project{
-								{
-									ObjectMeta: meta.ObjectMeta{
-										ID: "orange-book",
-									},
-								},
-							},
+					ListSubscribersFn: func(
+						context.Context,
+						Event,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{
+							Items: []Project{},
 						}, nil
 					},
 				},
@@ -125,7 +92,7 @@ func TestEventsServiceCreate(t *testing.T) {
 					return Event{}, nil
 				},
 			},
-			assertions: func(events EventList, err error) {
+			assertions: func(events meta.List[Event], err error) {
 				require.NoError(t, err)
 				require.Len(t, events.Items, 0)
 			},
@@ -146,8 +113,11 @@ func TestEventsServiceCreate(t *testing.T) {
 							},
 						}, nil
 					},
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{
+					ListSubscribersFn: func(
+						context.Context,
+						Event,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{
 							Items: []Project{
 								{
 									ObjectMeta: meta.ObjectMeta{
@@ -166,7 +136,7 @@ func TestEventsServiceCreate(t *testing.T) {
 					return Event{}, errors.New("error creating single event")
 				},
 			},
-			assertions: func(_ EventList, err error) {
+			assertions: func(_ meta.List[Event], err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "error creating single event")
 			},
@@ -187,8 +157,11 @@ func TestEventsServiceCreate(t *testing.T) {
 							},
 						}, nil
 					},
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{
+					ListSubscribersFn: func(
+						context.Context,
+						Event,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{
 							Items: []Project{
 								{
 									ObjectMeta: meta.ObjectMeta{
@@ -207,7 +180,7 @@ func TestEventsServiceCreate(t *testing.T) {
 					return Event{}, nil
 				},
 			},
-			assertions: func(events EventList, err error) {
+			assertions: func(events meta.List[Event], err error) {
 				require.NoError(t, err)
 				require.Len(t, events.Items, 1)
 			},
@@ -225,14 +198,17 @@ func TestEventsServiceCreate(t *testing.T) {
 			service: &eventsService{
 				authorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{}, errors.New(
+					ListSubscribersFn: func(
+						context.Context,
+						Event,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{}, errors.New(
 							"error getting subscribed projects",
 						)
 					},
 				},
 			},
-			assertions: func(_ EventList, err error) {
+			assertions: func(_ meta.List[Event], err error) {
 				require.Error(t, err)
 				require.Contains(
 					t,
@@ -255,8 +231,11 @@ func TestEventsServiceCreate(t *testing.T) {
 			service: &eventsService{
 				authorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{
+					ListSubscribersFn: func(
+						context.Context,
+						Event,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{
 							Items: []Project{{}, {}},
 						}, nil
 					},
@@ -269,7 +248,7 @@ func TestEventsServiceCreate(t *testing.T) {
 					return Event{}, errors.New("error creating single event")
 				},
 			},
-			assertions: func(_ EventList, err error) {
+			assertions: func(_ meta.List[Event], err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "error creating single event")
 			},
@@ -286,8 +265,11 @@ func TestEventsServiceCreate(t *testing.T) {
 			service: &eventsService{
 				authorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{
+					ListSubscribersFn: func(
+						context.Context,
+						Event,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{
 							Items: []Project{{}, {}},
 						}, nil
 					},
@@ -300,7 +282,7 @@ func TestEventsServiceCreate(t *testing.T) {
 					return Event{}, nil
 				},
 			},
-			assertions: func(events EventList, err error) {
+			assertions: func(events meta.List[Event], err error) {
 				require.NoError(t, err)
 				require.Len(t, events.Items, 2)
 			},
@@ -475,8 +457,8 @@ func TestEventsServiceList(t *testing.T) {
 						context.Context,
 						EventsSelector,
 						meta.ListOptions,
-					) (EventList, error) {
-						return EventList{}, errors.New("error listing events")
+					) (meta.List[Event], error) {
+						return meta.List[Event]{}, errors.New("error listing events")
 					},
 				},
 			},
@@ -495,8 +477,8 @@ func TestEventsServiceList(t *testing.T) {
 						context.Context,
 						EventsSelector,
 						meta.ListOptions,
-					) (EventList, error) {
-						return EventList{}, nil
+					) (meta.List[Event], error) {
+						return meta.List[Event]{}, nil
 					},
 				},
 			},
@@ -672,8 +654,11 @@ func TestEventsServiceClone(t *testing.T) {
 					},
 				},
 				projectsStore: &mockProjectsStore{
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{
+					ListSubscribersFn: func(
+						context.Context,
+						Event,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{
 							Items: []Project{{}, {}},
 						}, nil
 					},
@@ -711,8 +696,11 @@ func TestEventsServiceClone(t *testing.T) {
 					},
 				},
 				projectsStore: &mockProjectsStore{
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{
+					ListSubscribersFn: func(
+						context.Context,
+						Event,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{
 							Items: []Project{{}, {}},
 						}, nil
 					},
@@ -1619,8 +1607,11 @@ func TestEventsServiceRetry(t *testing.T) {
 					},
 				},
 				projectsStore: &mockProjectsStore{
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{
+					ListSubscribersFn: func(
+						context.Context,
+						Event,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{
 							Items: []Project{{}, {}},
 						}, nil
 					},
@@ -1662,8 +1653,11 @@ func TestEventsServiceRetry(t *testing.T) {
 					},
 				},
 				projectsStore: &mockProjectsStore{
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{
+					ListSubscribersFn: func(
+						context.Context,
+						Event,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{
 							Items: []Project{{}, {}},
 						}, nil
 					},
@@ -1709,8 +1703,11 @@ func TestEventsServiceRetry(t *testing.T) {
 					},
 				},
 				projectsStore: &mockProjectsStore{
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{
+					ListSubscribersFn: func(
+						context.Context,
+						Event,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{
 							Items: []Project{{}, {}},
 						}, nil
 					},
@@ -1760,8 +1757,11 @@ func TestEventsServiceRetry(t *testing.T) {
 					},
 				},
 				projectsStore: &mockProjectsStore{
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{
+					ListSubscribersFn: func(
+						context.Context,
+						Event,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{
 							Items: []Project{{}, {}},
 						}, nil
 					},
@@ -1803,8 +1803,11 @@ func TestEventsServiceRetry(t *testing.T) {
 					},
 				},
 				projectsStore: &mockProjectsStore{
-					ListSubscribersFn: func(context.Context, Event) (ProjectList, error) {
-						return ProjectList{
+					ListSubscribersFn: func(
+						context.Context,
+						Event,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{
 							Items: []Project{{}, {}},
 						}, nil
 					},
@@ -1851,7 +1854,7 @@ type mockEventsStore struct {
 		context.Context,
 		EventsSelector,
 		meta.ListOptions,
-	) (EventList, error)
+	) (meta.List[Event], error)
 	GetFn                    func(context.Context, string) (Event, error)
 	GetByHashedWorkerTokenFn func(context.Context, string) (Event, error)
 	UpdateSourceStateFn      func(context.Context, string, SourceState) error
@@ -1877,7 +1880,7 @@ func (m *mockEventsStore) List(
 	ctx context.Context,
 	selector EventsSelector,
 	opts meta.ListOptions,
-) (EventList, error) {
+) (meta.List[Event], error) {
 	return m.ListFn(ctx, selector, opts)
 }
 

--- a/v2/apiserver/internal/api/kubernetes/secrets_store_test.go
+++ b/v2/apiserver/internal/api/kubernetes/secrets_store_test.go
@@ -26,7 +26,7 @@ func TestSecretsStoreList(t *testing.T) {
 	testCases := []struct {
 		name       string
 		setup      func() *fake.Clientset
-		assertions func(api.SecretList, error)
+		assertions func(meta.List[api.Secret], error)
 	}{
 		{
 			name: "error getting kubernetes secret",
@@ -34,7 +34,7 @@ func TestSecretsStoreList(t *testing.T) {
 				// We'll force an error simply by having the secret not exist
 				return fake.NewSimpleClientset()
 			},
-			assertions: func(secrets api.SecretList, err error,
+			assertions: func(secrets meta.List[api.Secret], err error,
 			) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "error retrieving secret")
@@ -69,10 +69,9 @@ func TestSecretsStoreList(t *testing.T) {
 				require.NoError(t, err)
 				return kubeClient
 			},
-			assertions: func(secrets api.SecretList, err error) {
+			assertions: func(secrets meta.List[api.Secret], err error) {
 				require.NoError(t, err)
 				// Check that the Limit param was respected
-				require.Equal(t, testLimit, secrets.Len())
 				require.Len(t, secrets.Items, testLimit)
 				// Check that we got Secrets back, lexically ordered by Key AND the
 				// Continue param was respected

--- a/v2/apiserver/internal/api/mongodb/events_store.go
+++ b/v2/apiserver/internal/api/mongodb/events_store.go
@@ -67,8 +67,8 @@ func (e *eventsStore) List(
 	ctx context.Context,
 	selector api.EventsSelector,
 	opts meta.ListOptions,
-) (api.EventList, error) {
-	events := api.EventList{}
+) (meta.List[api.Event], error) {
+	events := meta.List[api.Event]{}
 
 	criteria := bson.M{
 		"deleted": bson.M{
@@ -133,7 +133,7 @@ func (e *eventsStore) List(
 		return events, errors.Wrap(err, "error decoding events")
 	}
 
-	if int64(len(events.Items)) == opts.Limit {
+	if events.Len() == opts.Limit {
 		continueTime := events.Items[opts.Limit-1].Created
 		continueID := events.Items[opts.Limit-1].ID
 		criteria["$or"] = []bson.M{

--- a/v2/apiserver/internal/api/mongodb/events_store_test.go
+++ b/v2/apiserver/internal/api/mongodb/events_store_test.go
@@ -88,14 +88,14 @@ func TestEventsStoreList(t *testing.T) {
 		name        string
 		listOptions meta.ListOptions
 		collection  mongodb.Collection
-		assertions  func(events api.EventList, err error)
+		assertions  func(events meta.List[api.Event], err error)
 	}{
 		{
 			name: "unparsable continue value",
 			listOptions: meta.ListOptions{
 				Continue: "invalid time",
 			},
-			assertions: func(events api.EventList, err error) {
+			assertions: func(events meta.List[api.Event], err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "error parsing continue time")
 			},
@@ -118,7 +118,7 @@ func TestEventsStoreList(t *testing.T) {
 					return nil, errors.New("something went wrong")
 				},
 			},
-			assertions: func(events api.EventList, err error) {
+			assertions: func(events meta.List[api.Event], err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "something went wrong")
 				require.Contains(t, err.Error(), "error finding events")
@@ -148,7 +148,7 @@ func TestEventsStoreList(t *testing.T) {
 					return 0, nil
 				},
 			},
-			assertions: func(events api.EventList, err error) {
+			assertions: func(events meta.List[api.Event], err error) {
 				require.NoError(t, err)
 				require.Len(t, events.Items, 1)
 				require.Equal(t, testEvent.ID, events.Items[0].ID)
@@ -180,7 +180,7 @@ func TestEventsStoreList(t *testing.T) {
 					return 5, nil
 				},
 			},
-			assertions: func(events api.EventList, err error) {
+			assertions: func(events meta.List[api.Event], err error) {
 				require.NoError(t, err)
 				require.Len(t, events.Items, 1)
 				require.Equal(t, testEvent.ID, events.Items[0].ID)

--- a/v2/apiserver/internal/api/mongodb/project_role_assignments_store.go
+++ b/v2/apiserver/internal/api/mongodb/project_role_assignments_store.go
@@ -63,8 +63,8 @@ func (p *projectRoleAssignmentsStore) List(
 	ctx context.Context,
 	selector api.ProjectRoleAssignmentsSelector,
 	opts meta.ListOptions,
-) (api.ProjectRoleAssignmentList, error) {
-	projectRoleAssignments := api.ProjectRoleAssignmentList{}
+) (meta.List[api.ProjectRoleAssignment], error) {
+	projectRoleAssignments := meta.List[api.ProjectRoleAssignment]{}
 
 	criteria := bson.M{}
 	if selector.ProjectID != "" {
@@ -136,7 +136,7 @@ func (p *projectRoleAssignmentsStore) List(
 			errors.Wrap(err, "error decoding project role assignments")
 	}
 
-	if int64(len(projectRoleAssignments.Items)) == opts.Limit {
+	if projectRoleAssignments.Len() == opts.Limit {
 		continueProjectID := projectRoleAssignments.Items[opts.Limit-1].ProjectID
 		continuePrincipalType :=
 			projectRoleAssignments.Items[opts.Limit-1].Principal.Type

--- a/v2/apiserver/internal/api/mongodb/project_role_assignments_store_test.go
+++ b/v2/apiserver/internal/api/mongodb/project_role_assignments_store_test.go
@@ -90,7 +90,7 @@ func TestProjectRoleAssignmentsStoreList(t *testing.T) {
 	testCases := []struct {
 		name       string
 		collection mongodb.Collection
-		assertions func(api.ProjectRoleAssignmentList, error)
+		assertions func(meta.List[api.ProjectRoleAssignment], error)
 	}{
 
 		{
@@ -104,7 +104,7 @@ func TestProjectRoleAssignmentsStoreList(t *testing.T) {
 					return nil, errors.New("something went wrong")
 				},
 			},
-			assertions: func(_ api.ProjectRoleAssignmentList, err error) {
+			assertions: func(_ meta.List[api.ProjectRoleAssignment], err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "something went wrong")
 				require.Contains(
@@ -136,7 +136,7 @@ func TestProjectRoleAssignmentsStoreList(t *testing.T) {
 				},
 			},
 			assertions: func(
-				projectRoleAssignments api.ProjectRoleAssignmentList,
+				projectRoleAssignments meta.List[api.ProjectRoleAssignment],
 				err error,
 			) {
 				require.NoError(t, err)
@@ -166,7 +166,7 @@ func TestProjectRoleAssignmentsStoreList(t *testing.T) {
 				},
 			},
 			assertions: func(
-				projectRoleAssignments api.ProjectRoleAssignmentList,
+				projectRoleAssignments meta.List[api.ProjectRoleAssignment],
 				err error,
 			) {
 				require.NoError(t, err)

--- a/v2/apiserver/internal/api/mongodb/projects_store_test.go
+++ b/v2/apiserver/internal/api/mongodb/projects_store_test.go
@@ -103,7 +103,7 @@ func TestProjectsStoreList(t *testing.T) {
 	testCases := []struct {
 		name       string
 		collection mongodb.Collection
-		assertions func(projects api.ProjectList, err error)
+		assertions func(projects meta.List[api.Project], err error)
 	}{
 
 		{
@@ -117,7 +117,7 @@ func TestProjectsStoreList(t *testing.T) {
 					return nil, errors.New("something went wrong")
 				},
 			},
-			assertions: func(projects api.ProjectList, err error) {
+			assertions: func(projects meta.List[api.Project], err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "something went wrong")
 				require.Contains(t, err.Error(), "error finding projects")
@@ -144,7 +144,7 @@ func TestProjectsStoreList(t *testing.T) {
 					return 0, nil
 				},
 			},
-			assertions: func(projects api.ProjectList, err error) {
+			assertions: func(projects meta.List[api.Project], err error) {
 				require.NoError(t, err)
 				require.Empty(t, projects.Continue)
 				require.Zero(t, projects.RemainingItemCount)
@@ -171,7 +171,7 @@ func TestProjectsStoreList(t *testing.T) {
 					return 5, nil
 				},
 			},
-			assertions: func(projects api.ProjectList, err error) {
+			assertions: func(projects meta.List[api.Project], err error) {
 				require.NoError(t, err)
 				require.Equal(t, testProject.ID, projects.Continue)
 				require.Equal(t, int64(5), projects.RemainingItemCount)
@@ -218,7 +218,7 @@ func TestProjectsStoreListSubscribers(t *testing.T) {
 	testCases := []struct {
 		name       string
 		collection mongodb.Collection
-		assertions func(subscribers api.ProjectList, err error)
+		assertions func(subscribers meta.List[api.Project], err error)
 	}{
 		{
 			name: "error finding subscribers",
@@ -231,7 +231,7 @@ func TestProjectsStoreListSubscribers(t *testing.T) {
 					return nil, errors.New("something went wrong")
 				},
 			},
-			assertions: func(subscribers api.ProjectList, err error) {
+			assertions: func(subscribers meta.List[api.Project], err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "something went wrong")
 				require.Contains(t, err.Error(), "error finding projects")
@@ -251,7 +251,7 @@ func TestProjectsStoreListSubscribers(t *testing.T) {
 					return cursor, nil
 				},
 			},
-			assertions: func(subscribers api.ProjectList, err error) {
+			assertions: func(subscribers meta.List[api.Project], err error) {
 				require.NoError(t, err)
 				require.Empty(t, subscribers.Items)
 			},
@@ -270,7 +270,7 @@ func TestProjectsStoreListSubscribers(t *testing.T) {
 					return cursor, nil
 				},
 			},
-			assertions: func(subscribers api.ProjectList, err error) {
+			assertions: func(subscribers meta.List[api.Project], err error) {
 				require.NoError(t, err)
 				require.Len(t, subscribers.Items, 2)
 			},

--- a/v2/apiserver/internal/api/mongodb/role_assignments_store.go
+++ b/v2/apiserver/internal/api/mongodb/role_assignments_store.go
@@ -57,8 +57,8 @@ func (r *roleAssignmentsStore) List(
 	ctx context.Context,
 	selector api.RoleAssignmentsSelector,
 	opts meta.ListOptions,
-) (api.RoleAssignmentList, error) {
-	roleAssignments := api.RoleAssignmentList{}
+) (meta.List[api.RoleAssignment], error) {
+	roleAssignments := meta.List[api.RoleAssignment]{}
 
 	criteria := bson.M{}
 	if selector.Principal != nil {
@@ -125,7 +125,7 @@ func (r *roleAssignmentsStore) List(
 		return roleAssignments, errors.Wrap(err, "error decoding role assignments")
 	}
 
-	if int64(len(roleAssignments.Items)) == opts.Limit {
+	if roleAssignments.Len() == opts.Limit {
 		continuePrincipalType := roleAssignments.Items[opts.Limit-1].Principal.Type
 		continuePrincipalID := roleAssignments.Items[opts.Limit-1].Principal.ID
 		continueRole := roleAssignments.Items[opts.Limit-1].Role

--- a/v2/apiserver/internal/api/mongodb/role_assignments_store_test.go
+++ b/v2/apiserver/internal/api/mongodb/role_assignments_store_test.go
@@ -86,7 +86,7 @@ func TestRoleAssignmentsStoreList(t *testing.T) {
 	testCases := []struct {
 		name       string
 		collection mongodb.Collection
-		assertions func(api.RoleAssignmentList, error)
+		assertions func(meta.List[api.RoleAssignment], error)
 	}{
 
 		{
@@ -100,7 +100,7 @@ func TestRoleAssignmentsStoreList(t *testing.T) {
 					return nil, errors.New("something went wrong")
 				},
 			},
-			assertions: func(_ api.RoleAssignmentList, err error) {
+			assertions: func(_ meta.List[api.RoleAssignment], err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "something went wrong")
 				require.Contains(t, err.Error(), "error finding role assignments")
@@ -127,7 +127,10 @@ func TestRoleAssignmentsStoreList(t *testing.T) {
 					return 0, nil
 				},
 			},
-			assertions: func(roleAssignments api.RoleAssignmentList, err error) {
+			assertions: func(
+				roleAssignments meta.List[api.RoleAssignment],
+				err error,
+			) {
 				require.NoError(t, err)
 				require.Empty(t, roleAssignments.Continue)
 				require.Zero(t, roleAssignments.RemainingItemCount)
@@ -154,7 +157,10 @@ func TestRoleAssignmentsStoreList(t *testing.T) {
 					return 5, nil
 				},
 			},
-			assertions: func(roleAssignments api.RoleAssignmentList, err error) {
+			assertions: func(
+				roleAssignments meta.List[api.RoleAssignment],
+				err error,
+			) {
 				require.NoError(t, err)
 				require.Equal(
 					t,

--- a/v2/apiserver/internal/api/mongodb/service_accounts_store.go
+++ b/v2/apiserver/internal/api/mongodb/service_accounts_store.go
@@ -88,8 +88,8 @@ func (s *serviceAccountsStore) Create(
 func (s *serviceAccountsStore) List(
 	ctx context.Context,
 	opts meta.ListOptions,
-) (api.ServiceAccountList, error) {
-	serviceAccounts := api.ServiceAccountList{}
+) (meta.List[api.ServiceAccount], error) {
+	serviceAccounts := meta.List[api.ServiceAccount]{}
 
 	criteria := bson.M{}
 	if opts.Continue != "" {
@@ -116,7 +116,7 @@ func (s *serviceAccountsStore) List(
 			errors.Wrap(err, "error decoding service accounts")
 	}
 
-	if int64(len(serviceAccounts.Items)) == opts.Limit {
+	if serviceAccounts.Len() == opts.Limit {
 		continueID := serviceAccounts.Items[opts.Limit-1].ID
 		criteria["id"] = bson.M{"$gt": continueID}
 		remaining, err := s.collection.CountDocuments(ctx, criteria)

--- a/v2/apiserver/internal/api/mongodb/service_accounts_store_test.go
+++ b/v2/apiserver/internal/api/mongodb/service_accounts_store_test.go
@@ -103,7 +103,7 @@ func TestServiceAccountsStoreList(t *testing.T) {
 	testCases := []struct {
 		name       string
 		collection mongodb.Collection
-		assertions func(serviceAccounts api.ServiceAccountList, err error)
+		assertions func(serviceAccounts meta.List[api.ServiceAccount], err error)
 	}{
 
 		{
@@ -117,7 +117,7 @@ func TestServiceAccountsStoreList(t *testing.T) {
 					return nil, errors.New("something went wrong")
 				},
 			},
-			assertions: func(_ api.ServiceAccountList, err error) {
+			assertions: func(_ meta.List[api.ServiceAccount], err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "something went wrong")
 				require.Contains(t, err.Error(), "error finding service accounts")
@@ -144,7 +144,10 @@ func TestServiceAccountsStoreList(t *testing.T) {
 					return 0, nil
 				},
 			},
-			assertions: func(serviceAccounts api.ServiceAccountList, err error) {
+			assertions: func(
+				serviceAccounts meta.List[api.ServiceAccount],
+				err error,
+			) {
 				require.NoError(t, err)
 				require.Empty(t, serviceAccounts.Continue)
 				require.Zero(t, serviceAccounts.RemainingItemCount)
@@ -171,7 +174,10 @@ func TestServiceAccountsStoreList(t *testing.T) {
 					return 5, nil
 				},
 			},
-			assertions: func(serviceAccounts api.ServiceAccountList, err error) {
+			assertions: func(
+				serviceAccounts meta.List[api.ServiceAccount],
+				err error,
+			) {
 				require.NoError(t, err)
 				require.Equal(t, testServiceAccount.ID, serviceAccounts.Continue)
 				require.Equal(t, int64(5), serviceAccounts.RemainingItemCount)

--- a/v2/apiserver/internal/api/mongodb/users_store.go
+++ b/v2/apiserver/internal/api/mongodb/users_store.go
@@ -69,8 +69,8 @@ func (u *usersStore) Create(ctx context.Context, user api.User) error {
 func (u *usersStore) List(
 	ctx context.Context,
 	opts meta.ListOptions,
-) (api.UserList, error) {
-	users := api.UserList{}
+) (meta.List[api.User], error) {
+	users := meta.List[api.User]{}
 
 	criteria := bson.M{}
 	if opts.Continue != "" {
@@ -95,7 +95,7 @@ func (u *usersStore) List(
 		return users, errors.Wrap(err, "error decoding users")
 	}
 
-	if int64(len(users.Items)) == opts.Limit {
+	if users.Len() == opts.Limit {
 		continueID := users.Items[opts.Limit-1].ID
 		criteria["id"] = bson.M{"$gt": continueID}
 		remaining, err := u.collection.CountDocuments(ctx, criteria)

--- a/v2/apiserver/internal/api/mongodb/users_store_test.go
+++ b/v2/apiserver/internal/api/mongodb/users_store_test.go
@@ -103,7 +103,7 @@ func TestUsersStoreList(t *testing.T) {
 	testCases := []struct {
 		name       string
 		collection mongodb.Collection
-		assertions func(api.UserList, error)
+		assertions func(meta.List[api.User], error)
 	}{
 
 		{
@@ -117,7 +117,7 @@ func TestUsersStoreList(t *testing.T) {
 					return nil, errors.New("something went wrong")
 				},
 			},
-			assertions: func(_ api.UserList, err error) {
+			assertions: func(_ meta.List[api.User], err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "something went wrong")
 				require.Contains(t, err.Error(), "error finding users")
@@ -144,7 +144,7 @@ func TestUsersStoreList(t *testing.T) {
 					return 0, nil
 				},
 			},
-			assertions: func(users api.UserList, err error) {
+			assertions: func(users meta.List[api.User], err error) {
 				require.NoError(t, err)
 				require.Empty(t, users.Continue)
 				require.Zero(t, users.RemainingItemCount)
@@ -171,7 +171,7 @@ func TestUsersStoreList(t *testing.T) {
 					return 5, nil
 				},
 			},
-			assertions: func(users api.UserList, err error) {
+			assertions: func(users meta.List[api.User], err error) {
 				require.NoError(t, err)
 				require.Equal(t, testUser.ID, users.Continue)
 				require.Equal(t, int64(5), users.RemainingItemCount)

--- a/v2/apiserver/internal/api/project_role_assignments.go
+++ b/v2/apiserver/internal/api/project_role_assignments.go
@@ -89,7 +89,7 @@ type ProjectRoleAssignmentsService interface {
 		context.Context,
 		ProjectRoleAssignmentsSelector,
 		meta.ListOptions,
-	) (ProjectRoleAssignmentList, error)
+	) (meta.List[ProjectRoleAssignment], error)
 
 	// Revoke revokes the project-level Role specified by the
 	// ProjectRoleAssignment for the principal also specified by the
@@ -200,9 +200,9 @@ func (p *projectRoleAssignmentsService) List(
 	ctx context.Context,
 	selector ProjectRoleAssignmentsSelector,
 	opts meta.ListOptions,
-) (ProjectRoleAssignmentList, error) {
+) (meta.List[ProjectRoleAssignment], error) {
 	if err := p.authorize(ctx, RoleReader, ""); err != nil {
-		return ProjectRoleAssignmentList{}, err
+		return meta.List[ProjectRoleAssignment]{}, err
 	}
 
 	if opts.Limit == 0 {
@@ -297,7 +297,7 @@ type ProjectRoleAssignmentsStore interface {
 		context.Context,
 		ProjectRoleAssignmentsSelector,
 		meta.ListOptions,
-	) (ProjectRoleAssignmentList, error)
+	) (meta.List[ProjectRoleAssignment], error)
 	// Revoke the Project specified by the ProjectRoleAssignment for the principal
 	// specified by the ProjectRoleAssignment.
 	Revoke(context.Context, ProjectRoleAssignment) error

--- a/v2/apiserver/internal/api/project_role_assignments.go
+++ b/v2/apiserver/internal/api/project_role_assignments.go
@@ -56,32 +56,6 @@ func (p ProjectRoleAssignment) MarshalJSON() ([]byte, error) {
 	)
 }
 
-// ProjectRoleAssignmentList is an ordered and pageable list of
-// ProjectRoleAssignments.
-type ProjectRoleAssignmentList struct {
-	// ListMeta contains list metadata.
-	meta.ListMeta `json:"metadata"`
-	// Items is a slice of ProjectRoleAssignments.
-	Items []ProjectRoleAssignment `json:"items,omitempty"`
-}
-
-// MarshalJSON amends ProjectRoleAssignmentList instances with type metadata.
-func (p ProjectRoleAssignmentList) MarshalJSON() ([]byte, error) {
-	type Alias ProjectRoleAssignmentList
-	return json.Marshal(
-		struct {
-			meta.TypeMeta `json:",inline"`
-			Alias         `json:",inline"`
-		}{
-			TypeMeta: meta.TypeMeta{
-				APIVersion: meta.APIVersion,
-				Kind:       ProjectRoleAssignmentListKind,
-			},
-			Alias: (Alias)(p),
-		},
-	)
-}
-
 // ProjectRoleAssignmentsSelector represents useful filter criteria when
 // selecting multiple ProjectRoleAssignments for API group operations like list.
 type ProjectRoleAssignmentsSelector struct {

--- a/v2/apiserver/internal/api/project_role_assignments_test.go
+++ b/v2/apiserver/internal/api/project_role_assignments_test.go
@@ -295,8 +295,8 @@ func TestProjectRoleAssignmentsServiceList(t *testing.T) {
 						context.Context,
 						ProjectRoleAssignmentsSelector,
 						meta.ListOptions,
-					) (ProjectRoleAssignmentList, error) {
-						return ProjectRoleAssignmentList{},
+					) (meta.List[ProjectRoleAssignment], error) {
+						return meta.List[ProjectRoleAssignment]{},
 							errors.New("something went wrong")
 					},
 				},
@@ -320,8 +320,8 @@ func TestProjectRoleAssignmentsServiceList(t *testing.T) {
 						context.Context,
 						ProjectRoleAssignmentsSelector,
 						meta.ListOptions,
-					) (ProjectRoleAssignmentList, error) {
-						return ProjectRoleAssignmentList{}, nil
+					) (meta.List[ProjectRoleAssignment], error) {
+						return meta.List[ProjectRoleAssignment]{}, nil
 					},
 				},
 			},
@@ -509,7 +509,7 @@ type mockProjectRoleAssignmentsStore struct {
 		context.Context,
 		ProjectRoleAssignmentsSelector,
 		meta.ListOptions,
-	) (ProjectRoleAssignmentList, error)
+	) (meta.List[ProjectRoleAssignment], error)
 	RevokeFn            func(context.Context, ProjectRoleAssignment) error
 	RevokeByProjectIDFn func(ctx context.Context, projectID string) error
 	RevokeByPrincipalFn func(context.Context, PrincipalReference) error
@@ -530,7 +530,7 @@ func (m *mockProjectRoleAssignmentsStore) List(
 	ctx context.Context,
 	selector ProjectRoleAssignmentsSelector,
 	opts meta.ListOptions,
-) (ProjectRoleAssignmentList, error) {
+) (meta.List[ProjectRoleAssignment], error) {
 	return m.ListFn(ctx, selector, opts)
 }
 

--- a/v2/apiserver/internal/api/project_role_assignments_test.go
+++ b/v2/apiserver/internal/api/project_role_assignments_test.go
@@ -81,14 +81,6 @@ func TestProjectRoleAssignmentMatches(t *testing.T) {
 	}
 }
 
-func TestProjectRoleAssignmentListMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(
-		t,
-		&ProjectRoleAssignmentList{},
-		ProjectRoleAssignmentListKind,
-	)
-}
-
 func TestNewProjectRoleAssignmentsService(t *testing.T) {
 	projectsStore := &mockProjectsStore{}
 	usersStore := &mockUsersStore{}

--- a/v2/apiserver/internal/api/projects.go
+++ b/v2/apiserver/internal/api/projects.go
@@ -139,7 +139,7 @@ type ProjectsService interface {
 	Create(context.Context, Project) (Project, error)
 	// List returns a ProjectList, with its Items (Projects) ordered
 	// alphabetically by Project ID.
-	List(context.Context, meta.ListOptions) (ProjectList, error)
+	List(context.Context, meta.ListOptions) (meta.List[Project], error)
 	// Get retrieves a single Project specified by its identifier. If the
 	// specified Project does not exist, implementations MUST return a
 	// *meta.ErrNotFound error.
@@ -306,9 +306,9 @@ func (p *projectsService) Create(
 func (p *projectsService) List(
 	ctx context.Context,
 	opts meta.ListOptions,
-) (ProjectList, error) {
+) (meta.List[Project], error) {
 	if err := p.authorize(ctx, RoleReader, ""); err != nil {
-		return ProjectList{}, err
+		return meta.List[Project]{}, err
 	}
 
 	if opts.Limit == 0 {
@@ -439,11 +439,11 @@ type ProjectsStore interface {
 	List(
 		context.Context,
 		meta.ListOptions,
-	) (ProjectList, error)
+	) (meta.List[Project], error)
 	ListSubscribers(
 		ctx context.Context,
 		event Event,
-	) (ProjectList, error)
+	) (meta.List[Project], error)
 	// Get returns a Project having the indicated ID. If no such Project exists,
 	// implementations MUST return a *meta.ErrNotFound error.
 	Get(context.Context, string) (Project, error)

--- a/v2/apiserver/internal/api/projects.go
+++ b/v2/apiserver/internal/api/projects.go
@@ -55,46 +55,6 @@ func (p Project) MarshalJSON() ([]byte, error) {
 	)
 }
 
-// ProjectList is an ordered and pageable list of Projects.
-type ProjectList struct {
-	// ListMeta contains list metadata.
-	meta.ListMeta `json:"metadata"`
-	// Items is a slice of Projects.
-	Items []Project `json:"items"`
-}
-
-// MarshalJSON amends ProjectList instances with type metadata.
-func (p ProjectList) MarshalJSON() ([]byte, error) {
-	type Alias ProjectList
-	return json.Marshal(
-		struct {
-			meta.TypeMeta `json:",inline"`
-			Alias         `json:",inline"`
-		}{
-			TypeMeta: meta.TypeMeta{
-				APIVersion: meta.APIVersion,
-				Kind:       "ProjectList",
-			},
-			Alias: (Alias)(p),
-		},
-	)
-}
-
-// Contains returns a boolean value indicating whether the ProjectList contains
-// the provided Project
-func (p ProjectList) Contains(project Project) bool {
-	for _, proj := range p.Items {
-		if proj.ID == project.ID {
-			if proj.Kubernetes == nil && project.Kubernetes == nil ||
-				proj.Kubernetes != nil && project.Kubernetes != nil &&
-					proj.Kubernetes.Namespace == project.Kubernetes.Namespace {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // ProjectUpdateOptions represents useful, optional settings for updating a
 // Project. It currently has no fields, but exists to preserve the possibility
 // of future expansion without having to change client function signatures.

--- a/v2/apiserver/internal/api/projects_test.go
+++ b/v2/apiserver/internal/api/projects_test.go
@@ -206,8 +206,11 @@ func TestProjectServiceList(t *testing.T) {
 			service: &projectsService{
 				authorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
-					ListFn: func(context.Context, meta.ListOptions) (ProjectList, error) {
-						return ProjectList{}, errors.New("error listing projects")
+					ListFn: func(
+						context.Context,
+						meta.ListOptions,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{}, errors.New("error listing projects")
 					},
 				},
 			},
@@ -222,8 +225,11 @@ func TestProjectServiceList(t *testing.T) {
 			service: &projectsService{
 				authorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
-					ListFn: func(context.Context, meta.ListOptions) (ProjectList, error) {
-						return ProjectList{}, nil
+					ListFn: func(
+						context.Context,
+						meta.ListOptions,
+					) (meta.List[Project], error) {
+						return meta.List[Project]{}, nil
 					},
 				},
 			},
@@ -697,9 +703,12 @@ func TestProjectServiceDelete(t *testing.T) {
 }
 
 type mockProjectsStore struct {
-	CreateFn          func(context.Context, Project) error
-	ListFn            func(context.Context, meta.ListOptions) (ProjectList, error)
-	ListSubscribersFn func(context.Context, Event) (ProjectList, error)
+	CreateFn func(context.Context, Project) error
+	ListFn   func(
+		context.Context,
+		meta.ListOptions,
+	) (meta.List[Project], error)
+	ListSubscribersFn func(context.Context, Event) (meta.List[Project], error)
 	GetFn             func(context.Context, string) (Project, error)
 	UpdateFn          func(context.Context, Project) error
 	DeleteFn          func(context.Context, string) error
@@ -712,14 +721,14 @@ func (m *mockProjectsStore) Create(ctx context.Context, project Project) error {
 func (m *mockProjectsStore) List(
 	ctx context.Context,
 	opts meta.ListOptions,
-) (ProjectList, error) {
+) (meta.List[Project], error) {
 	return m.ListFn(ctx, opts)
 }
 
 func (m *mockProjectsStore) ListSubscribers(
 	ctx context.Context,
 	event Event,
-) (ProjectList, error) {
+) (meta.List[Project], error) {
 	return m.ListSubscribersFn(ctx, event)
 }
 

--- a/v2/apiserver/internal/api/projects_test.go
+++ b/v2/apiserver/internal/api/projects_test.go
@@ -14,68 +14,6 @@ func TestProjectMarshalJSON(t *testing.T) {
 	metaTesting.RequireAPIVersionAndType(t, &Project{}, ProjectKind)
 }
 
-func TestProjectListMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(t, &ProjectList{}, "ProjectList")
-}
-
-func TestProjectListContains(t *testing.T) {
-	testProject := Project{
-		ObjectMeta: meta.ObjectMeta{
-			ID: "myproject",
-		},
-		Kubernetes: &KubernetesDetails{
-			Namespace: "mynamespace",
-		},
-	}
-
-	t.Run("empty list", func(t *testing.T) {
-		projectList := ProjectList{}
-		require.False(t, projectList.Contains(testProject))
-	})
-
-	t.Run("project not in list", func(t *testing.T) {
-		projectList := ProjectList{
-			Items: []Project{
-				{
-					ObjectMeta: meta.ObjectMeta{
-						ID: "diffproject",
-					},
-				},
-			},
-		}
-		require.False(t, projectList.Contains(testProject))
-	})
-
-	t.Run("name matches, namespace does not", func(t *testing.T) {
-		projectList := ProjectList{
-			Items: []Project{
-				{
-					ObjectMeta: meta.ObjectMeta{
-						ID: "myproject",
-					},
-				},
-			},
-		}
-		require.False(t, projectList.Contains(testProject))
-	})
-
-	t.Run("project matches", func(t *testing.T) {
-		projectList := ProjectList{
-			Items: []Project{
-				{
-					ObjectMeta: meta.ObjectMeta{
-						ID: "myproject",
-					},
-					Kubernetes: &KubernetesDetails{
-						Namespace: "mynamespace",
-					},
-				},
-			},
-		}
-		require.True(t, projectList.Contains(testProject))
-	})
-}
-
 func TestNewProjectsService(t *testing.T) {
 	projectsStore := &mockProjectsStore{}
 	eventsStore := &mockEventsStore{}

--- a/v2/apiserver/internal/api/role_assignments.go
+++ b/v2/apiserver/internal/api/role_assignments.go
@@ -53,32 +53,6 @@ func (r RoleAssignment) Matches(role Role, scope string) bool {
 		(r.Scope == scope || r.Scope == RoleScopeGlobal)
 }
 
-// RoleAssignmentList is an ordered and pageable list of system-level
-// RoleAssignments.
-type RoleAssignmentList struct {
-	// ListMeta contains list metadata.
-	meta.ListMeta `json:"metadata"`
-	// Items is a slice of RoleAssignments.
-	Items []RoleAssignment `json:"items,omitempty"`
-}
-
-// MarshalJSON amends RoleAssignmentList instances with type metadata.
-func (r RoleAssignmentList) MarshalJSON() ([]byte, error) {
-	type Alias RoleAssignmentList
-	return json.Marshal(
-		struct {
-			meta.TypeMeta `json:",inline"`
-			Alias         `json:",inline"`
-		}{
-			TypeMeta: meta.TypeMeta{
-				APIVersion: meta.APIVersion,
-				Kind:       RoleAssignmentListKind,
-			},
-			Alias: (Alias)(r),
-		},
-	)
-}
-
 // RoleAssignmentsSelector represents useful filter criteria when selecting
 // multiple RoleAssignments for API group operations like list.
 type RoleAssignmentsSelector struct {

--- a/v2/apiserver/internal/api/role_assignments.go
+++ b/v2/apiserver/internal/api/role_assignments.go
@@ -82,7 +82,7 @@ type RoleAssignmentsService interface {
 		context.Context,
 		RoleAssignmentsSelector,
 		meta.ListOptions,
-	) (RoleAssignmentList, error)
+	) (meta.List[RoleAssignment], error)
 
 	// Revoke revokes the Role specified by the RoleAssignment for the principal
 	// also specified by the RoleAssignment. If the specified principal does not
@@ -171,9 +171,9 @@ func (r *roleAssignmentsService) List(
 	ctx context.Context,
 	selector RoleAssignmentsSelector,
 	opts meta.ListOptions,
-) (RoleAssignmentList, error) {
+) (meta.List[RoleAssignment], error) {
 	if err := r.authorize(ctx, RoleReader, ""); err != nil {
-		return RoleAssignmentList{}, err
+		return meta.List[RoleAssignment]{}, err
 	}
 
 	if opts.Limit == 0 {
@@ -252,7 +252,7 @@ type RoleAssignmentsStore interface {
 		context.Context,
 		RoleAssignmentsSelector,
 		meta.ListOptions,
-	) (RoleAssignmentList, error)
+	) (meta.List[RoleAssignment], error)
 	// Revoke the role specified by the RoleAssignment for the principal specified
 	// by the RoleAssignment.
 	Revoke(context.Context, RoleAssignment) error

--- a/v2/apiserver/internal/api/role_assignments_test.go
+++ b/v2/apiserver/internal/api/role_assignments_test.go
@@ -241,8 +241,9 @@ func TestRoleAssignmentsServiceList(t *testing.T) {
 						context.Context,
 						RoleAssignmentsSelector,
 						meta.ListOptions,
-					) (RoleAssignmentList, error) {
-						return RoleAssignmentList{}, errors.New("something went wrong")
+					) (meta.List[RoleAssignment], error) {
+						return meta.List[RoleAssignment]{},
+							errors.New("something went wrong")
 					},
 				},
 			},
@@ -265,8 +266,8 @@ func TestRoleAssignmentsServiceList(t *testing.T) {
 						context.Context,
 						RoleAssignmentsSelector,
 						meta.ListOptions,
-					) (RoleAssignmentList, error) {
-						return RoleAssignmentList{}, nil
+					) (meta.List[RoleAssignment], error) {
+						return meta.List[RoleAssignment]{}, nil
 					},
 				},
 			},
@@ -412,7 +413,7 @@ type mockRoleAssignmentsStore struct {
 		context.Context,
 		RoleAssignmentsSelector,
 		meta.ListOptions,
-	) (RoleAssignmentList, error)
+	) (meta.List[RoleAssignment], error)
 	RevokeFn            func(context.Context, RoleAssignment) error
 	RevokeByPrincipalFn func(context.Context, PrincipalReference) error
 	ExistsFn            func(context.Context, RoleAssignment) (bool, error)
@@ -429,7 +430,7 @@ func (m *mockRoleAssignmentsStore) List(
 	ctx context.Context,
 	selector RoleAssignmentsSelector,
 	opts meta.ListOptions,
-) (RoleAssignmentList, error) {
+) (meta.List[RoleAssignment], error) {
 	return m.ListFn(ctx, selector, opts)
 }
 

--- a/v2/apiserver/internal/api/role_assignments_test.go
+++ b/v2/apiserver/internal/api/role_assignments_test.go
@@ -74,14 +74,6 @@ func TestMatches(t *testing.T) {
 	}
 }
 
-func TestRoleAssignmentListMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(
-		t,
-		&RoleAssignmentList{},
-		RoleAssignmentListKind,
-	)
-}
-
 func TestNewRoleAssignmentsService(t *testing.T) {
 	usersStore := &mockUsersStore{}
 	serviceAccountsStore := &mockServiceAccountStore{}

--- a/v2/apiserver/internal/api/secrets.go
+++ b/v2/apiserver/internal/api/secrets.go
@@ -16,6 +16,10 @@ type Secret struct {
 	Value string `json:"value,omitempty"`
 }
 
+func (s Secret) Less(other Secret) bool {
+	return s.Key < other.Key
+}
+
 // MarshalJSON amends Secret instances with type metadata.
 func (s Secret) MarshalJSON() ([]byte, error) {
 	type Alias Secret
@@ -45,7 +49,7 @@ type SecretsService interface {
 		ctx context.Context,
 		projectID string,
 		opts meta.ListOptions,
-	) (SecretList, error)
+	) (meta.List[Secret], error)
 	// Set sets the value of a new Secret or updates the value of an existing
 	// Secret. If the specified Project does not exist, implementations MUST
 	// return a *meta.ErrNotFound error. If the specified Key does not exist, it
@@ -88,12 +92,12 @@ func (s *secretsService) List(
 	ctx context.Context,
 	projectID string,
 	opts meta.ListOptions,
-) (SecretList, error) {
+) (meta.List[Secret], error) {
 	if err := s.authorize(ctx, RoleReader, ""); err != nil {
-		return SecretList{}, err
+		return meta.List[Secret]{}, err
 	}
 
-	secrets := SecretList{}
+	secrets := meta.List[Secret]{}
 	project, err := s.projectsStore.Get(ctx, projectID)
 	if err != nil {
 		return secrets, errors.Wrapf(
@@ -181,7 +185,7 @@ type SecretsStore interface {
 	List(ctx context.Context,
 		project Project,
 		opts meta.ListOptions,
-	) (SecretList, error)
+	) (meta.List[Secret], error)
 	// Set adds or updates the provided Secret associated with the specified
 	// Project.
 	Set(ctx context.Context, project Project, secret Secret) error

--- a/v2/apiserver/internal/api/secrets.go
+++ b/v2/apiserver/internal/api/secrets.go
@@ -8,50 +8,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// SecretList is an ordered and pageable list of Secrets.
-type SecretList struct {
-	// ListMeta contains list metadata.
-	meta.ListMeta `json:"metadata"`
-	// Items is a slice of Secrets.
-	Items []Secret `json:"items,omitempty"`
-}
-
-// All of the following functions are implemented on the SecretsList type to
-// facilitate sorting by each constituent Secret's Key field.
-
-// Len returns the cardinality of the underlying Items field.
-func (s SecretList) Len() int {
-	return len(s.Items)
-}
-
-// Swap swaps Secret i and Secret j in the underlying Items field.
-func (s SecretList) Swap(i, j int) {
-	s.Items[i], s.Items[j] = s.Items[j], s.Items[i]
-}
-
-// Less returns true when Secret i's Key field is less than Secret j's Key field
-// in the underlying Items field (when compared lexically).
-func (s SecretList) Less(i, j int) bool {
-	return s.Items[i].Key < s.Items[j].Key
-}
-
-// MarshalJSON amends SecretList instances with type metadata.
-func (s SecretList) MarshalJSON() ([]byte, error) {
-	type Alias SecretList
-	return json.Marshal(
-		struct {
-			meta.TypeMeta `json:",inline"`
-			Alias         `json:",inline"`
-		}{
-			TypeMeta: meta.TypeMeta{
-				APIVersion: meta.APIVersion,
-				Kind:       "SecretList",
-			},
-			Alias: (Alias)(s),
-		},
-	)
-}
-
 // Secret represents Project-level sensitive information.
 type Secret struct {
 	// Key is a key by which the secret can referred.

--- a/v2/apiserver/internal/api/secrets.go
+++ b/v2/apiserver/internal/api/secrets.go
@@ -16,10 +16,6 @@ type Secret struct {
 	Value string `json:"value,omitempty"`
 }
 
-func (s Secret) Less(other Secret) bool {
-	return s.Key < other.Key
-}
-
 // MarshalJSON amends Secret instances with type metadata.
 func (s Secret) MarshalJSON() ([]byte, error) {
 	type Alias Secret

--- a/v2/apiserver/internal/api/secrets_test.go
+++ b/v2/apiserver/internal/api/secrets_test.go
@@ -14,65 +14,6 @@ func TestSecretMarshalJSON(t *testing.T) {
 	metaTesting.RequireAPIVersionAndType(t, &Secret{}, "Secret")
 }
 
-func TestSecretListMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(t, &SecretList{}, "SecretList")
-}
-
-func TestSecretListLen(t *testing.T) {
-	secretList := SecretList{
-		Items: []Secret{
-			{
-				Key:   "foo",
-				Value: "bar",
-			},
-			{
-				Key:   "bat",
-				Value: "baz",
-			},
-		},
-	}
-	require.Equal(t, len(secretList.Items), secretList.Len())
-}
-
-func TestSecretListSwap(t *testing.T) {
-	testSecret0 := Secret{
-		Key:   "foo",
-		Value: "bar",
-	}
-	testSecret1 := Secret{
-		Key:   "bat",
-		Value: "baz",
-	}
-	secretList := SecretList{
-		Items: []Secret{testSecret0, testSecret1},
-	}
-	secretList.Swap(0, 1)
-	require.Equal(
-		t,
-		[]Secret{testSecret1, testSecret0},
-		secretList.Items,
-	)
-}
-
-func TestSecretListLess(t *testing.T) {
-	secretList := SecretList{
-		Items: []Secret{
-			{
-				Key:   "foo",
-				Value: "bar",
-			},
-			{
-				Key:   "bat",
-				Value: "baz",
-			},
-		},
-	}
-	require.False(t, secretList.Less(0, 0))
-	require.False(t, secretList.Less(0, 1))
-	require.True(t, secretList.Less(1, 0))
-	require.False(t, secretList.Less(1, 1))
-}
-
 func TestNewSecretsService(t *testing.T) {
 	projectsStore := &mockProjectsStore{}
 	secretsStore := &mockSecretsStore{}
@@ -136,8 +77,8 @@ func TestSecretsServiceList(t *testing.T) {
 						context.Context,
 						Project,
 						meta.ListOptions,
-					) (SecretList, error) {
-						return SecretList{}, errors.New("something went wrong")
+					) (meta.List[Secret], error) {
+						return meta.List[Secret]{}, errors.New("something went wrong")
 					},
 				},
 			},
@@ -161,8 +102,8 @@ func TestSecretsServiceList(t *testing.T) {
 						context.Context,
 						Project,
 						meta.ListOptions,
-					) (SecretList, error) {
-						return SecretList{}, nil
+					) (meta.List[Secret], error) {
+						return meta.List[Secret]{}, nil
 					},
 				},
 			},
@@ -355,7 +296,11 @@ func TestSecretsServiceUnSet(t *testing.T) {
 }
 
 type mockSecretsStore struct {
-	ListFn  func(context.Context, Project, meta.ListOptions) (SecretList, error)
+	ListFn func(
+		context.Context,
+		Project,
+		meta.ListOptions,
+	) (meta.List[Secret], error)
 	SetFn   func(context.Context, Project, Secret) error
 	UnsetFn func(context.Context, Project, string) error
 }
@@ -364,7 +309,7 @@ func (m *mockSecretsStore) List(
 	ctx context.Context,
 	project Project,
 	opts meta.ListOptions,
-) (SecretList, error) {
+) (meta.List[Secret], error) {
 	return m.ListFn(ctx, project, opts)
 }
 

--- a/v2/apiserver/internal/api/service_accounts.go
+++ b/v2/apiserver/internal/api/service_accounts.go
@@ -56,7 +56,7 @@ type ServiceAccountsService interface {
 	// already exists, implementations MUST return a *meta.ErrConflict error.
 	Create(context.Context, ServiceAccount) (Token, error)
 	// List retrieves a ServiceAccountList.
-	List(context.Context, meta.ListOptions) (ServiceAccountList, error)
+	List(context.Context, meta.ListOptions) (meta.List[ServiceAccount], error)
 	// Get retrieves a single ServiceAccount specified by its identifier. If the
 	// specified ServiceAccount does not exist, implementations MUST return a
 	// *meta.ErrNotFound error.
@@ -130,9 +130,9 @@ func (s *serviceAccountsService) Create(
 func (s *serviceAccountsService) List(
 	ctx context.Context,
 	opts meta.ListOptions,
-) (ServiceAccountList, error) {
+) (meta.List[ServiceAccount], error) {
 	if err := s.authorize(ctx, RoleReader, ""); err != nil {
-		return ServiceAccountList{}, err
+		return meta.List[ServiceAccount]{}, err
 	}
 
 	if opts.Limit == 0 {
@@ -269,7 +269,7 @@ type ServiceAccountsStore interface {
 	Create(context.Context, ServiceAccount) error
 	// List retrieves a ServiceAccountList from the underlying data store, with
 	// its Items (ServiceAccounts) ordered by ID.
-	List(context.Context, meta.ListOptions) (ServiceAccountList, error)
+	List(context.Context, meta.ListOptions) (meta.List[ServiceAccount], error)
 	// Get retrieves a single ServiceAccount from the underlying data store. If
 	// the specified ServiceAccount does not exist, implementations MUST return
 	// a *meta.ErrNotFound error.

--- a/v2/apiserver/internal/api/service_accounts.go
+++ b/v2/apiserver/internal/api/service_accounts.go
@@ -47,31 +47,6 @@ func (s ServiceAccount) MarshalJSON() ([]byte, error) {
 	)
 }
 
-// ServiceAccountList is an ordered and pageable list of ServiceAccounts.
-type ServiceAccountList struct {
-	// ListMeta contains list metadata.
-	meta.ListMeta `json:"metadata"`
-	// Items is a slice of ServiceAccounts.
-	Items []ServiceAccount `json:"items,omitempty"`
-}
-
-// MarshalJSON amends ServiceAccountList instances with type metadata.
-func (s ServiceAccountList) MarshalJSON() ([]byte, error) {
-	type Alias ServiceAccountList
-	return json.Marshal(
-		struct {
-			meta.TypeMeta `json:",inline"`
-			Alias         `json:",inline"`
-		}{
-			TypeMeta: meta.TypeMeta{
-				APIVersion: meta.APIVersion,
-				Kind:       "ServiceAccountList",
-			},
-			Alias: (Alias)(s),
-		},
-	)
-}
-
 // ServiceAccountsService is the specialized interface for managing
 // ServiceAccounts. It's decoupled from underlying technology choices (e.g. data
 // store) to keep business logic reusable and consistent while the underlying

--- a/v2/apiserver/internal/api/service_accounts_test.go
+++ b/v2/apiserver/internal/api/service_accounts_test.go
@@ -108,8 +108,8 @@ func TestServiceAccountsServiceList(t *testing.T) {
 					ListFn: func(
 						context.Context,
 						meta.ListOptions,
-					) (ServiceAccountList, error) {
-						return ServiceAccountList{},
+					) (meta.List[ServiceAccount], error) {
+						return meta.List[ServiceAccount]{},
 							errors.New("error listing service accounts")
 					},
 				},
@@ -132,8 +132,8 @@ func TestServiceAccountsServiceList(t *testing.T) {
 					ListFn: func(
 						context.Context,
 						meta.ListOptions,
-					) (ServiceAccountList, error) {
-						return ServiceAccountList{}, nil
+					) (meta.List[ServiceAccount], error) {
+						return meta.List[ServiceAccount]{}, nil
 					},
 				},
 			},
@@ -496,7 +496,7 @@ type mockServiceAccountStore struct {
 	ListFn   func(
 		context.Context,
 		meta.ListOptions,
-	) (ServiceAccountList, error)
+	) (meta.List[ServiceAccount], error)
 	GetFn              func(context.Context, string) (ServiceAccount, error)
 	GetByHashedTokenFn func(context.Context, string) (ServiceAccount, error)
 	LockFn             func(context.Context, string) error
@@ -518,7 +518,7 @@ func (m *mockServiceAccountStore) Create(
 func (m *mockServiceAccountStore) List(
 	ctx context.Context,
 	opts meta.ListOptions,
-) (ServiceAccountList, error) {
+) (meta.List[ServiceAccount], error) {
 	return m.ListFn(ctx, opts)
 }
 

--- a/v2/apiserver/internal/api/service_accounts_test.go
+++ b/v2/apiserver/internal/api/service_accounts_test.go
@@ -14,14 +14,6 @@ func TestServiceAccountMarshalJSON(t *testing.T) {
 	metaTesting.RequireAPIVersionAndType(t, ServiceAccount{}, "ServiceAccount")
 }
 
-func TestServiceAccountListMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(
-		t,
-		ServiceAccountList{},
-		"ServiceAccountList",
-	)
-}
-
 func TestNewServiceAccountService(t *testing.T) {
 	serviceAccountsStore := &mockServiceAccountStore{}
 	roleAssignmentsStore := &mockRoleAssignmentsStore{}

--- a/v2/apiserver/internal/api/users.go
+++ b/v2/apiserver/internal/api/users.go
@@ -54,7 +54,7 @@ type UsersServiceConfig struct {
 // change.
 type UsersService interface {
 	// List returns a UserList.
-	List(context.Context, meta.ListOptions) (UserList, error)
+	List(context.Context, meta.ListOptions) (meta.List[User], error)
 	// Get retrieves a single User specified by their identifier.
 	Get(context.Context, string) (User, error)
 
@@ -101,13 +101,13 @@ func NewUsersService(
 func (u *usersService) List(
 	ctx context.Context,
 	opts meta.ListOptions,
-) (UserList, error) {
+) (meta.List[User], error) {
 	if err := u.authorize(ctx, RoleReader, ""); err != nil {
-		return UserList{}, err
+		return meta.List[User]{}, err
 	}
 
 	if !u.config.ThirdPartyAuthEnabled {
-		return UserList{}, errUserManagementDisabled()
+		return meta.List[User]{}, errUserManagementDisabled()
 	}
 
 	if opts.Limit == 0 {
@@ -219,7 +219,7 @@ type UsersStore interface {
 	Create(context.Context, User) error
 	// List retrieves a UserList from the underlying data store, with its Items
 	// (Users) ordered by ID.
-	List(context.Context, meta.ListOptions) (UserList, error)
+	List(context.Context, meta.ListOptions) (meta.List[User], error)
 	// Get retrieves a single User from the underlying data store. Implementations
 	// MUST use a case insensitive query for this operation. If the specified User
 	// does not exist, implementations MUST return a *meta.ErrNotFound error.

--- a/v2/apiserver/internal/api/users.go
+++ b/v2/apiserver/internal/api/users.go
@@ -40,31 +40,6 @@ func (u User) MarshalJSON() ([]byte, error) {
 	)
 }
 
-// UserList is an ordered and pageable list of Users.
-type UserList struct {
-	// ListMeta contains list metadata.
-	meta.ListMeta `json:"metadata"`
-	// Items is a slice of Users.
-	Items []User `json:"items,omitempty"`
-}
-
-// MarshalJSON amends UserList instances with type metadata.
-func (u UserList) MarshalJSON() ([]byte, error) {
-	type Alias UserList
-	return json.Marshal(
-		struct {
-			meta.TypeMeta `json:",inline"`
-			Alias         `json:",inline"`
-		}{
-			TypeMeta: meta.TypeMeta{
-				APIVersion: meta.APIVersion,
-				Kind:       "UserList",
-			},
-			Alias: (Alias)(u),
-		},
-	)
-}
-
 // UsersServiceConfig encapsulates several configuration options for the
 // UsersService.
 type UsersServiceConfig struct {

--- a/v2/apiserver/internal/api/users_test.go
+++ b/v2/apiserver/internal/api/users_test.go
@@ -69,8 +69,11 @@ func TestUserServiceList(t *testing.T) {
 			service: &usersService{
 				authorize: alwaysAuthorize,
 				usersStore: &mockUsersStore{
-					ListFn: func(context.Context, meta.ListOptions) (UserList, error) {
-						return UserList{}, errors.New("error listing users")
+					ListFn: func(
+						context.Context,
+						meta.ListOptions,
+					) (meta.List[User], error) {
+						return meta.List[User]{}, errors.New("error listing users")
 					},
 				},
 				config: UsersServiceConfig{
@@ -88,8 +91,11 @@ func TestUserServiceList(t *testing.T) {
 			service: &usersService{
 				authorize: alwaysAuthorize,
 				usersStore: &mockUsersStore{
-					ListFn: func(context.Context, meta.ListOptions) (UserList, error) {
-						return UserList{}, nil
+					ListFn: func(
+						context.Context,
+						meta.ListOptions,
+					) (meta.List[User], error) {
+						return meta.List[User]{}, nil
 					},
 				},
 				config: UsersServiceConfig{
@@ -535,7 +541,7 @@ func TestUsersServiceDelete(t *testing.T) {
 
 type mockUsersStore struct {
 	CreateFn func(context.Context, User) error
-	ListFn   func(context.Context, meta.ListOptions) (UserList, error)
+	ListFn   func(context.Context, meta.ListOptions) (meta.List[User], error)
 	GetFn    func(context.Context, string) (User, error)
 	LockFn   func(context.Context, string) error
 	UnlockFn func(context.Context, string) error
@@ -549,7 +555,7 @@ func (m *mockUsersStore) Create(ctx context.Context, user User) error {
 func (m *mockUsersStore) List(
 	ctx context.Context,
 	opts meta.ListOptions,
-) (UserList, error) {
+) (meta.List[User], error) {
 	return m.ListFn(ctx, opts)
 }
 

--- a/v2/apiserver/internal/api/users_test.go
+++ b/v2/apiserver/internal/api/users_test.go
@@ -14,10 +14,6 @@ func TestUserMarshalJSON(t *testing.T) {
 	metaTesting.RequireAPIVersionAndType(t, User{}, "User")
 }
 
-func TestUserListMarshalJSON(t *testing.T) {
-	metaTesting.RequireAPIVersionAndType(t, UserList{}, "UserList")
-}
-
 func TestNewUsersService(t *testing.T) {
 	usersStore := &mockUsersStore{}
 	sessionsStore := &mockSessionsStore{}

--- a/v2/apiserver/internal/meta/list.go
+++ b/v2/apiserver/internal/meta/list.go
@@ -1,0 +1,53 @@
+package meta
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/brigadecore/brigade/sdk/v3/meta"
+)
+
+// List is a generic type that represents an ordered and pageable collection.
+type List[T any] struct {
+	// ListMeta contains list metadata.
+	ListMeta `json:"metadata"`
+	// Items is a slice of items of type T.
+	Items []T `json:"items,omitempty"`
+}
+
+// Len returns the length of the List's Items field.
+func (l List[T]) Len() int64 {
+	return int64(len(l.Items))
+}
+
+// Sort sorts the contents of a List's Items field. Because List is a generic
+// type and cannot know how to compare all types, this function takes a
+// comparison function as an argument. The comparison function MUST return an
+// int value < 0 when its first argument is less than the second argument, 0
+// when its first and second arguments are equal, and a in value > 0 when the
+// first argument is greater than the second.
+func (l List[T]) Sort(compare func(lhs, rhs T) int) {
+	sort.Slice(l.Items, func(i, j int) bool {
+		return compare(l.Items[i], l.Items[j]) < 0
+	})
+}
+
+func (l List[T]) MarshalJSON() ([]byte, error) {
+	kind := fmt.Sprintf("%sList", reflect.TypeOf(new(T)).Elem().Name())
+	return json.Marshal(
+		struct {
+			meta.TypeMeta `json:",inline"`
+			ListMeta      `json:"metadata"`
+			Items         []T `json:"items,omitempty"`
+		}{
+			TypeMeta: meta.TypeMeta{
+				APIVersion: meta.APIVersion,
+				Kind:       kind,
+			},
+			ListMeta: l.ListMeta,
+			Items:    l.Items,
+		},
+	)
+}

--- a/v2/apiserver/internal/meta/list_test.go
+++ b/v2/apiserver/internal/meta/list_test.go
@@ -1,0 +1,30 @@
+package meta
+
+import (
+	"testing"
+
+	metaTesting "github.com/brigadecore/brigade/v2/apiserver/internal/meta/testing" // nolint: lll
+	"github.com/stretchr/testify/require"
+)
+
+func TestListLen(t *testing.T) {
+	list := List[int]{
+		Items: []int{2, 3, 5, 1, 4},
+	}
+	require.Equal(t, int64(len(list.Items)), list.Len())
+}
+
+func TestListSort(t *testing.T) {
+	list := List[int]{
+		Items: []int{2, 3, 5, 1, 4},
+	}
+	list.Sort(func(lhs, rhs int) int {
+		return lhs - rhs
+	})
+	require.Equal(t, []int{1, 2, 3, 4, 5}, list.Items)
+}
+
+func TestListMarshalJSON(t *testing.T) {
+	type TestType struct{}
+	metaTesting.RequireAPIVersionAndType(t, List[TestType]{}, "TestTypeList")
+}


### PR DESCRIPTION
Follow up to #1808 

Starts to make use of generics.

This PR is decomposed into the following commits:

* Add generic list type
* Remove non-generic list types
* Transition all API server code from non-generic list types to the generic list type
* Resolving conflicts that arose after #1903 added new units tests

There are no functional changes in this PR.

Additionally, I've proactively commented in-line on the very, very few changes wherein the reason for them might not be immediately evident without explanation.
