### PR TITLE
update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,3 @@
 
 # Global Owners: These are brigadecore org maintainers
 * @brigadecore/maintainers
-
-# Doc Owners:
-/docs/ @brigadecore/docs-maintainers


### PR DESCRIPTION
The `docs-maintainers` team no longer exists.

It had only one member -- an MSFT tech writer who had volunteered to help and then disappeared.

I've been auditing membership in the org in order to preserve secrets if we soon start to add some private repos, so this individual was downgraded to an "outside collaborator."

We can explicitly call him out, individually, as an owner of the `docs/` directory if and when it becomes necessary.

For now, this team no longer exists and this PR updates `CODEOWNERS` accordingly.