### PR TITLE
update CONTRIBUTING.md to point to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing Guide
 
-See our Brigade project [Contributing Guide](https://github.com/brigadecore/community/blob/main/contributing.md).
+See our Brigade project [Contributor Guide](https://docs.brigade.sh/topics/contributor-guide/).


### PR DESCRIPTION
I toyed with deleting this file completely and linking to the new docs from the `README.md`, but I believe the presence of a `CONTRIBUTING.md` file has become a _de facto_ convention.