### PR TITLE
allow longer event qualifier and label values

### DIFF
--- a/v2/apiserver/schemas/common.json
+++ b/v2/apiserver/schemas/common.json
@@ -33,7 +33,7 @@
 			"type": "string",
 			"pattern": "^[\\w:/\\-\\.\\?=\\*]*$",
 			"minLength": 1,
-			"maxLength": 63
+			"maxLength": 255
 		},
 
 		"principalReference": {


### PR DESCRIPTION
I'm not sure why we ever limited the length of qualifiers and labels so aggressively. These are never applied to labels on any k8s resources, so that's not the reason. In all probability, we modeled it after _limitations_ of k8s labels and annotations just in case.

Now there's a good reason to accept longer qualifer and label values -- namely CloudEvents can have very long values in the source field. This is a _different_ source field than the source field on a Brigade event. The CloudEvents gateway always take the value of the CloudEvent's source field and preserves it by popping it into a Brigade event qualifier.

So bottom line is we need this change in order to get the CloudEvents gateway to go GA.

You can already see this works here:

https://dashboard.brigade2.io/projects/acr-demo

Events for that project have very long qualifiers and there has been no issue resulting from that.

(The dogfood Brigade already has these changes.)