### PR TITLE
support externally hosted mongodb

### DIFF
--- a/charts/brigade/Chart.yaml
+++ b/charts/brigade/Chart.yaml
@@ -15,3 +15,4 @@ dependencies:
 - name: mongodb
   version: 10.29.2
   repository: https://charts.bitnami.com/bitnami
+  condition: mongodb.enabled

--- a/charts/brigade/templates/NOTES.txt
+++ b/charts/brigade/templates/NOTES.txt
@@ -18,6 +18,7 @@ root user, run:
 
 {{- end }}
 
+{{- if .Values.mongodb.enabled }}
 To retrieve the root password for MongoDB, run:
 
   $ kubectl --namespace {{ .Release.Namespace }} get secret \
@@ -29,6 +30,8 @@ To retrieve the password for the {{ quote (index .Values.mongodb.auth.databases 
   $ kubectl --namespace {{ .Release.Namespace }} get secret \
       {{ include "call-nested" (list . "mongodb" "mongodb.fullname") }} \
       -o jsonpath={.data.mongodb-passwords} | base64 --decode
+
+{{- end }}
 
 To retrieve the auto-generated password for Artemis, run:
 

--- a/charts/brigade/templates/deployments.yaml
+++ b/charts/brigade/templates/deployments.yaml
@@ -138,6 +138,9 @@ metadata:
     {{- include "brigade.apiserver.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if not .Values.mongodb.enabled }}
+  database-connection-string: {{ .Values.externalMongodb.connectionString }}
+  {{- end }}
   {{- if .Values.apiserver.rootUser.enabled }}
   root-user-password: {{ $rootUserPassword }}
   {{- end }}
@@ -321,6 +324,7 @@ spec:
         - name: TLS_KEY_PATH
           value: /app/certs/tls.key
         {{- end }}
+        {{- if .Values.mongodb.enabled }}
         {{- if eq .Values.mongodb.architecture "replicaset" }}
         {{- $replicaCount := int .Values.mongodb.replicaCount }}
         {{- $fullname := include "call-nested" (list . "mongodb" "mongodb.fullname") }}
@@ -347,6 +351,15 @@ spec:
             secretKeyRef:
               name: {{ include "call-nested" (list . "mongodb" "mongodb.fullname") }}
               key: mongodb-passwords
+        {{- else }}
+        - name: DATABASE_CONNECTION_STRING
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "brigade.apiserver.fullname" . }}
+              key: database-connection-string
+        - name: DATABASE_NAME
+          value: {{ .Values.externalMongodb.databaseName }}
+        {{- end }}
         - name: AMQP_ADDRESS
           value: amqp://{{ include "brigade.artemis.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5672
         - name: AMQP_USERNAME

--- a/charts/brigade/templates/logger/secret.yaml
+++ b/charts/brigade/templates/logger/secret.yaml
@@ -90,6 +90,7 @@ stringData:
     <match worker job>
       @type mongo
 
+      {{- if .Values.mongodb.enabled }}
       {{- if eq .Values.mongodb.architecture "replicaset" }}
       {{- $replicaCount := int .Values.mongodb.replicaCount }}
       {{- $fullname := include "call-nested" (list . "mongodb" "mongodb.fullname") }}
@@ -104,6 +105,10 @@ stringData:
       database {{ index .Values.mongodb.auth.databases 0 }}
       user {{ index .Values.mongodb.auth.usernames 0 }}
       password {{ index .Values.mongodb.auth.passwords 0 }}
+      {{- else }}
+      connection_string {{ .Values.externalMongodb.connectionString }}
+      database {{ .Values.externalMongodb.databaseName }}
+      {{- end }}
 
       collection logs
 

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -395,6 +395,8 @@ logger:
       value: windows
 
 mongodb:
+  enabled: true
+
   ## Global Docker image parameters
   ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
   ## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -2073,6 +2073,16 @@ mongodb:
       ##
       rules: {}
 
+externalMongodb:
+  ## This connection string and database name are used to point the API server
+  ## and logger components to an external MongoDB database ONLY IF the included
+  ## MongoDB subchart is disabled. (Set mongodb.enabled to false.)
+  ##
+  ## The connection string should begin with mongodb:// and should contain
+  ## all relevant options -- username, password, replicaset, etc.
+  # connectionString: mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]
+  # databaseName: brigade
+
 artemis:
 
   ## It is recommended NOT to scale Artemis beyond a single node. While

--- a/v2/apiserver/config.go
+++ b/v2/apiserver/config.go
@@ -42,16 +42,16 @@ func databaseConnection(ctx context.Context) (*mongo.Database, error) {
 	if dbConnectionStr != "" {
 		dbClientOpts = options.Client().ApplyURI(dbConnectionStr)
 	} else {
-		hosts, err := os.GetRequiredEnvVar("DATABASE_HOSTS")
-		if err != nil {
+		var hosts string
+		if hosts, err = os.GetRequiredEnvVar("DATABASE_HOSTS"); err != nil {
 			return nil, err
 		}
-		username, err := os.GetRequiredEnvVar("DATABASE_USERNAME")
-		if err != nil {
+		var username string
+		if username, err = os.GetRequiredEnvVar("DATABASE_USERNAME"); err != nil {
 			return nil, err
 		}
-		password, err := os.GetRequiredEnvVar("DATABASE_PASSWORD")
-		if err != nil {
+		var password string
+		if password, err = os.GetRequiredEnvVar("DATABASE_PASSWORD"); err != nil {
 			return nil, err
 		}
 		replicaSetName := os.GetEnvVar("DATABASE_REPLICA_SET", "")

--- a/v2/apiserver/config_test.go
+++ b/v2/apiserver/config_test.go
@@ -30,8 +30,33 @@ func TestDatabaseConnection(t *testing.T) {
 		assertions func(*mongo.Database, error)
 	}{
 		{
-			name:  "DATABASE_HOSTS not set",
+			name:  "DATABASE_NAME not set",
 			setup: func() {},
+			assertions: func(_ *mongo.Database, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value not found for")
+				require.Contains(t, err.Error(), "DATABASE_NAME")
+			},
+		},
+		{
+			name: "DATABASE_CONNECTION_STRING set; success",
+			setup: func() {
+				t.Setenv(
+					"DATABASE_CONNECTION_STRING",
+					"mongodb://fake-connection-string",
+				)
+				t.Setenv("DATABASE_NAME", "brigade")
+			},
+			assertions: func(database *mongo.Database, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, database)
+			},
+		},
+		{
+			name: "DATABASE_CONNECTION_STRING not set; DATABASE_HOSTS not set",
+			setup: func() {
+				t.Setenv("DATABASE_CONNECTION_STRING", "")
+			},
 			assertions: func(_ *mongo.Database, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "value not found for")
@@ -39,7 +64,7 @@ func TestDatabaseConnection(t *testing.T) {
 			},
 		},
 		{
-			name: "DATABASE_USERNAME not set",
+			name: "DATABASE_CONNECTION_STRING not set; DATABASE_USERNAME not set",
 			setup: func() {
 				t.Setenv("DATABASE_HOSTS", "localhost")
 			},
@@ -50,7 +75,7 @@ func TestDatabaseConnection(t *testing.T) {
 			},
 		},
 		{
-			name: "DATABASE_PASSWORD not set",
+			name: "DATABASE_CONNECTION_STRING not set; DATABASE_PASSWORD not set",
 			setup: func() {
 				t.Setenv("DATABASE_USERNAME", "jarvis")
 			},
@@ -61,20 +86,9 @@ func TestDatabaseConnection(t *testing.T) {
 			},
 		},
 		{
-			name: "DATABASE_NAME not set",
-			setup: func() {
-				t.Setenv("DATABASE_PASSWORD", "yourenotironmaniam")
-			},
-			assertions: func(_ *mongo.Database, err error) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "value not found for")
-				require.Contains(t, err.Error(), "DATABASE_NAME")
-			},
-		},
-		{
 			name: "success",
 			setup: func() {
-				t.Setenv("DATABASE_NAME", "brigade")
+				t.Setenv("DATABASE_PASSWORD", "yourenotironmaniam")
 				t.Setenv("DATABASE_REPLICA_SET", "rs0")
 			},
 			assertions: func(database *mongo.Database, err error) {


### PR DESCRIPTION
Fixes #1876

cc @emilwangaa

__EDIT:__

I pre-built docker images so anyone can try this.

⚠️ You need to check out this branch because the chart itself has modifications.

```console
$ export DOCKER_ORG=krancour
$ export TAG=14ff4f1

$ export MONGODB_CONNECTION_STRING=mongodb://<whatever>
$ export MONGODB_DATABASE_NAME=<whatever>

$ helm dep up charts/brigade

$ kubectl create namespace brigade

$ helm install brigade charts/brigade \
    --namespace brigade \
    --set artemis.image.repository=$DOCKER_ORG/brigade2-artemis \
    --set artemis.image.tag=$TAG \
    --set apiserver.image.repository=$DOCKER_ORG/brigade2-apiserver \
    --set apiserver.image.tag=$TAG \
    --set scheduler.image.repository=$DOCKER_ORG/brigade2-scheduler \
    --set scheduler.image.tag=$TAG \
    --set observer.image.repository=$DOCKER_ORG/brigade2-observer \
    --set observer.image.tag=$TAG \
    --set worker.image.repository=$DOCKER_ORG/brigade2-worker \
    --set worker.image.tag=$TAG \
    --set gitInitializer.linux.image.repository=$DOCKER_ORG/brigade2-git-initializer \
    --set gitInitializer.linux.image.tag=$TAG \
    --set logger.linux.image.repository=$DOCKER_ORG/brigade2-logger\
    --set logger.linux.image.tag=$TAG \
    --set mongodb.enabled=false \
    --set externalMongodb.connectionString=$MONGODB_CONNECTION_STRING \
    --set externalMongodb.databaseName=$MONGODB_DATABASE_NAME
```