### PR TITLE
remove mention of acr gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ gateways, and more.
 Our event gateways receive events from upstream systems (the "outside world")
 and convert them to Brigade events that are emitted into Brigade's event bus.
 
-* [ACR (Azure Container Registry) Gateway](https://github.com/brigadecore/brigade-acr-gateway)
 * [Bitbucket Gateway](https://github.com/brigadecore/brigade-bitbucket-gateway/tree/v2)
 * [CloudEvents Gateway](https://github.com/brigadecore/brigade-cloudevents-gateway)
 * [Docker Hub Gateway](https://github.com/brigadecore/brigade-dockerhub-gateway)

--- a/docs/content/topics/operators/gateways.md
+++ b/docs/content/topics/operators/gateways.md
@@ -34,7 +34,6 @@ listing of compatible gateways.
 
 Currently, the list of official Brigade gateways is as follows:
 
-* [ACR (Azure Container Registry) Gateway](https://github.com/brigadecore/brigade-acr-gateway)
 * [BitBucket Gateway](https://github.com/brigadecore/brigade-bitbucket-gateway/tree/v2)
 * [CloudEvents Gateway](https://github.com/brigadecore/brigade-cloudevents-gateway)
 * [Docker Hub Gateway](https://github.com/brigadecore/brigade-dockerhub-gateway)


### PR DESCRIPTION
The ACR gateway was archived a week or two ago (without ever having reached GA) because the CloudEvents gateway provides sufficient integration with ACR.

This PR removes mention of the ACR gateway from the docs.