### PR TITLE
chart: add ability to hard-config API tokens at dev time

### DIFF
--- a/charts/brigade/templates/deployments.yaml
+++ b/charts/brigade/templates/deployments.yaml
@@ -75,21 +75,21 @@
 {{- $schedulerAPIToken := "" }}
 {{- $data := (lookup "v1" "Secret" .Release.Namespace (include "brigade.scheduler.fullname" . )).data }}
 {{- if $data }}
-  # Reuse the existing token
-  {{- $schedulerAPIToken = b64dec (index $data "api-token") }}
+  # Reuse the existing token unless the operator specified one
+  {{- $schedulerAPIToken = default (b64dec (index $data "api-token")) .Values.scheduler.apiToken }}
 {{- else }}
-  # Generate a new token
-  {{- $schedulerAPIToken = randAlphaNum 30 }}
+  # Generate a new token unless the operator specified one
+  {{- $schedulerAPIToken = default (randAlphaNum 30) .Values.scheduler.apiToken }}
 {{- end }}
 
 {{- $observerAPIToken := "" }}
 {{- $data = (lookup "v1" "Secret" .Release.Namespace (include "brigade.observer.fullname" . )).data }}
 {{- if $data }}
-  # Reuse the existing token
-  {{- $observerAPIToken = b64dec (index $data "api-token") }}
+  # Reuse the existing token unless the operator specified one
+  {{- $observerAPIToken = default (b64dec (index $data "api-token")) .Values.observer.apiToken }}
 {{- else }}
-  # Generate a new token
-  {{- $observerAPIToken = randAlphaNum 30 }}
+  # Generate a new token unless the operator specified one
+  {{- $observerAPIToken = default (randAlphaNum 30) .Values.observer.apiToken }}
 {{- end }}
 
 {{- $apiServerTLSCert := "" }}


### PR DESCRIPTION
A while ago, we introduced behavior in the chart where certain secret values are generated randomly on initial install, but on subsequent `helm upgrade` operations, existing values are retrieved and reused. This has led to a more stable upgrade process.

This falls apart, however, in cases where there's no cluster to connect to to find existing secrets _and_ you need the secrets to have stable, unchanging values. Namely this can happen when using Tilt (see #1910) at dev time since Tilt never does `helm install` or `helm upgrade`, but rather only does `helm template` and then applies the returned YAML.

i.e. We want this ability if we want to limit  unnecessary refreshes of components at dev time just because some token got a new random value every time the chart is rendered.

Note that I did NOT surface this as an option in the `values.yaml` file because no one should ever hardcode these _except_ to facilitate development.