### PR TITLE
cli: add source and type filters to event list command

### DIFF
--- a/v2/cli/event_commands.go
+++ b/v2/cli/event_commands.go
@@ -311,6 +311,12 @@ var eventCommand = &cli.Command{
 					Usage: "If set, will retrieve events with their worker in RUNNING " +
 						"phase; mutually exclusive with --terminal and --non-terminal",
 				},
+				&cli.StringFlag{
+					Name:    flagSource,
+					Aliases: []string{"s"},
+					Usage: "If set, will retrieve events only from the specified " +
+						"source",
+				},
 				&cli.BoolFlag{
 					Name: flagStarting,
 					Usage: "If set, will retrieve events with their worker in a " +
@@ -333,6 +339,12 @@ var eventCommand = &cli.Command{
 					Usage: "If set, will retrieve events with their worker in a " +
 						"TIMED_OUT phase; mutually exclusive with --terminal and " +
 						"--non-terminal",
+				},
+				&cli.StringFlag{
+					Name:    flagType,
+					Aliases: []string{"t"},
+					Usage: "If set, will retrieve only events having the specified " +
+						"type",
 				},
 				&cli.BoolFlag{
 					Name: flagUnknown,


### PR DESCRIPTION
Fixes #1824

All that was needed was for the flags to be added to the command. Everything else was already in place.