### PR TITLE
Fix deleting a non-existing project tells you're unauthorized

### DIFF
--- a/v2/apiserver/internal/api/projects.go
+++ b/v2/apiserver/internal/api/projects.go
@@ -409,13 +409,13 @@ func (p *projectsService) Update(
 }
 
 func (p *projectsService) Delete(ctx context.Context, id string) error {
-	if err := p.projectAuthorize(ctx, id, RoleProjectAdmin); err != nil {
-		return err
-	}
-
 	project, err := p.projectsStore.Get(ctx, id)
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving project %q from store", id)
+	}
+
+	if err := p.projectAuthorize(ctx, id, RoleProjectAdmin); err != nil {
+		return err
 	}
 
 	// Delete all events associated with this project

--- a/v2/apiserver/internal/api/projects.go
+++ b/v2/apiserver/internal/api/projects.go
@@ -409,6 +409,10 @@ func (p *projectsService) Update(
 }
 
 func (p *projectsService) Delete(ctx context.Context, id string) error {
+	if err := p.authorize(ctx, RoleReader, ""); err != nil {
+		return err
+	}
+
 	project, err := p.projectsStore.Get(ctx, id)
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving project %q from store", id)

--- a/v2/apiserver/internal/api/projects_test.go
+++ b/v2/apiserver/internal/api/projects_test.go
@@ -474,9 +474,9 @@ func TestProjectServiceDelete(t *testing.T) {
 		assertions func(error)
 	}{
 		{
-			name: "unauthorized",
+			name: "read unauthorized",
 			service: &projectsService{
-				projectAuthorize: neverProjectAuthorize,
+				authorize: neverAuthorize,
 			},
 			assertions: func(err error) {
 				require.Error(t, err)
@@ -486,7 +486,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "error retrieving project from store",
 			service: &projectsService{
-				projectAuthorize: alwaysProjectAuthorize,
+				authorize: alwaysAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
 						return Project{}, errors.New("store error")
@@ -500,8 +500,25 @@ func TestProjectServiceDelete(t *testing.T) {
 			},
 		},
 		{
+			name: "project access unauthorized",
+			service: &projectsService{
+				authorize:        alwaysAuthorize,
+				projectAuthorize: neverProjectAuthorize,
+				projectsStore: &mockProjectsStore{
+					GetFn: func(ctx context.Context, s string) (Project, error) {
+						return Project{}, nil
+					},
+				},
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.IsType(t, &meta.ErrAuthorization{}, err)
+			},
+		},
+		{
 			name: "error deleting events associated with project",
 			service: &projectsService{
+				authorize:        alwaysAuthorize,
 				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
@@ -529,6 +546,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "error deleting project logs",
 			service: &projectsService{
+				authorize:        alwaysAuthorize,
 				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
@@ -570,6 +588,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "error deleting role assignments associated with project",
 			service: &projectsService{
+				authorize:        alwaysAuthorize,
 				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
@@ -611,6 +630,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "error deleting project from store",
 			service: &projectsService{
+				authorize:        alwaysAuthorize,
 				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
@@ -648,6 +668,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "error deleting project from substrate",
 			service: &projectsService{
+				authorize:        alwaysAuthorize,
 				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {
@@ -690,6 +711,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		{
 			name: "success",
 			service: &projectsService{
+				authorize:        alwaysAuthorize,
 				projectAuthorize: alwaysProjectAuthorize,
 				projectsStore: &mockProjectsStore{
 					GetFn: func(context.Context, string) (Project, error) {

--- a/v2/apiserver/internal/api/projects_test.go
+++ b/v2/apiserver/internal/api/projects_test.go
@@ -474,7 +474,7 @@ func TestProjectServiceDelete(t *testing.T) {
 		assertions func(error)
 	}{
 		{
-			name: "read unauthorized",
+			name: "user does not have read permissions",
 			service: &projectsService{
 				authorize: neverAuthorize,
 			},
@@ -500,7 +500,7 @@ func TestProjectServiceDelete(t *testing.T) {
 			},
 		},
 		{
-			name: "project access unauthorized",
+			name: "user is not a project admin",
 			service: &projectsService{
 				authorize:        alwaysAuthorize,
 				projectAuthorize: neverProjectAuthorize,


### PR DESCRIPTION
Signed-off-by: Anurag Pathak <anuragpathak911@gmail.com>
Fixes #1750 

<!--
Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR (https://github.com/brigadecore/community/blob/main/contributing.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).

2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
-->

**What this PR does / why we need it**:
When a project delete request is sent, instead of directly checking for PROJECT_ADMIN role we'll now be checking if the project exists first so that we can avoid getting unauthorized error when the project doesn't exist.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
