### PR TITLE
upgrade to mongodb v10.31.5

### DIFF
--- a/charts/brigade/Chart.yaml
+++ b/charts/brigade/Chart.yaml
@@ -13,6 +13,6 @@ maintainers:
   email: cncf-brigade-maintainers@lists.cncf.io
 dependencies:
 - name: mongodb
-  version: 10.29.2
+  version: 10.31.5
   repository: https://charts.bitnami.com/bitnami
   condition: mongodb.enabled


### PR DESCRIPTION
Bitnami seems to have dropped v10.29.2 from their repo sometime in the last 24 hours.