### PR TITLE
chart: don't share secrets across components

### DIFF
--- a/charts/brigade/templates/deployments.yaml
+++ b/charts/brigade/templates/deployments.yaml
@@ -141,6 +141,8 @@ stringData:
   {{- if .Values.apiserver.rootUser.enabled }}
   root-user-password: {{ $rootUserPassword }}
   {{- end }}
+  observer-api-token: {{ $observerAPIToken }}
+  scheduler-api-token: {{ $schedulerAPIToken }}
   {{- if eq .Values.apiserver.thirdPartyAuth.strategy "oidc" }}
   oidc-client-secret: {{ .Values.apiserver.thirdPartyAuth.oidc.clientSecret }}
   {{- end }}
@@ -306,13 +308,13 @@ spec:
         - name: SCHEDULER_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ include "brigade.scheduler.fullname" . }}
-              key: api-token
+              name: {{ include "brigade.apiserver.fullname" . }}
+              key: scheduler-api-token
         - name: OBSERVER_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ include "brigade.observer.fullname" . }}
-              key: api-token
+              name: {{ include "brigade.apiserver.fullname" . }}
+              key: observer-api-token
         - name: TLS_ENABLED
           value: {{ quote .Values.apiserver.tls.enabled }}
         {{- if .Values.apiserver.tls.enabled }}


### PR DESCRIPTION
This is a very minor and non-breaking chart change.

What it does is prevents the apiserver from having a dependencies on secrets that "owned" by the observer and the scheduler.

This isn't usually a problem, but #1910 will move us to using Tilt to facilitate a tighter, faster "inner-loop" during dev and Tilt has an interesting feature that k8s itself lacks -- the ability to understand dependencies between components in your microservice architecure. We can use this to improve devx a tiny bit further by preventing the apiserver from starting before the database and queue are ready, and we can likewise prevent the observer and scheduler from starting before the apiserver is ready.

If, however, the apiserver depends on secrets "owned" by the observer and scheduler, we create a dependency cycle.

This PR breaks that cycle.