### PR TITLE
apiserver: do not mount shared workspace to worker as read only

### DIFF
--- a/v2/apiserver/internal/api/kubernetes/substrate.go
+++ b/v2/apiserver/internal/api/kubernetes/substrate.go
@@ -926,7 +926,6 @@ func (s *substrate) createWorkerPod(
 			corev1.VolumeMount{
 				Name:      "workspace",
 				MountPath: "/var/workspace",
-				ReadOnly:  true,
 			},
 		)
 	}


### PR DESCRIPTION
Fixes #1943