### PR TITLE
remove unused sections of values.yaml

### DIFF
--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -2145,13 +2145,3 @@ artemis:
 
   service:
     type: ClusterIP
-
-externalAMQP:
-  address:
-  username:
-  password:
-
-azureServiceBus:
-  address:
-  username:
-  password:


### PR DESCRIPTION
These config options are accidental remnants from an early prototype of Brigade 2 and are completely unused.