### PR TITLE
run first stage of worker build only on native architecture

### DIFF
--- a/v2/worker/Dockerfile
+++ b/v2/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.11.0-bullseye-slim as builder
+FROM --platform=$BUILDPLATFORM node:16.11.0-bullseye-slim as builder
 
 ARG VERSION
 


### PR DESCRIPTION
This runs the first stage of the worker build only on the native architecture, which should dramatically improve build time.