### PR TITLE
ci: increase timeout on worker build job

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -356,7 +356,9 @@ jobs[publishSchedulerSBOMJobName] = publishSchedulerSBOMJob
 
 const buildWorkerJobName = "build-worker"
 const buildWorkerJob = (event: Event, version?: string) => {
-  return new BuildImageJob("worker", event, version)
+  const job = new BuildImageJob("worker", event, version)
+  job.timeoutSeconds = 30 * 60
+  return job
 }
 jobs[buildWorkerJobName] = buildWorkerJob
 


### PR DESCRIPTION
Frustratingly the multiarch worker image sometimes takes quite some time to build. I believe the arm64 emulation involved in the build process is mostly to blame.

This PR increases the timeout on the job that builds the worker.

In the future, I may consider doing all the dependency resolution only with the native architecture and only going multiarch in the final stage.

For now, this will unblock a 2.4.1 RC.