### PR TITLE
Makefile: only include production dependencies in yarn audits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,13 +165,13 @@ yarn-audit:
 	$(JS_DOCKER_CMD) sh -c ' \
 		cd v2/brigadier && \
 		yarn install && \
-		yarn audit && \
+		yarn audit --groups dependencies && \
 		cd ../brigadier-polyfill && \
 		yarn install && \
-		yarn audit && \
+		yarn audit --groups dependencies && \
 		cd ../worker && \
 		yarn install && \
-		yarn audit \
+		yarn audit --groups dependencies \
 	'
 
 .PHONY: clean-js


### PR DESCRIPTION
Only production dependencies make it into the image, so I'm counting it as noise when `yarn audit` finds issues with dependencies that are only used during development.