### PR TITLE
Dockerfiles: cache go mods in their own layer

### DIFF
--- a/v2/apiserver/Dockerfile
+++ b/v2/apiserver/Dockerfile
@@ -9,10 +9,12 @@ ENV CGO_ENABLED=0
 WORKDIR /src
 COPY sdk/ sdk/
 WORKDIR /src/v2
-COPY v2/apiserver/ apiserver/
-COPY v2/internal/ internal/
 COPY v2/go.mod go.mod
 COPY v2/go.sum go.sum
+RUN go mod download
+COPY v2/apiserver/ apiserver/
+COPY v2/internal/ internal/
+
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -o ../bin/apiserver \
   -ldflags "-w -X github.com/brigadecore/brigade-foundations/version.version=$VERSION -X github.com/brigadecore/brigade-foundations/version.commit=$COMMIT" \

--- a/v2/git-initializer/Dockerfile
+++ b/v2/git-initializer/Dockerfile
@@ -9,10 +9,12 @@ ENV CGO_ENABLED=0
 WORKDIR /src
 COPY sdk/ sdk/
 WORKDIR /src/v2
-COPY v2/git-initializer/ git-initializer/
-COPY v2/internal/ internal/
 COPY v2/go.mod go.mod
 COPY v2/go.sum go.sum
+RUN go mod download
+COPY v2/git-initializer/ git-initializer/
+COPY v2/internal/ internal/
+
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -o ../bin/git-initializer \
   -ldflags "-w -X github.com/brigadecore/brigade-foundations/version.version=$VERSION -X github.com/brigadecore/brigade-foundations/version.commit=$COMMIT" \

--- a/v2/observer/Dockerfile
+++ b/v2/observer/Dockerfile
@@ -9,10 +9,12 @@ ENV CGO_ENABLED=0
 WORKDIR /src
 COPY sdk/ sdk/
 WORKDIR /src/v2
-COPY v2/observer/ observer/
-COPY v2/internal/ internal/
 COPY v2/go.mod go.mod
 COPY v2/go.sum go.sum
+RUN go mod download
+COPY v2/observer/ observer/
+COPY v2/internal/ internal/
+
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -o ../bin/observer \
   -ldflags "-w -X github.com/brigadecore/brigade-foundations/version.version=$VERSION -X github.com/brigadecore/brigade-foundations/version.commit=$COMMIT" \

--- a/v2/scheduler/Dockerfile
+++ b/v2/scheduler/Dockerfile
@@ -9,10 +9,12 @@ ENV CGO_ENABLED=0
 WORKDIR /src
 COPY sdk/ sdk/
 WORKDIR /src/v2
-COPY v2/scheduler/ scheduler/
-COPY v2/internal/ internal/
 COPY v2/go.mod go.mod
 COPY v2/go.sum go.sum
+RUN go mod download
+COPY v2/scheduler/ scheduler/
+COPY v2/internal/ internal/
+
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -o ../bin/scheduler \
   -ldflags "-w -X github.com/brigadecore/brigade-foundations/version.version=$VERSION -X github.com/brigadecore/brigade-foundations/version.commit=$COMMIT" \


### PR DESCRIPTION
This PR makes image builds that include binaries built with Go a little bit faster when they're done repeatedly (e.g. during dev). It does this by caching the results of dependency resolution in a separate layer of each image.