### PR TITLE
chore: update the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,13 @@
 <!--
-Thanks for sending a pull request!  Here are some tips for you:
-1. Make sure to read the Contributing Guide before submitting your PR (https://github.com/brigadecore/community/blob/main/contributing.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).
+Thanks for opening a pull request!  Here are some tips for you:
 
-2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.
+1. Make sure to read the Contributing Guide (https://docs.brigade.sh/topics/contributor-guide/).
 
-3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
+2. Be sure that your contribution adheres to the CNCF Code of Conduct (https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer with more context.
+
+4. Draft PRs are welcome as a way to get early feedback if so desired.
 -->
 
 **What this PR does / why we need it**:
@@ -12,6 +15,7 @@ Thanks for sending a pull request!  Here are some tips for you:
 **Special notes for your reviewer**:
 
 **If applicable**:
+
 - [ ] this PR contains documentation
 - [ ] this PR contains unit tests
 - [ ] this PR has been tested for backwards compatibility


### PR DESCRIPTION
The PR template was getting a bit stale. The contributing docs have moved since it was written, it was still referencing the MS code of conduct instead of the CNCF one, and it was also written before draft PRs were a thing.

This PR should bring everything up to date.