### PR TITLE
Fix setting secrets on a non-existing project tells you're unauthorized

### DIFF
--- a/v2/apiserver/internal/api/secrets.go
+++ b/v2/apiserver/internal/api/secrets.go
@@ -165,7 +165,7 @@ func (s *secretsService) Set(
 	projectID string,
 	secret Secret,
 ) error {
-	if err := s.projectAuthorize(ctx, projectID, RoleProjectAdmin); err != nil {
+	if err := s.authorize(ctx, RoleReader, ""); err != nil {
 		return err
 	}
 
@@ -177,6 +177,11 @@ func (s *secretsService) Set(
 			projectID,
 		)
 	}
+
+	if err := s.projectAuthorize(ctx, projectID, RoleProjectAdmin); err != nil {
+		return err
+	}
+
 	if err := s.secretsStore.Set(ctx, project, secret); err != nil {
 		return errors.Wrapf(
 			err,

--- a/v2/apiserver/internal/api/secrets_test.go
+++ b/v2/apiserver/internal/api/secrets_test.go
@@ -195,7 +195,7 @@ func TestSecretsServiceSet(t *testing.T) {
 		assertions func(error)
 	}{
 		{
-			name: "unauthorized",
+			name: "user does not have read permissions",
 			service: &secretsService{
 				authorize: neverAuthorize,
 			},


### PR DESCRIPTION
Signed-off-by: Anurag Pathak <anuragpathak911@gmail.com>
Fixes #1893 

<!--
Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR (https://github.com/brigadecore/community/blob/main/contributing.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).

2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
-->

**What this PR does / why we need it**:
While setting a secret, instead of directly checking for PROJECT_ADMIN role we'll now be checking if the user is a READER followed by checking if the project exists so that we can avoid getting unauthorized error when the project doesn't exist.
**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
