### PR TITLE
add contributor ladder

### DIFF
--- a/docs/content/topics/contributor-guide/_index.md
+++ b/docs/content/topics/contributor-guide/_index.md
@@ -18,3 +18,4 @@ This guide is decomposed into the following, high-level topics:
 - [Signing Commits](signing)
 - [Hacking on Brigade](hacking)
 - [Releasing Brigade](releasing)
+- [Contributor Ladder](ladder)

--- a/docs/content/topics/contributor-guide/ladder.md
+++ b/docs/content/topics/contributor-guide/ladder.md
@@ -1,0 +1,159 @@
+---
+title: Contributor Ladder
+description: The Brigade contributor ladder
+section: contributor-guide
+weight: 5
+---
+
+This document outlines the different contributor roles within the Brigade
+Project, along with their accompanying responsibilities and privileges.
+Community members generally start at the first levels of the ladder and climb
+the ladder as their involvement in the Project grows. Project Maintainers and
+Core Maintainers are happy to do what they can to help anyone advance along the
+contributor ladder.
+
+> ⚠️&nbsp;&nbsp;Throughout this document, "project" (with a lowercase "p") is
+> used to denote individual software projects or source code repositories that
+> are related in some way to Brigade and owned by the
+> [@brigadecore](https://github.com/brigadecore) GitHub org. In contrast,
+> "Project" (with an uppercase "P") is used to denote the entire breadth of
+> Brigade as a "program" encompassing Brigade itself and _all_ related software
+> projects or source code repositories owned by the __@brigadecore__ org.
+
+## Community Participant
+
+__Community Participant__ is the _de facto_ role for any Brigade user who ceases
+to be anonymous and begins publicly interacting with the Brigade Community. Some
+ways to become a Community Participant include, but are not limited to,
+voluntarily:
+
+* Participating in Community discussions (e.g. on Slack)
+* Assisting other Community Participants
+* Opening or commenting on issues
+* Commenting on PRs
+* Trying out new releases
+* Attending Community events
+
+All Community Participants must adhere to the
+[CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
+
+## Contributor
+
+A __Contributor__ is a Community Participant who goes a step farther and
+contributes _directly_ to moving the Brigade Project forward in some fashion.
+All that is required to become a Contributor is to start contributing!
+_Contributions do not need not be code._ Some ways to contribute include, but
+are not limited to, voluntarily:
+
+* Opening PRs containing code, documentation, or other content
+  * Such contributions should adhere to our [Contributor Guide](./index.md)
+* Using knowledge of Brigade to substantially assist other Community
+  Participants
+* Publicly promoting the Brigade Project
+
+## Organization Member
+
+An __Organization Member__ is an established and trusted Contributor who
+contributes _regularly_ to the Brigade Project and has been granted membership
+by the Core Maintainers in the __@brigadecore__ GitHub org.
+
+An Organization Member must have:
+
+* Made _several_ contributions to the Project
+* Earned the trust of the Core Maintainers
+* A _demonstrated need_ for org membership
+  * Usually this will be because Core Maintainers have determined that the
+    individual requires (and is trusted with) elevated permissions _vis-à-vis_
+    one or more GitHub repositories belonging to the __@brigadecore__ GitHub
+    org.
+
+Privileges include:
+
+* CI processes that run automatically for their PRs
+* Authorizing CI processes to run for PRs from other Contributors
+
+## Project Maintainer
+
+Project Maintainers are established and trusted Contributors who are granted
+broad responsibility for one or more, but not all, projects owned by the
+__@brigadecore__ GitHub org. They are, generally, but not necessarily,
+Organization Members. Project Maintainers (along with Core Maintainers) have
+responsibility for ensuring the quality of code contributions by means of
+conducting (or delegating) thorough reviews of PRs.
+
+Project Maintainers must:
+
+* Have earned the trust of the Core Maintainers
+* Exercise sound judgement for the good of their project(s) and the Project,
+  independent of their employer's interests
+* Contribute regularly to their project(s)
+* Conduct PR reviews
+* Mentor other Contributors
+* Regularly participate in Community meetings
+
+Privileges include:
+
+* Publicly representing their respective project(s)
+* Having a vote in matters affecting project direction, including the election
+  of new Project Maintainers
+
+Becoming a Project Maintainer for a given project requires a formal nomination
+by one of that project's existing Maintainers _or_ a Core Maintainer. The
+project's existing Maintainers and Core Maintainers are all eligible to vote.
+Nominations and voting must occur publicly in an issue in the applicable GitHub
+repository. Polling must remain open for a period of no less than two weeks or
+until a simple majority is obtained.
+
+## Core Maintainer
+
+Core Maintainers are established Contributors who are granted broad and ultimate
+responsibility for the _entirety_ of the Brigade Project. This includes
+administrative access to all projects owned by the __@brigadecore__ GitHub org
+and administrative access to the org itself.
+
+Core Maintainers must:
+
+* Must have earned the trust of the existing Core Maintainers
+* Have made _extensive_ contributions to the Project
+* Posses deep technical knowledge of Brigade
+* Exercise sound judgement for the good the Project, independent of their
+  employer's interests
+* Contribute regularly to the Project
+* Conduct PR reviews
+* Mentor other Contributors
+* Regularly participate in Community meetings
+
+Privileges include:
+
+* Publicly representing the Brigade Project
+* Communicating with CNCF on behalf of the Project
+* Stewardship of Project secrets (passwords, keys, etc.)
+* Having a vote in matters affecting Project direction, including the election
+  of new Project Maintainers and Core Maintainers
+
+## Maintainer Emeritus
+
+__Maintainers Emeriti__ are individuals who have voluntarily stepped down from
+the Core Maintainer role or been honorably discharged from that role by fellow
+Core Maintainers due to inactivity or competing commitments. The Project owes a
+debt of gratitude to these individuals and their re-ascension of the contributor
+ladder may be fast-tracked if or when their routine contributions to the Project
+resume.
+
+## Involuntary Removal of Maintainers
+
+Involuntary removal/demotion of Project Maintainers or Core Maintainers may
+occur if such an individual is unable to meet their responsibilities, as
+described by this document.
+
+As a professional courtesy, any Project Maintainer or Core Maintainer that is
+the subject of potential involuntary removal will be asked first to step down
+voluntarily.
+
+The process for involuntary removal mirrors the process for Project Maintainer
+and Core Maintainer nominations and elections. The process must occur publicly
+in an issue of a applicable GitHub repository and polling must remain open for a
+period of no less than two weeks or until a simple majority of the eligible
+voters has been obtained. Any Project Maintainer or Core Maintainer that is
+the subject of potential involuntary removal is ineligible to vote in the matter
+of their removal.

--- a/docs/content/topics/contributor-guide/ladder.md
+++ b/docs/content/topics/contributor-guide/ladder.md
@@ -79,7 +79,8 @@ broad responsibility for one or more, but not all, projects owned by the
 __@brigadecore__ GitHub org. They are, generally, but not necessarily,
 Organization Members. Project Maintainers (along with Core Maintainers) have
 responsibility for ensuring the quality of code contributions by means of
-conducting (or delegating) thorough reviews of PRs.
+conducting (or delegating) thorough reviews of PRs. This role includes write
+and administrative access to applicable repositories.
 
 Project Maintainers must:
 
@@ -107,9 +108,9 @@ until a simple majority is obtained.
 ## Core Maintainer
 
 Core Maintainers are established Contributors who are granted broad and ultimate
-responsibility for the _entirety_ of the Brigade Project. This includes
-administrative access to all projects owned by the __@brigadecore__ GitHub org
-and administrative access to the org itself.
+responsibility for the _entirety_ of the Brigade Project. This role includes
+write and administrative access to all projects owned by the __@brigadecore__
+GitHub org and administrative access to the org itself.
 
 Core Maintainers must:
 
@@ -130,6 +131,14 @@ Privileges include:
 * Stewardship of Project secrets (passwords, keys, etc.)
 * Having a vote in matters affecting Project direction, including the election
   of new Project Maintainers and Core Maintainers
+
+Becoming a Core Maintainer requires a formal nomination
+by an existing Core Maintainer. All
+existing Core Maintainers are all eligible to vote.
+Nominations and voting must occur publicly in an issue in Brigade's
+[main GitHub repository](https://github.com/brigadecore/brigade). Polling must
+remain open for a period of no less than two weeks or until a simple majority is
+obtained.
 
 ## Maintainer Emeritus
 

--- a/docs/content/topics/contributor-guide/ladder.md
+++ b/docs/content/topics/contributor-guide/ladder.md
@@ -79,8 +79,7 @@ broad responsibility for one or more, but not all, projects owned by the
 __@brigadecore__ GitHub org. They are, generally, but not necessarily,
 Organization Members. Project Maintainers (along with Core Maintainers) have
 responsibility for ensuring the quality of code contributions by means of
-conducting (or delegating) thorough reviews of PRs. This role includes write
-and administrative access to applicable repositories.
+conducting (or delegating) thorough reviews of PRs.
 
 Project Maintainers must:
 
@@ -94,13 +93,14 @@ Project Maintainers must:
 
 Privileges include:
 
+* Write and administrative access to applicable repositories
 * Publicly representing their respective project(s)
 * Having a vote in matters affecting project direction, including the election
   of new Project Maintainers
 
 Becoming a Project Maintainer for a given project requires a formal nomination
 by one of that project's existing Maintainers _or_ a Core Maintainer. The
-project's existing Maintainers and Core Maintainers are all eligible to vote.
+project's existing Maintainers and Core Maintainers are eligible to vote.
 Nominations and voting must occur publicly in an issue in the applicable GitHub
 repository. Polling must remain open for a period of no less than two weeks or
 until a simple majority is obtained.
@@ -108,9 +108,7 @@ until a simple majority is obtained.
 ## Core Maintainer
 
 Core Maintainers are established Contributors who are granted broad and ultimate
-responsibility for the _entirety_ of the Brigade Project. This role includes
-write and administrative access to all projects owned by the __@brigadecore__
-GitHub org and administrative access to the org itself.
+responsibility for the _entirety_ of the Brigade Project.
 
 Core Maintainers must:
 
@@ -126,6 +124,8 @@ Core Maintainers must:
 
 Privileges include:
 
+* Write and administrative access to all Project repositories
+* Administrative access to the __@brigadecore__ org
 * Publicly representing the Brigade Project
 * Communicating with CNCF on behalf of the Project
 * Stewardship of Project secrets (passwords, keys, etc.)


### PR DESCRIPTION
This new contributor ladder tentatively expands, revises, and replaces https://github.com/brigadecore/community/blob/main/governance.md

This is based heavily on work @carolynvs has done in TAG Contributor Strategy, and revised a good deal to suit the needs of the project.

Note that it was a deliberate choice to refrain from quantifying phrases like "several contributions" or "regularly contributing." I felt that at this stage of the project, leaving these subjective gives the project maintainers and core maintainers greater latitude and discretion in moving contributors up and down the ladder. There is no reason that cannot be revised in the future as the community grows and its needs change.

If this is somewhat lacking on details relating to code review processes, that is because those details will be covered in a separate doc, again, based on some of @carolynvs' excellent work in TAG Contributor Strategy.

In addition to @vdice, I would be eager for feedback on this PR from @carolynvs and @karenhchu.