### PR TITLE
Fallible jobs pt2

### DIFF
--- a/sdk/v3/jobs.go
+++ b/sdk/v3/jobs.go
@@ -143,6 +143,11 @@ type JobSpec struct {
 	// non-default operating system (i.e. Windows) or specific hardware (e.g. a
 	// GPU.)
 	Host *JobHost `json:"host,omitempty"`
+	// Fallible specifies whether the job is permitted to fail WITHOUT causing the
+	// worker process to fail. The API server does not use this field directly,
+	// but it is information that may be valuable to gateways that report job
+	// success/failure upstream to original event sources.
+	Fallible bool `json:"fallible"`
 }
 
 // JobContainerSpec amends the ContainerSpec type with additional Job-specific

--- a/sdk/v3/jobs.go
+++ b/sdk/v3/jobs.go
@@ -147,7 +147,11 @@ type JobSpec struct {
 	// worker process to fail. The API server does not use this field directly,
 	// but it is information that may be valuable to gateways that report job
 	// success/failure upstream to original event sources.
-	Fallible bool `json:"fallible"`
+	//
+	// Note that omitempty keeps this compatible with older API servers (whose
+	// schema-based validation will reject the unknown field) as long as it's not
+	// set to true.
+	Fallible bool `json:"fallible,omitempty"`
 }
 
 // JobContainerSpec amends the ContainerSpec type with additional Job-specific

--- a/v2/apiserver/internal/api/jobs.go
+++ b/v2/apiserver/internal/api/jobs.go
@@ -135,6 +135,11 @@ type JobSpec struct {
 	// non-default operating system (i.e. Windows) or specific hardware (e.g. a
 	// GPU.)
 	Host *JobHost `json:"host,omitempty" bson:"host,omitempty"`
+	// Fallible specifies whether the job is permitted to fail WITHOUT causing the
+	// worker process to fail. The API server does not use this field directly,
+	// but it is information that may be valuable to gateways that report job
+	// success/failure upstream to original event sources.
+	Fallible bool `json:"fallible" bson:"fallible"`
 }
 
 func (js JobSpec) EqualTo(js2 JobSpec) bool {

--- a/v2/apiserver/schemas/job.json
+++ b/v2/apiserver/schemas/job.json
@@ -128,6 +128,10 @@
 				},
 				"host": {
 					"$ref": "#/definitions/host"
+				},
+				"fallible": {
+					"type": "boolean",
+					"description": "Whether the job is permitted to fail without affecting the overall status of the worker"
 				}
 			}
 		}


### PR DESCRIPTION
Since #1772 we've allowed jobs to be marked as allowed to fail without impacting the overall success or failure of the worker.

Until now, the worker has kept this information to itself.

This is the first of a few related PRs that will get the worker to start sharing this information with the API server when it creates new jobs.

The API server won't do anything directly with this information, however, having this information available makes it possible to share with gateways that monitor event/job status and report that status upstream. For a perfect example, see https://github.com/brigadecore/brigade-github-gateway/issues/93