### PR TITLE
feature: support basic auth for private repos

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -440,6 +440,7 @@ const testIntegrationJob = (event: Event) => {
   const env = {
     "CGO_ENABLED": "0",
     "BRIGADE_CI_PRIVATE_REPO_SSH_KEY": secrets.privateRepoSSHKey,
+    "BRIGADE_CI_PRIVATE_REPO_PAT": secrets.privateRepoPersonalAccessToken,
     "IMAGE_PULL_POLICY": "IfNotPresent",
     // Use the Docker daemon that's running in a sidecar
     "DOCKER_HOST": "localhost:2375"

--- a/docs/content/topics/project-developers/projects.md
+++ b/docs/content/topics/project-developers/projects.md
@@ -175,7 +175,7 @@ To list secrets for a project:
 $ brig project secret list --project <project id>
 ```
 
-The above command will display all keys, but will redacted values.
+The above command will display all keys, but with redacted values.
 
 To delete a secret, use:
 

--- a/docs/content/topics/project-developers/projects.md
+++ b/docs/content/topics/project-developers/projects.md
@@ -9,51 +9,16 @@ aliases:
   - /topics/project-developers/projects.md
 ---
 
-In Brigade, a project is a conceptual grouping of event subscriptions paired
-with logic expressing how to handle those events.
-
+Brigade projects pair event subscriptions with scripted event-handling logic.
 This document explains how to create and manage projects in Brigade.
 
-## An Introduction to Projects
+## Defining a Project
 
-Brigade projects provide the necessary context for executing Brigade scripts.
-In addition to event subscriptions, they also specify the configuration of the
-worker in charge of running the event handler logic.
+A project definition is represented as YAML or JSON, and may look familiar to
+users who have dealt with Kubernetes manifests, although Brigade project
+definitions are _not_ Kubernetes manifests.
 
-Often times, a Brigade Project will point to an external VCS repository, in
-which case this configuration will also be a part of the project definition.
-The purpose of this feature is to make it easy to inject source code from a
-repository into a Brigade pipeline, and do so in a way that meets standard
-expectations about file versioning and storage.
-
-Because GitHub is massively popular with open source developers, we chose to
-focus on GitHub as a first experience. However, this document explains how to
-work with other Git services, and how to extend Brigade to work with other VCS
-systems.
-
-## Creating and Managing a Project
-
-Before we can create a Brigade project, we need to define the project itself.
-We will discuss the project definition file and then explore how to create and
-manage a project from on a given definition file.  If you'd like to skip ahead
-and learn how to streamline project creation via the `brig init` command,
-proceed to the [brig init section] below.
-
-[brig init section]: #brig-init
-
-### Project definition files
-
-Brigade project definition files are represented in YAML or JSON and follow a
-schema that will look familiar to users who have dealt with Kubernetes
-manifests - however, they are their own entities and are only understood by
-Brigade and the brig CLI.
-
-This approach allows users of Brigade to persist project configuration in a VCS
-of their choice.  Updating a pre-existing project is as easy as supplying the
-updated configuration to the corresponding brig command.
-
-As an example, let's look at a project definition expressed in YAML and break
-it down into its main sections:
+A typical project definition might resemble this example:
 
 ```yaml
 apiVersion: brigade.sh/v2
@@ -79,206 +44,209 @@ spec:
         events.process();
 ```
 
-There are three high-level sections in the definition above.  They are:
+Some of the most notable features of this definition include:
 
-  1. Project metadata, including:
-    i. The `apiVersion` of the schema for this project
-    ii. The schema `kind`, which will always be `Project`
-    iii. The `id`, or name, of the Project
-    iv. A `description` of the project
-  2. The `eventSubscriptions` configuration, which contains one event source
-    (`brigade.sh/cli`) and one type under that source (`exec`). This particular
-    configuration corresponds to events that arise from `brig event create`
-    commands.
-  3. The `workerTemplate`, which represents the configuration for the worker in
-    charge of running the script associated with this project. This particular
-    configuration has `logLevel` set to `DEBUG` and the `brigade.js` script for
-    this project defined in-line under `defaultConfigFiles`. We'll discuss
-    similar scripts in more detail in the [Scripting Guide], but for now we see
-    that this script imports the `events` object from the brigadier library and
-    declares an event handler for the event source/type combination mentioned
-    above.  In response to such events, it prints "Hello, World!" to the
-    console.
+  * The `metadata.id` field, which includes a project name that must be unique
+    to your instance of Brigade.
+  * A `description` of the project.
+  * The `spec.eventSubscriptions` configuration, which describes all the events
+    the project subscribes to. This particular configuration subscribes to
+    events that are created manually from the `brig` CLI.
+  * The `spec.workerTemplate` configuration, which describes the container the
+    project will launch to handle any events to which it has subscribed. This
+    particular configuration includes a `brigade.js` script _in-line_ in the
+    `defaultConfigFiles` section and does little more than print "Hello, World!"
+    to `stdout` when handling an event originating from the CLI. We'll discuss
+    scripting in more detail in the [Scripting Guide].
 
-For further examples of project definition files to help you get started, see
-the [examples directory].  Each example sub-directory will have a
-`project.yaml` file - this is the project definition file with configuration to
-that specific project.
+Writing a script in-line, as in the example above is convenient for very simple
+scripts such as this one, but in practical usage can become unwieldy quickly due
+to the absence of proper syntax highlighting, for instance, so it is more common
+for a `workerTemplate` to reference a git repository where a script can be
+found, as in this example:
 
-[examples directory]: ./examples
-[Scripting Guide]: /topics/scripting
-
-### Brig init
-
-To quickly bootstrap a new project, Brigade offers the `brig init` command. It
-will generate a new project definition file based on the options provided,
-which can then be used to create the project in Brigade.
-
-For example, to initialize a project named `myproject` with default settings,
-which includes TypeScript as the scripting language and no git configuration,
-run the following:
-
-```shell
-$ brig init --id myproject
-```
-
-Or, if the alternate scripting language option of JavaScript is preferred, run:
-
-```shell
-$ brig init --id myproject --language js
-```
-
-If the project is git-based, supply the git repository name where the Brigade
-script for this project will reside:
-
-```shell
-$ brig init --id myproject --git https://github.com/<org>/<repo>.git
-```
-
-A few assets will be created in the directory in which the command is run.
-The bulk of the generated files can be found in the `.brigade/` directory,
-including the project definition file (`project.yaml`), a secrets file
-(`secrets.yaml`) and a `NOTES.txt` file with next steps.  Additionally, a
-`.gitignore` file is created (or amended, if it already exists) to ensure that
-the secrets file and script dependencies are not tracked in version control.
-
-### The `brig project create` Command
-
-With a project definition file in hand, you're now ready to create the project
-with brig. For purposes of demonstration, let's say the `project.yaml` file
-exists in the same directory as the command being run:
-
-```shell
-$ brig project create --file project.yaml
-```
-
-This command will submit the project definition to Brigade's API server. After
-validating that the definition adheres to the project schema, Brigade will
-persist the project on the substrate (in the form of a unique namespace) and in
-the backing database.
-
-### Update a project
-
-You can update a project at any time with the following command:
-
-```shell
-$ brig project update --file project.yaml
-```
-
-### Delete a project
-
-To delete a project, run:
-
-```shell
-$ brig project delete --id myproject
-```
-
-### Listing and inspecting projects with `brig`
-
-You can list all projects via:
-
-```shell
-$ brig project list
-```
-
-You can also directly inspect your project with `brig project get`. To see the
-full project definition, add `--output [yaml|json]`:
-
-```shell
-$ brig project get --id myproject --output yaml
-```
-
-### Additional project management commands
-
-To manage project secrets, the `brig project secret` suite of commands can be
-used. For example, to set secrets for a project via a secrets file, run:
-
-```shell
-$ brig project secret set --file secrets.yaml
-```
-
-To explore different ways to manage secrets in Brigade, see the [Secrets] doc.
-
-To manage roles for a project, see the `brig project roles` suite of commands.
-Roles can be created, listed and revoked. For an overview on roles and
-authorization in general, see the [Authorization] doc.
-
-[Secrets]: /topics/project-developers/secrets
-[Authorization]: /topics/administrators/authorization
-
-## Project namespaces
-
-Brigade creates a unique namespace on the underlying substrate (Kubernetes)
-corresponding to each project. Although most users shouldn't have a need to
-inspect resources under a project namespace on the substrate, to see which
-unique namespace a project is assigned, run the `brig project get` command and
-note the `kubernetes.namespace` value.  For example:
-
-```plain
-$ brig project get --id hello-world --output yaml
-
+```yaml
 apiVersion: brigade.sh/v2
-description: The simplest possible example
 kind: Project
-kubernetes:
-  namespace: brigade-97cd352f-90e1-48d0-8797-4f7867a72bd3
 metadata:
-  created: "2021-08-11T17:47:07.555Z"
   id: hello-world
+description: Demonstrates responding to an event with brigadier
 spec:
   eventSubscriptions:
   - source: brigade.sh/cli
     types:
     - exec
   workerTemplate:
-    defaultConfigFiles:
-      brigade.js: |
-        console.log("Hello, World!");
     logLevel: DEBUG
-    useWorkspace: false
+    git:
+      cloneURL: https://github.com/example/repo.git
 ```
 
-## Git-based projects
+> ⚠️&nbsp;&nbsp;Individual Brigade events, from certain sources (such as the
+> [GitHub gateway](https://github.com/brigadecore/brigade-github-gateway), for
+> instance), can override the project definition's `git.cloneURL` field or
+> supplement it by specifying a branch, tag, or commit (by SHA). This ability is
+> what makes Brigade capable of implementing CI/CD use cases.
 
-### Using SSH Keys
+While it is entirely possible to create project definitions from scratch, it
+is often more convenient to use `brig init` to generate one for you, which you
+can then edit to suit your needs.
 
-You can use SSH keys and a `git+ssh` URL to secure a private repository.
+For further examples of project definitions to help you get started, see the [Examples](/topics/examples) section of the documentation.
 
-In this case, your project's `cloneURL` should be of the form
-`git@github.com:<org>/<repo>.git` and you will need to add the SSH
-_private key_ as a secret to the project with the key `gitSSHKey`.
+## Creating and Managing Projects
 
-For example, if project secrets are contained in a `secrets.yaml` file, the
-private key would be added like so:
+While Brigade project definitions are _not_ Kubernetes manifests and the Brigade
+projects they describe are _not_ Kubernetes resources, they can still be thought
+of in similar terms. In a Kubernetes cluster, a given resource doesn't exist
+until it has been defined by a manifest _and_ that manifest has been applied
+(uploaded) to the Kubernetes API server -- and so it is with Brigade projects. A
+project is _defined_ in a file and that definition must be uploaded to the
+Brigade API server in order to _create_ the project.
 
-```yaml
-gitSSHKey: |-
-  -----BEGIN RSA PRIVATE KEY-----
-  IIEpAIBAAKCAg1wyZD164xNLrANjRrcsbieLwHJ6fKD3LC19E...
-  ...
-  ...
-  -----END RSA PRIVATE KEY-----
-```
-
-The project secrets can then be updated via the usual brig command:
+With a project definition file in hand -- `project.yaml` in this example -- the
+following command will post the new project to the Brigade API server:
 
 ```shell
-$ brig project secrets set --file secrets.yaml
+$ brig project create --file project.yaml
 ```
 
-### Using other Git providers
+Projects can be listed:
 
-Brigade ships with generalized Git support, so use of repositories from any Git
-provider should be possible on a Brigade project.
+```shell
+$ brig project list
+```
 
-You must ensure, however, that the Kubernetes cluster hosting Brigade can
-access the Git repository over the network via the URL provided in `cloneURL`.
+A project definition (and status) can be retrieved by specifying the project's
+ID and an output format:
 
-To subscribe a Git-based project to events from a corresponding provider, a
-[Gateway] is necessary. Brigade currently has gateway support for [GitHub] and
-[BitBucket]. See the [Gateways] doc for further info.
+```shell
+$ brig project get --id <project id> --output yaml
+```
 
-[Gateway]: /topics/operators/gateways
-[GitHub]: https://github.com/brigadecore/brigade-github-gateway
-[BitBucket]: https://github.com/brigadecore/brigade-bitbucket-gateway/tree/v2
-[Gateways]: /topics/operators/gateways
+Projects can be updated from a modified definition using:
+
+```shell
+$ brig project update --file project.yaml
+```
+
+To delete a project, run:
+
+```shell
+$ brig project delete --id <project id>
+```
+
+## Project Namespaces
+
+Brigade creates a unique namespace for each project on the underlying workload
+execution substrate (Kubernetes) corresponding to each project. Most Brigade
+users will have no need to access this information, but for certain advanced use
+cases -- for instance, ones wherein a script is meant to directly modify
+Kubernetes resources in a cluster -- a user who has credentials for the
+underlying Kubernetes cluster may wish to learn what namespace a project is
+assigned to so they can directly modify resources such as Kubernetes
+`ServiceAccount`s or `RoleBinding`s in that namespace.
+
+This information can be retrieved from the `kubernetes.namespace` section after
+using the `brig project get` command as described in the previous section.
+
+## Project Secrets
+
+The scripts executed by a project's workers often need to make use of sensitive
+information that should not be hard-coded into the project definition or script.
+To manage such details, the CLI provides a suite of `brig project secret`
+commands.
+
+To set a secret:
+
+```shell
+$ brig project secret set --project <project id> --set <key>=<value>
+```
+
+To set many secrets in bulk from a "flat" JSON or YAML file:
+
+```shell
+$ brig project secret set --project <project id> --file secrets.yaml
+```
+
+To list secrets for a project:
+
+```shell
+$ brig project secret list --project <project id>
+```
+
+The above command will display all keys, but will redacted values.
+
+To delete a secret, use:
+
+```shell
+$ brig project secret unset --project <project id> --unset <key>
+```
+
+The [Scripting Guide] details how to access those secrets within your scripts.
+
+> ⚠️&nbsp;&nbsp;Internally, Brigade never stores secrets in its own database.
+> Since Brigade uses Kubernetes to execute scripts and other workloads, it
+> stores the secrets as close as possible to where they are used --  namely
+> Kubernetes `Secret` resources. This makes sense for a variety of reasons:
+>
+> 1. If the secrets were stored elsewhere, they'd _still_ need to be copied to
+>    Kubernetes `Secret` resources to be usable by the worker `Pod` that
+>    executes your script. Storing them there in the first place means they are
+>    already where they are needed and there are no additional copies of each
+>    secret anywhere else.
+>
+> 1. Storing secrets _only_ in Kubernetes `Secret` resources means you can trust
+>    Brigade with your secrets to the same extent (whatever that may be) that
+>    you already trust Kubernetes with your secrets. If you are unhappy with
+>    that (for instance, many Kubernetes clusters do not adequately encrypt
+>    `Secret` resources) and wish to improve the status quo, you can solve for
+>    that at the _cluster_ level. It becomes a Kubernetes problem instead of a
+>    Brigade problem.
+
+### Special Secrets for Working with Private Git Repos
+
+Brigade secrets are simple key/value pairs of strings. There are currently
+_four_ keys that each offer some special utility in that Brigade itself will
+utilize their values if and when required. Specifically, these secrets play a
+role in enabling Brigade to clone and work with _private_ git repositories.
+
+* __`gitSSHKey`:__ A PEM-encoded private key beginning with
+  `-----BEGIN RSA PRIVATE KEY-----`, ending with
+  `-----END RSA PRIVATE KEY-----`, and containing all of its usual line breaks.
+  Using a `secrets.yaml` file to set this is the easiest way to preserve all of
+  the correct formatting, as in the example below:
+
+  ```yaml
+  gitSSHKey: |-
+    -----BEGIN RSA PRIVATE KEY-----
+    IIEpAIBAAKCAg1wyZD164xNLrANjRrcsbieLwHJ6fKD3LC19E...
+    ...
+    ...
+    -----END RSA PRIVATE KEY-----  
+  ```
+
+  If this secret is provided for a given project, Brigade will utilize that key
+  when cloning that project's git repository.
+
+  Do _not_ set this secret if you're using a repository URL that begins with
+  `https://`.
+
+* __`gitSSHKeyPassword`:__ Optional passphrase for unlocking the PEM-encoded
+  private key specified by `gitSSHKey`.
+
+* __`gitUsername`/`gitPassword`:__ Basic auth username and/or password for
+  cloning private repos whose URL begins with `https://`.
+
+  If you need to use this, do _not_ set `gitSSHKey`, as `gitSSHKey` takes
+  precedence.
+
+  Consult your git provider's documentation for the correct way to set
+  username/password for basic auth. For instance, with GitHub, the username is
+  ignored/not required and the password should be a
+  [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+  On Bitbucket, by contrast, the username must be a real Bitbucket username (but
+  not an email address) and the password should be an
+  [app password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/).
+
+[Scripting Guide]: /topics/scripting


### PR DESCRIPTION
On Slack, @emilwangaa wrote:

> in v1 we could set a github token + HTTPS cloneUrl in our project definitions to access private git repositories. In v2 it looks like only SSH keys and git+ssh urls are supported for private repos. Is this a deliberate design decision? Or am I just missing something? (and sorry that I keep bugging you with questions).

This PR addresses this issue.

The feature prompted several modifications to the docs on creating/managing projects, so that section ended up with a comprehensive overhaul. I _think_ they cover the new details well and are more succinct with no real loss of detail.

I will publish a custom build of this branch shortly so @emilwangaa can take this for a test drive.