### PR TITLE
pre-release version bumps

### DIFF
--- a/docs/content/intro/quickstart.md
+++ b/docs/content/intro/quickstart.md
@@ -68,7 +68,7 @@ the Brigade CLI later when we're ready to take Brigade for a test drive.
     ```shell
     $ helm install brigade \
         oci://ghcr.io/brigadecore/brigade \
-        --version v2.5.0 \
+        --version v2.6.0 \
         --create-namespace \
         --namespace brigade \
         --wait \
@@ -109,7 +109,7 @@ environments:
 **Linux**
 
 ```shell
-$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.5.0/brig-linux-amd64
+$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.6.0/brig-linux-amd64
 $ chmod +x /usr/local/bin/brig
 ```
 
@@ -126,7 +126,7 @@ Alternatively, you can install manually by directly downloading a pre-built
 binary:
 
 ```shell
-$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.5.0/brig-darwin-amd64
+$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.6.0/brig-darwin-amd64
 $ chmod +x /usr/local/bin/brig
 ```
 
@@ -134,7 +134,7 @@ $ chmod +x /usr/local/bin/brig
 
 ```powershell
 > mkdir -force $env:USERPROFILE\bin
-> (New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.5.0/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
+> (New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.6.0/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
 > $env:PATH+=";$env:USERPROFILE\bin"
 ```
 
@@ -268,7 +268,7 @@ Below is example output:
 Created event "2cb85062-f964-454d-ac5c-526cdbdd2679".
 
 Waiting for event's worker to be RUNNING...
-2021-08-10T16:52:01.699Z INFO: brigade-worker version: v2.5.0
+2021-08-10T16:52:01.699Z INFO: brigade-worker version: v2.6.0
 2021-08-10T16:52:01.701Z DEBUG: writing default brigade.ts to /var/vcs/.brigade/brigade.ts
 2021-08-10T16:52:01.702Z DEBUG: using npm as the package manager
 2021-08-10T16:52:01.702Z DEBUG: path /var/vcs/.brigade/node_modules/@brigadecore does not exist; creating it
@@ -327,7 +327,7 @@ using the following commands:
 $ helm uninstall brigade -n brigade
 $ helm install brigade \
     oci://ghcr.io/brigadecore/brigade \
-    --version v2.5.0 \
+    --version v2.6.0 \
     --namespace brigade \
     --wait \
     --timeout 300s

--- a/docs/content/topics/operators/deploy.md
+++ b/docs/content/topics/operators/deploy.md
@@ -75,7 +75,7 @@ cluster, view our [QuickStart](/intro/quickstart/) instead.
 
 ```shell
 $ helm inspect values oci://ghcr.io/brigadecore/brigade \
-    --version v2.5.0 > ~/brigade-values.yaml
+    --version v2.6.0 > ~/brigade-values.yaml
 ```
 
 In the next steps, we'll edit `~/brigade-values.yaml` to configure a
@@ -302,7 +302,7 @@ suitable for production, we can proceed with installation:
 ```shell
 $ helm install brigade \
     oci://ghcr.io/brigadecore/brigade \
-    --version v2.5.0 \
+    --version v2.6.0 \
     --create-namespace \
     --namespace brigade \
     --values ~/brigade-values.yaml \
@@ -360,7 +360,7 @@ instructions for common environments:
 **Linux**
 
 ```shell
-$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.5.0/brig-linux-amd64
+$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.6.0/brig-linux-amd64
 $ chmod +x /usr/local/bin/brig
 ```
 
@@ -377,7 +377,7 @@ Alternatively, you can install manually by directly downloading a pre-built
 binary:
 
 ```shell
-$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.5.0/brig-darwin-amd64
+$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.6.0/brig-darwin-amd64
 $ chmod +x /usr/local/bin/brig
 ```
 
@@ -385,7 +385,7 @@ $ chmod +x /usr/local/bin/brig
 
 ```powershell
 > mkdir -force $env:USERPROFILE\bin
-> (New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.5.0/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
+> (New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.6.0/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
 > $env:PATH+=";$env:USERPROFILE\bin"
 ```
 

--- a/docs/content/topics/project-developers/brig.md
+++ b/docs/content/topics/project-developers/brig.md
@@ -33,7 +33,7 @@ You can also build brig from source; see the [Developers] guide for more info.
 **linux**
 
 ```shell
-curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.5.0/brig-linux-amd64
+curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.6.0/brig-linux-amd64
 chmod +x /usr/local/bin/brig
 ```
 
@@ -50,7 +50,7 @@ Alternatively, you can install manually by directly downloading a pre-built
 binary:
 
 ```shell
-$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.5.0/brig-darwin-amd64
+$ curl -Lo /usr/local/bin/brig https://github.com/brigadecore/brigade/releases/download/v2.6.0/brig-darwin-amd64
 $ chmod +x /usr/local/bin/brig
 ```
 
@@ -58,7 +58,7 @@ $ chmod +x /usr/local/bin/brig
 
 ```powershell
 > mkdir -force $env:USERPROFILE\bin
-> (New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.5.0/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
+> (New-Object Net.WebClient).DownloadFile("https://github.com/brigadecore/brigade/releases/download/v2.6.0/brig-windows-amd64.exe", "$ENV:USERPROFILE\bin\brig.exe")
 > $env:PATH+=";$env:USERPROFILE\bin"
 ```
 

--- a/docs/content/topics/scripting/brigadier.md
+++ b/docs/content/topics/scripting/brigadier.md
@@ -90,7 +90,7 @@ Then, create a `package.json` file with our brigadier dependency added:
 ```json
 {
   "dependencies": {
-    "@brigadecore/brigadier": "^2.5.0"
+    "@brigadecore/brigadier": "^2.6.0"
   }
 }
 ```

--- a/v2/cli/init_templates.go
+++ b/v2/cli/init_templates.go
@@ -136,7 +136,7 @@ var secretsTemplate = []byte(`## This file was created by brig init.
 var packageTemplate = []byte(`{
   "name": "{{ .ProjectID }}",
   "dependencies": {
-    "@brigadecore/brigadier": "^2.5.0"
+    "@brigadecore/brigadier": "^2.6.0"
   }
 }
 `)


### PR DESCRIPTION
This PR is another pre-emptive "for when we're ready" pre-release version bump PR.

The CloudEvents Gateway is very close to going GA and it requires some changes to Brigade (longer qualifier values) that are as-yet-unreleased -- which is the impetus for releasing a v2.6.0 rather soon.